### PR TITLE
Refactor scan

### DIFF
--- a/WDAC-Policy-Wizard/app/src/BuildPage.Designer.cs
+++ b/WDAC-Policy-Wizard/app/src/BuildPage.Designer.cs
@@ -165,7 +165,7 @@ namespace WDAC_Wizard
             this.Controls.Add(this.label1);
             this.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.Name = "BuildPage";
-            this.Size = new System.Drawing.Size(1428, 778);
+            this.Size = new System.Drawing.Size(1733, 1000);
             this.finishPanel.ResumeLayout(false);
             this.finishPanel.PerformLayout();
             this.ResumeLayout(false);

--- a/WDAC-Policy-Wizard/app/src/MainForm.cs
+++ b/WDAC-Policy-Wizard/app/src/MainForm.cs
@@ -33,6 +33,7 @@ namespace WDAC_Wizard
         public bool ErrorOnPage { get; set; }            // Flag blocking proceeding to next user control. 
         public string ErrorMsg { get; set; }             // Accompanying message error description for ErrorOnPage flag 
         public bool RedoFlowRequired { get; set; }       // Flag which prohibts user from making changes on page 1 then skipping back to page 4, for instance
+        public bool CustomRuleinProgress { get; set; }   // Flag set when user has kicked off the custom rule procedure. Ensures user does not go to build page without accidentally creating the rule
 
         public Logger Log { get; set; }
         public List<string> PageList;
@@ -61,6 +62,8 @@ namespace WDAC_Wizard
             this.Policy = new WDAC_Policy();
             this.PageList = new List<string>();
             this.ExeFolderPath = GetExecutablePath(false);
+
+            this.CustomRuleinProgress = false; 
 
             CheckForUpdates().GetAwaiter().GetResult();
         }
@@ -194,6 +197,7 @@ namespace WDAC_Wizard
 
             // Reset flags
             this.ConfigInProcess = false;
+            this.CustomRuleinProgress = false; 
             this.view = 0;
             this.CurrentPage = 0; 
 
@@ -228,6 +232,16 @@ namespace WDAC_Wizard
         {
             if (!this.ErrorOnPage)
             {
+                // Check that a custom rule is not in progress
+                if(this.CustomRuleinProgress)
+                {
+                    DialogResult res = MessageBox.Show("Do you want to create this custom rule before building your WDAC policy?", 
+                        "Confirmation", MessageBoxButtons.YesNo, MessageBoxIcon.Question);
+
+                    if (res == DialogResult.Yes)
+                        return;
+                }
+
                 this.CurrentPage++;
                 pageController(sender, e);
             }

--- a/WDAC-Policy-Wizard/app/src/MainForm.cs
+++ b/WDAC-Policy-Wizard/app/src/MainForm.cs
@@ -713,7 +713,7 @@ namespace WDAC_Wizard
             if (progressPercent <= 10)
                 process = "Building policy rules ...";
             else if (progressPercent <= 70)
-                process = "Configuring policy signing rules ...";
+                process = "Configuring custom policy signing rules ...";
             else if (progressPercent <= 80)
                 process = "Building policy signing rules ...";
             else if (progressPercent <= 85)
@@ -927,7 +927,7 @@ namespace WDAC_Wizard
                 {
                     this.Log.AddErrorMsg("CreatePolicyFileRuleOptions() caught the following exception ", e);
                 }
-                worker.ReportProgress(70 + i / nCustomRules * 10);
+                worker.ReportProgress(10 + i / nCustomRules * 70); //Assumes the operations involved with this step take about 70%
             }
 
             //TODO: results check ensuring 
@@ -944,21 +944,22 @@ namespace WDAC_Wizard
             {
                 case PolicyCustomRules.RuleType.Publisher:
                     {
-                        customRuleScript = String.Format("$Rule_{0} = New-CIPolicyRule -Level {1} -DriverFilePath \"{2}\"" + 
+                        customRuleScript = String.Format("$Rule_{0} = New-CIPolicyRule -Level {1} -DriverFilePath \'{2}\'" + 
                             " -Fallback Hash", customRule.PSVariable, customRule.GetRuleLevel(), customRule.ReferenceFile);
                     }
                     break;
 
                 case PolicyCustomRules.RuleType.FilePath:
                     {
-
+                        customRuleScript = String.Format("$Rule_{0} = New-CIPolicyRule -Level FilePath -DriverFilePath \"{1}\"" +
+                            " -Fallback Hash", customRule.PSVariable, customRule.ReferenceFile);
                     }
 
                     break;
 
                 case PolicyCustomRules.RuleType.Folder:
                     {
-                        // Check if part of the folder path can be replaced with an env variable eg. %
+                        // Check if part of the folder path can be replaced with an env variable eg. %OSDRIVE% == "C:\"
                         if (customRule.GetRuleType() == PolicyCustomRules.RuleType.FilePath &&
                             Properties.Settings.Default.useEnvVars && customRule.isEnvVar())
                             customRuleScript = String.Format("$Rule_{0} = New-CIPolicyRule -FilePathRule {1}", customRule.PSVariable, customRule.GetEnvVar());
@@ -971,7 +972,7 @@ namespace WDAC_Wizard
                 case PolicyCustomRules.RuleType.FileAttributes:
                     {
                         customRuleScript = String.Format("$Rule_{0} = New-CIPolicyRule -Level FileName -SpecificFileNameLevel {1} -DriverFilePath \"{2}\" " +
-                            "-Fallback Hash", customRule.PSVariable, customRule.GetRuleLevel(), customRule.RuleIndex);
+                            "-Fallback Hash", customRule.PSVariable, customRule.GetRuleLevel(), customRule.ReferenceFile);
                     }
 
                     break;
@@ -1356,7 +1357,6 @@ namespace WDAC_Wizard
                 // If Start indexof returns -1, 
                 if (Start == 6)
                 {
-                    this.Log.AddInfoMsg("No ID located");
                     continue; 
                 }
 
@@ -1368,7 +1368,6 @@ namespace WDAC_Wizard
 
             if (NewestID < 0)
             {
-                this.Log.AddInfoMsg(String.Format("No existing temp policy located in {0}", folderPth));
                 newUniquePath = System.IO.Path.Combine(folderPth, "policy_0.xml"); //first temp policy being created
             }
             else

--- a/WDAC-Policy-Wizard/app/src/SigningRules_Control.cs
+++ b/WDAC-Policy-Wizard/app/src/SigningRules_Control.cs
@@ -45,7 +45,8 @@ namespace WDAC_Wizard
             this.AllFilesinFolder = new List<string>(); 
 
             this._MainWindow = pMainWindow;
-            this._MainWindow.RedoFlowRequired = false; 
+            this._MainWindow.RedoFlowRequired = false;
+            this._MainWindow.CustomRuleinProgress = false; 
             this.Log = this._MainWindow.Log;
             this.RowSelected = -1; 
         }
@@ -227,6 +228,9 @@ namespace WDAC_Wizard
                 if (refPath == String.Empty)
                     return;
 
+                // Custom rule in progress
+                this._MainWindow.CustomRuleinProgress = true;
+
                 // Get generic file information to be shown to user
                 PolicyCustomRule.FileInfo = new Dictionary<string, string>(); // Reset dict
                 FileVersionInfo fileInfo = FileVersionInfo.GetVersionInfo(refPath);
@@ -302,6 +306,10 @@ namespace WDAC_Wizard
                     this.AllFilesinFolder = new List<string>();
                     if (PolicyCustomRule.ReferenceFile == String.Empty)
                         break;
+
+                    // Custom rule in progress
+                    this._MainWindow.CustomRuleinProgress = true;
+
                     textBox_ReferenceFile.Text = PolicyCustomRule.ReferenceFile;
                     //ProcessAllFiles(PolicyCustomRule.ReferenceFile);
                     //PolicyCustomRule.FolderContents = this.AllFilesinFolder; 
@@ -641,6 +649,7 @@ namespace WDAC_Wizard
             
             // Reset UI view
             ClearCustomRulesPanel(true);
+            this._MainWindow.CustomRuleinProgress = false; 
         }
 
         /// <summary>

--- a/WDAC-Policy-Wizard/app/src/SigningRules_Control.cs
+++ b/WDAC-Policy-Wizard/app/src/SigningRules_Control.cs
@@ -194,10 +194,10 @@ namespace WDAC_Wizard
         private void FileButton_CheckedChanged(object sender, EventArgs e)
         {
             if (radioButton_File.Checked)
-                this.PolicyCustomRule.SetRuleLevel(PolicyCustomRules.RuleLevel.FilePath);
+                this.PolicyCustomRule.SetRuleType(PolicyCustomRules.RuleType.FilePath);
 
             else
-                this.PolicyCustomRule.SetRuleLevel(PolicyCustomRules.RuleLevel.Folder);
+                this.PolicyCustomRule.SetRuleType(PolicyCustomRules.RuleType.Folder);
 
             // Check if user changed Rule Level after already browsing and selecting a reference file
             if (this.PolicyCustomRule.ReferenceFile != null)
@@ -303,8 +303,8 @@ namespace WDAC_Wizard
                     if (PolicyCustomRule.ReferenceFile == String.Empty)
                         break;
                     textBox_ReferenceFile.Text = PolicyCustomRule.ReferenceFile;
-                    ProcessAllFiles(PolicyCustomRule.ReferenceFile);
-                    PolicyCustomRule.FolderContents = this.AllFilesinFolder; 
+                    //ProcessAllFiles(PolicyCustomRule.ReferenceFile);
+                    //PolicyCustomRule.FolderContents = this.AllFilesinFolder; 
                     this.PolicyCustomRule.SetRuleLevel(PolicyCustomRules.RuleLevel.Folder);
                     break; 
 
@@ -614,7 +614,7 @@ namespace WDAC_Wizard
                     break;
 
                 default:
-                    name = String.Format("{0}; {1}", this.PolicyCustomRule.GetRuleLevel(), Path.GetFileName(this.PolicyCustomRule.ReferenceFile));
+                    name = String.Format("{0}; {1}", this.PolicyCustomRule.GetRuleLevel(), this.PolicyCustomRule.ReferenceFile);
                     break;
 
             }

--- a/WDAC-Policy-Wizard/app/src/SigningRules_Control.cs
+++ b/WDAC-Policy-Wizard/app/src/SigningRules_Control.cs
@@ -634,6 +634,9 @@ namespace WDAC_Wizard
             this.Policy.CustomRules.Add(this.PolicyCustomRule);
             this.PolicyCustomRule = new PolicyCustomRules();
 
+            // Scroll to bottom to see new rule added to list
+            this.rulesDataGrid.FirstDisplayedScrollingRowIndex = this.rulesDataGrid.RowCount - 1;
+
             bubbleUp();
             
             // Reset UI view


### PR DESCRIPTION
Creating WDAC policies uses the -DriverFilesPath instead of scanning the entire directory and parsing the correct Driver. 

The result is much more accurate and fast rules/policies creation. 