### PR TITLE
Allow user to select all policies they wish to merge into one policy in the FileDialog Window

### DIFF
--- a/WDAC-Policy-Wizard/app/src/Helper.cs
+++ b/WDAC-Policy-Wizard/app/src/Helper.cs
@@ -498,7 +498,6 @@ namespace WDAC_Wizard
                 sb.Append(logHash[i].ToString("x2"));
             }
             return sb.ToString();
-
         }
 
         private void AddBoilerPlate()
@@ -507,9 +506,7 @@ namespace WDAC_Wizard
             FileVersionInfo versionInfo = FileVersionInfo.GetVersionInfo(assembly.Location);
             this.AddInfoMsg(String.Format("WDAC Policy Wizard Version # {0}", versionInfo.FileVersion));
         }
-
     }
-
 }
 
 

--- a/WDAC-Policy-Wizard/app/src/MainForm.Designer.cs
+++ b/WDAC-Policy-Wizard/app/src/MainForm.Designer.cs
@@ -62,9 +62,10 @@ namespace WDAC_Wizard
             this.label_Welcome.AutoSize = true;
             this.label_Welcome.Font = new System.Drawing.Font("Tahoma", 15F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label_Welcome.ForeColor = System.Drawing.Color.Black;
-            this.label_Welcome.Location = new System.Drawing.Point(185, 42);
+            this.label_Welcome.Location = new System.Drawing.Point(222, 50);
+            this.label_Welcome.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label_Welcome.Name = "label_Welcome";
-            this.label_Welcome.Size = new System.Drawing.Size(115, 30);
+            this.label_Welcome.Size = new System.Drawing.Size(136, 36);
             this.label_Welcome.TabIndex = 3;
             this.label_Welcome.Text = "Welcome";
             // 
@@ -76,10 +77,10 @@ namespace WDAC_Wizard
             this.button_New.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.button_New.Font = new System.Drawing.Font("Tahoma", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.button_New.Image = global::WDAC_Wizard.Properties.Resources.newPolicy;
-            this.button_New.Location = new System.Drawing.Point(328, 225);
-            this.button_New.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.button_New.Location = new System.Drawing.Point(394, 270);
+            this.button_New.Margin = new System.Windows.Forms.Padding(4, 2, 4, 2);
             this.button_New.Name = "button_New";
-            this.button_New.Size = new System.Drawing.Size(195, 217);
+            this.button_New.Size = new System.Drawing.Size(234, 260);
             this.button_New.TabIndex = 10;
             this.button_New.Text = "Policy Creator";
             this.button_New.TextAlign = System.Drawing.ContentAlignment.BottomCenter;
@@ -89,11 +90,12 @@ namespace WDAC_Wizard
             // label_Info
             // 
             this.label_Info.AutoSize = true;
-            this.label_Info.Font = new System.Drawing.Font("Tahoma", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label_Info.Font = new System.Drawing.Font("Tahoma", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label_Info.ForeColor = System.Drawing.Color.DeepSkyBlue;
-            this.label_Info.Location = new System.Drawing.Point(168, 674);
+            this.label_Info.Location = new System.Drawing.Point(202, 809);
+            this.label_Info.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label_Info.Name = "label_Info";
-            this.label_Info.Size = new System.Drawing.Size(77, 21);
+            this.label_Info.Size = new System.Drawing.Size(84, 22);
             this.label_Info.TabIndex = 9;
             this.label_Info.Text = "Info Text";
             this.label_Info.Visible = false;
@@ -113,10 +115,10 @@ namespace WDAC_Wizard
             this.button_Edit.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.button_Edit.Font = new System.Drawing.Font("Tahoma", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.button_Edit.Image = global::WDAC_Wizard.Properties.Resources.tools;
-            this.button_Edit.Location = new System.Drawing.Point(567, 225);
-            this.button_Edit.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.button_Edit.Location = new System.Drawing.Point(680, 270);
+            this.button_Edit.Margin = new System.Windows.Forms.Padding(4, 2, 4, 2);
             this.button_Edit.Name = "button_Edit";
-            this.button_Edit.Size = new System.Drawing.Size(195, 217);
+            this.button_Edit.Size = new System.Drawing.Size(234, 260);
             this.button_Edit.TabIndex = 25;
             this.button_Edit.Text = "Policy Editor";
             this.button_Edit.TextAlign = System.Drawing.ContentAlignment.BottomCenter;
@@ -131,10 +133,10 @@ namespace WDAC_Wizard
             this.button_Merge.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.button_Merge.Font = new System.Drawing.Font("Tahoma", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.button_Merge.Image = global::WDAC_Wizard.Properties.Resources.merge;
-            this.button_Merge.Location = new System.Drawing.Point(813, 225);
-            this.button_Merge.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.button_Merge.Location = new System.Drawing.Point(976, 270);
+            this.button_Merge.Margin = new System.Windows.Forms.Padding(4, 2, 4, 2);
             this.button_Merge.Name = "button_Merge";
-            this.button_Merge.Size = new System.Drawing.Size(195, 217);
+            this.button_Merge.Size = new System.Drawing.Size(234, 260);
             this.button_Merge.TabIndex = 26;
             this.button_Merge.Text = "Policy Merger";
             this.button_Merge.TextAlign = System.Drawing.ContentAlignment.BottomCenter;
@@ -155,9 +157,9 @@ namespace WDAC_Wizard
             this.control_Panel.Controls.Add(this.settings_Button);
             this.control_Panel.ForeColor = System.Drawing.SystemColors.ControlText;
             this.control_Panel.Location = new System.Drawing.Point(0, 0);
-            this.control_Panel.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.control_Panel.Margin = new System.Windows.Forms.Padding(4, 2, 4, 2);
             this.control_Panel.Name = "control_Panel";
-            this.control_Panel.Size = new System.Drawing.Size(150, 700);
+            this.control_Panel.Size = new System.Drawing.Size(180, 840);
             this.control_Panel.TabIndex = 30;
             // 
             // page5_Button
@@ -171,10 +173,10 @@ namespace WDAC_Wizard
             this.page5_Button.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.page5_Button.Font = new System.Drawing.Font("Tahoma", 9.5F);
             this.page5_Button.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            this.page5_Button.Location = new System.Drawing.Point(15, 400);
-            this.page5_Button.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.page5_Button.Location = new System.Drawing.Point(18, 480);
+            this.page5_Button.Margin = new System.Windows.Forms.Padding(4, 2, 4, 2);
             this.page5_Button.Name = "page5_Button";
-            this.page5_Button.Size = new System.Drawing.Size(146, 45);
+            this.page5_Button.Size = new System.Drawing.Size(175, 54);
             this.page5_Button.TabIndex = 39;
             this.page5_Button.Text = "Page 5";
             this.page5_Button.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -193,10 +195,10 @@ namespace WDAC_Wizard
             this.page4_Button.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.page4_Button.Font = new System.Drawing.Font("Tahoma", 9.5F);
             this.page4_Button.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            this.page4_Button.Location = new System.Drawing.Point(15, 350);
-            this.page4_Button.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.page4_Button.Location = new System.Drawing.Point(18, 420);
+            this.page4_Button.Margin = new System.Windows.Forms.Padding(4, 2, 4, 2);
             this.page4_Button.Name = "page4_Button";
-            this.page4_Button.Size = new System.Drawing.Size(146, 45);
+            this.page4_Button.Size = new System.Drawing.Size(175, 54);
             this.page4_Button.TabIndex = 38;
             this.page4_Button.Text = "Page 4";
             this.page4_Button.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -215,10 +217,10 @@ namespace WDAC_Wizard
             this.page3_Button.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.page3_Button.Font = new System.Drawing.Font("Tahoma", 9.5F);
             this.page3_Button.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            this.page3_Button.Location = new System.Drawing.Point(15, 300);
-            this.page3_Button.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.page3_Button.Location = new System.Drawing.Point(18, 360);
+            this.page3_Button.Margin = new System.Windows.Forms.Padding(4, 2, 4, 2);
             this.page3_Button.Name = "page3_Button";
-            this.page3_Button.Size = new System.Drawing.Size(146, 45);
+            this.page3_Button.Size = new System.Drawing.Size(175, 54);
             this.page3_Button.TabIndex = 37;
             this.page3_Button.Text = "Page 3";
             this.page3_Button.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -237,10 +239,10 @@ namespace WDAC_Wizard
             this.page2_Button.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.page2_Button.Font = new System.Drawing.Font("Tahoma", 9.5F);
             this.page2_Button.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            this.page2_Button.Location = new System.Drawing.Point(15, 250);
-            this.page2_Button.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.page2_Button.Location = new System.Drawing.Point(18, 300);
+            this.page2_Button.Margin = new System.Windows.Forms.Padding(4, 2, 4, 2);
             this.page2_Button.Name = "page2_Button";
-            this.page2_Button.Size = new System.Drawing.Size(146, 45);
+            this.page2_Button.Size = new System.Drawing.Size(175, 54);
             this.page2_Button.TabIndex = 36;
             this.page2_Button.Text = "Page 2";
             this.page2_Button.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -259,10 +261,10 @@ namespace WDAC_Wizard
             this.page1_Button.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.page1_Button.Font = new System.Drawing.Font("Tahoma", 9.5F);
             this.page1_Button.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            this.page1_Button.Location = new System.Drawing.Point(15, 200);
-            this.page1_Button.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.page1_Button.Location = new System.Drawing.Point(18, 240);
+            this.page1_Button.Margin = new System.Windows.Forms.Padding(4, 2, 4, 2);
             this.page1_Button.Name = "page1_Button";
-            this.page1_Button.Size = new System.Drawing.Size(146, 45);
+            this.page1_Button.Size = new System.Drawing.Size(175, 54);
             this.page1_Button.TabIndex = 35;
             this.page1_Button.Text = "Page 1";
             this.page1_Button.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -280,10 +282,10 @@ namespace WDAC_Wizard
             this.workflow_Button.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.workflow_Button.Font = new System.Drawing.Font("Tahoma", 10F);
             this.workflow_Button.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            this.workflow_Button.Location = new System.Drawing.Point(5, 150);
-            this.workflow_Button.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.workflow_Button.Location = new System.Drawing.Point(6, 180);
+            this.workflow_Button.Margin = new System.Windows.Forms.Padding(4, 2, 4, 2);
             this.workflow_Button.Name = "workflow_Button";
-            this.workflow_Button.Size = new System.Drawing.Size(130, 45);
+            this.workflow_Button.Size = new System.Drawing.Size(156, 54);
             this.workflow_Button.TabIndex = 34;
             this.workflow_Button.Text = "Workflow";
             this.workflow_Button.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -293,9 +295,10 @@ namespace WDAC_Wizard
             // controlHighlight_Panel
             // 
             this.controlHighlight_Panel.BackColor = System.Drawing.Color.CornflowerBlue;
-            this.controlHighlight_Panel.Location = new System.Drawing.Point(0, 96);
+            this.controlHighlight_Panel.Location = new System.Drawing.Point(0, 115);
+            this.controlHighlight_Panel.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.controlHighlight_Panel.Name = "controlHighlight_Panel";
-            this.controlHighlight_Panel.Size = new System.Drawing.Size(8, 35);
+            this.controlHighlight_Panel.Size = new System.Drawing.Size(10, 42);
             this.controlHighlight_Panel.TabIndex = 33;
             // 
             // home_Button
@@ -309,10 +312,10 @@ namespace WDAC_Wizard
             this.home_Button.Font = new System.Drawing.Font("Tahoma", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.home_Button.Image = ((System.Drawing.Image)(resources.GetObject("home_Button.Image")));
             this.home_Button.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            this.home_Button.Location = new System.Drawing.Point(15, 92);
-            this.home_Button.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.home_Button.Location = new System.Drawing.Point(18, 110);
+            this.home_Button.Margin = new System.Windows.Forms.Padding(4, 2, 4, 2);
             this.home_Button.Name = "home_Button";
-            this.home_Button.Size = new System.Drawing.Size(129, 45);
+            this.home_Button.Size = new System.Drawing.Size(155, 54);
             this.home_Button.TabIndex = 32;
             this.home_Button.Text = "     Home";
             this.home_Button.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -330,10 +333,10 @@ namespace WDAC_Wizard
             this.settings_Button.Font = new System.Drawing.Font("Tahoma", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.settings_Button.Image = ((System.Drawing.Image)(resources.GetObject("settings_Button.Image")));
             this.settings_Button.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            this.settings_Button.Location = new System.Drawing.Point(15, 647);
-            this.settings_Button.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.settings_Button.Location = new System.Drawing.Point(18, 776);
+            this.settings_Button.Margin = new System.Windows.Forms.Padding(4, 2, 4, 2);
             this.settings_Button.Name = "settings_Button";
-            this.settings_Button.Size = new System.Drawing.Size(129, 45);
+            this.settings_Button.Size = new System.Drawing.Size(155, 54);
             this.settings_Button.TabIndex = 31;
             this.settings_Button.Text = "     Settings";
             this.settings_Button.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -342,10 +345,10 @@ namespace WDAC_Wizard
             // 
             // button_Next
             // 
-            this.button_Next.Location = new System.Drawing.Point(1134, 663);
-            this.button_Next.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.button_Next.Location = new System.Drawing.Point(1361, 796);
+            this.button_Next.Margin = new System.Windows.Forms.Padding(4, 2, 4, 2);
             this.button_Next.Name = "button_Next";
-            this.button_Next.Size = new System.Drawing.Size(93, 33);
+            this.button_Next.Size = new System.Drawing.Size(112, 40);
             this.button_Next.TabIndex = 31;
             this.button_Next.Text = "Next";
             this.button_Next.UseVisualStyleBackColor = true;
@@ -357,9 +360,10 @@ namespace WDAC_Wizard
             this.label1.AutoSize = true;
             this.label1.Font = new System.Drawing.Font("Tahoma", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label1.ForeColor = System.Drawing.Color.Black;
-            this.label1.Location = new System.Drawing.Point(185, 82);
+            this.label1.Location = new System.Drawing.Point(222, 98);
+            this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(311, 24);
+            this.label1.Size = new System.Drawing.Size(373, 29);
             this.label1.TabIndex = 32;
             this.label1.Text = "Select a task below to get started";
             // 
@@ -367,10 +371,10 @@ namespace WDAC_Wizard
             // 
             this.label2.AutoSize = true;
             this.label2.Font = new System.Drawing.Font("Tahoma", 9F);
-            this.label2.Location = new System.Drawing.Point(296, 453);
+            this.label2.Location = new System.Drawing.Point(355, 544);
             this.label2.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(244, 36);
+            this.label2.Size = new System.Drawing.Size(293, 44);
             this.label2.TabIndex = 33;
             this.label2.Text = "Create a new base or supplemental \r\npolicy";
             // 
@@ -378,10 +382,10 @@ namespace WDAC_Wizard
             // 
             this.label3.AutoSize = true;
             this.label3.Font = new System.Drawing.Font("Tahoma", 9F);
-            this.label3.Location = new System.Drawing.Point(563, 453);
+            this.label3.Location = new System.Drawing.Point(676, 544);
             this.label3.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(195, 18);
+            this.label3.Size = new System.Drawing.Size(245, 22);
             this.label3.TabIndex = 34;
             this.label3.Text = "Edit an existing policy on disk";
             // 
@@ -389,19 +393,19 @@ namespace WDAC_Wizard
             // 
             this.label4.AutoSize = true;
             this.label4.Font = new System.Drawing.Font("Tahoma", 9F);
-            this.label4.Location = new System.Drawing.Point(802, 453);
+            this.label4.Location = new System.Drawing.Point(962, 544);
             this.label4.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(236, 18);
+            this.label4.Size = new System.Drawing.Size(293, 22);
             this.label4.TabIndex = 35;
             this.label4.Text = "Merge two existing policies into one\r\n";
             // 
             // MainWindow
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(120F, 120F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(144F, 144F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.Color.White;
-            this.ClientSize = new System.Drawing.Size(1232, 703);
+            this.ClientSize = new System.Drawing.Size(1478, 844);
             this.Controls.Add(this.label4);
             this.Controls.Add(this.label3);
             this.Controls.Add(this.label2);
@@ -416,7 +420,7 @@ namespace WDAC_Wizard
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
             this.HelpButton = true;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-            this.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.Margin = new System.Windows.Forms.Padding(4, 2, 4, 2);
             this.Name = "MainWindow";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "Windows Defender App Control Policy Wizard";

--- a/WDAC-Policy-Wizard/app/src/MainForm.cs
+++ b/WDAC-Policy-Wizard/app/src/MainForm.cs
@@ -227,7 +227,9 @@ namespace WDAC_Wizard
                 if(this.CustomRuleinProgress)
                 {
                     DialogResult res = MessageBox.Show("Do you want to create this custom rule before building your WDAC policy?", 
-                        "Confirmation", MessageBoxButtons.YesNo, MessageBoxIcon.Question);
+                        "Confirmation", 
+                        MessageBoxButtons.YesNo, 
+                        MessageBoxIcon.Question);
 
                     if (res == DialogResult.Yes)
                         return;
@@ -1494,7 +1496,10 @@ namespace WDAC_Wizard
         private bool wantToAbandonWork()
         {
             this.Log.AddWarningMsg("Abandon Work Entered.");
-            DialogResult res = MessageBox.Show("Are you sure you want to abandon your progress?", "Confirmation", MessageBoxButtons.OKCancel, MessageBoxIcon.Information);
+            DialogResult res = MessageBox.Show("Are you sure you want to abandon your progress?", 
+                "Confirmation", 
+                MessageBoxButtons.OKCancel, 
+                MessageBoxIcon.Information);
 
             if (res == DialogResult.OK)
             {
@@ -1906,8 +1911,11 @@ namespace WDAC_Wizard
             {
                 this.Log.AddWarningMsg(String.Format("Incompatible Windows Build Detected!! BuildN={0}", releaseN));
                 this.Log.AddWarningMsg(String.Format("Incompatible Windows Edition/Product Detected!! CompositionEditionID={0} and ProductName={1}", edition, prodName));
-                DialogResult res = MessageBox.Show("The Policy Wizard has detected an incompatible version of Windows. The Wizard may not be able to successfully complete policy creation.",
-                "Incompatible Windows Product", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                DialogResult res = MessageBox.Show("The Policy Wizard has detected an incompatible version of Windows. " +
+                    "The Wizard may not be able to successfully complete policy creation.",
+                    "Incompatible Windows Product", 
+                    MessageBoxButtons.OK, 
+                    MessageBoxIcon.Warning);
 
                 if (res == DialogResult.OK)
                 {

--- a/WDAC-Policy-Wizard/app/src/PolicyMerge_Control.Designer.cs
+++ b/WDAC-Policy-Wizard/app/src/PolicyMerge_Control.Designer.cs
@@ -34,11 +34,11 @@
             this.finalPolicyTextBox = new System.Windows.Forms.TextBox();
             this.button_Browse = new System.Windows.Forms.Button();
             this.policiesDataGrid = new System.Windows.Forms.DataGridView();
-            this.Column_Number = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.Column_Path = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.button_AddPolicy = new System.Windows.Forms.Button();
             this.button_RemovePolicy = new System.Windows.Forms.Button();
             this.label_Error = new System.Windows.Forms.Label();
+            this.Column_Number = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.Column_Path = new System.Windows.Forms.DataGridViewTextBoxColumn();
             ((System.ComponentModel.ISupportInitialize)(this.policiesDataGrid)).BeginInit();
             this.SuspendLayout();
             // 
@@ -47,10 +47,10 @@
             this.label1.AutoSize = true;
             this.label1.Font = new System.Drawing.Font("Tahoma", 14F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label1.ForeColor = System.Drawing.Color.Black;
-            this.label1.Location = new System.Drawing.Point(164, 42);
+            this.label1.Location = new System.Drawing.Point(197, 50);
             this.label1.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(327, 29);
+            this.label1.Size = new System.Drawing.Size(381, 34);
             this.label1.TabIndex = 1;
             this.label1.Text = "Merge Multiple WDAC Policies";
             // 
@@ -59,10 +59,10 @@
             this.label2.AutoSize = true;
             this.label2.Font = new System.Drawing.Font("Tahoma", 10F);
             this.label2.ForeColor = System.Drawing.Color.Black;
-            this.label2.Location = new System.Drawing.Point(165, 103);
+            this.label2.Location = new System.Drawing.Point(198, 124);
             this.label2.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(262, 21);
+            this.label2.Size = new System.Drawing.Size(313, 24);
             this.label2.TabIndex = 2;
             this.label2.Text = "Select at least 2 policies to merge";
             // 
@@ -71,19 +71,20 @@
             this.label3.AutoSize = true;
             this.label3.Font = new System.Drawing.Font("Tahoma", 10F);
             this.label3.ForeColor = System.Drawing.Color.Black;
-            this.label3.Location = new System.Drawing.Point(165, 374);
+            this.label3.Location = new System.Drawing.Point(198, 449);
             this.label3.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(210, 21);
+            this.label3.Size = new System.Drawing.Size(252, 24);
             this.label3.TabIndex = 3;
             this.label3.Text = "Choose final policy location";
             // 
             // finalPolicyTextBox
             // 
             this.finalPolicyTextBox.Font = new System.Drawing.Font("Tahoma", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.finalPolicyTextBox.Location = new System.Drawing.Point(169, 414);
+            this.finalPolicyTextBox.Location = new System.Drawing.Point(203, 497);
+            this.finalPolicyTextBox.Margin = new System.Windows.Forms.Padding(4);
             this.finalPolicyTextBox.Name = "finalPolicyTextBox";
-            this.finalPolicyTextBox.Size = new System.Drawing.Size(393, 26);
+            this.finalPolicyTextBox.Size = new System.Drawing.Size(471, 29);
             this.finalPolicyTextBox.TabIndex = 4;
             this.finalPolicyTextBox.Click += new System.EventHandler(this.button_Browse_Click);
             // 
@@ -94,10 +95,10 @@
             this.button_Browse.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.button_Browse.Font = new System.Drawing.Font("Tahoma", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.button_Browse.ForeColor = System.Drawing.Color.Black;
-            this.button_Browse.Location = new System.Drawing.Point(581, 410);
+            this.button_Browse.Location = new System.Drawing.Point(697, 492);
             this.button_Browse.Margin = new System.Windows.Forms.Padding(2);
             this.button_Browse.Name = "button_Browse";
-            this.button_Browse.Size = new System.Drawing.Size(136, 35);
+            this.button_Browse.Size = new System.Drawing.Size(163, 42);
             this.button_Browse.TabIndex = 94;
             this.button_Browse.Text = "Browse";
             this.button_Browse.UseVisualStyleBackColor = true;
@@ -110,14 +111,55 @@
             this.policiesDataGrid.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
             this.Column_Number,
             this.Column_Path});
-            this.policiesDataGrid.Location = new System.Drawing.Point(169, 139);
+            this.policiesDataGrid.Location = new System.Drawing.Point(203, 167);
+            this.policiesDataGrid.Margin = new System.Windows.Forms.Padding(4);
             this.policiesDataGrid.Name = "policiesDataGrid";
             this.policiesDataGrid.RowHeadersWidth = 51;
             this.policiesDataGrid.RowTemplate.Height = 24;
-            this.policiesDataGrid.Size = new System.Drawing.Size(498, 150);
+            this.policiesDataGrid.Size = new System.Drawing.Size(657, 180);
             this.policiesDataGrid.TabIndex = 95;
             this.policiesDataGrid.VirtualMode = true;
             this.policiesDataGrid.CellValueNeeded += new System.Windows.Forms.DataGridViewCellValueEventHandler(this.policiesDataGrid_CellValueNeeded);
+            // 
+            // button_AddPolicy
+            // 
+            this.button_AddPolicy.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(224)))), ((int)(((byte)(224)))), ((int)(((byte)(224)))));
+            this.button_AddPolicy.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.button_AddPolicy.Location = new System.Drawing.Point(281, 368);
+            this.button_AddPolicy.Margin = new System.Windows.Forms.Padding(4);
+            this.button_AddPolicy.Name = "button_AddPolicy";
+            this.button_AddPolicy.Size = new System.Drawing.Size(144, 36);
+            this.button_AddPolicy.TabIndex = 96;
+            this.button_AddPolicy.Text = "+ Add Policy";
+            this.button_AddPolicy.UseVisualStyleBackColor = true;
+            this.button_AddPolicy.Click += new System.EventHandler(this.button_AddPolicy_Click);
+            // 
+            // button_RemovePolicy
+            // 
+            this.button_RemovePolicy.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(224)))), ((int)(((byte)(224)))), ((int)(((byte)(224)))));
+            this.button_RemovePolicy.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.button_RemovePolicy.Location = new System.Drawing.Point(536, 368);
+            this.button_RemovePolicy.Margin = new System.Windows.Forms.Padding(4);
+            this.button_RemovePolicy.Name = "button_RemovePolicy";
+            this.button_RemovePolicy.Size = new System.Drawing.Size(144, 36);
+            this.button_RemovePolicy.TabIndex = 97;
+            this.button_RemovePolicy.Text = "- Remove Policy";
+            this.button_RemovePolicy.UseVisualStyleBackColor = true;
+            this.button_RemovePolicy.Click += new System.EventHandler(this.button_RemovePolicy_Click);
+            // 
+            // label_Error
+            // 
+            this.label_Error.AutoSize = true;
+            this.label_Error.Font = new System.Drawing.Font("Tahoma", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label_Error.ForeColor = System.Drawing.Color.Red;
+            this.label_Error.Location = new System.Drawing.Point(199, 720);
+            this.label_Error.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.label_Error.Name = "label_Error";
+            this.label_Error.Size = new System.Drawing.Size(765, 22);
+            this.label_Error.TabIndex = 98;
+            this.label_Error.Text = "Label_Error: Lorem Ipsum text text text text. Lorum Ipsum text text text text tex" +
+    "t text text text";
+            this.label_Error.Visible = false;
             // 
             // Column_Number
             // 
@@ -131,49 +173,11 @@
             this.Column_Path.HeaderText = "Policy Path";
             this.Column_Path.MinimumWidth = 6;
             this.Column_Path.Name = "Column_Path";
-            this.Column_Path.Width = 400;
-            // 
-            // button_AddPolicy
-            // 
-            this.button_AddPolicy.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(224)))), ((int)(((byte)(224)))), ((int)(((byte)(224)))));
-            this.button_AddPolicy.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.button_AddPolicy.Location = new System.Drawing.Point(234, 307);
-            this.button_AddPolicy.Name = "button_AddPolicy";
-            this.button_AddPolicy.Size = new System.Drawing.Size(120, 30);
-            this.button_AddPolicy.TabIndex = 96;
-            this.button_AddPolicy.Text = "+ Add Policy";
-            this.button_AddPolicy.UseVisualStyleBackColor = true;
-            this.button_AddPolicy.Click += new System.EventHandler(this.button_AddPolicy_Click);
-            // 
-            // button_RemovePolicy
-            // 
-            this.button_RemovePolicy.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(224)))), ((int)(((byte)(224)))), ((int)(((byte)(224)))));
-            this.button_RemovePolicy.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.button_RemovePolicy.Location = new System.Drawing.Point(447, 307);
-            this.button_RemovePolicy.Name = "button_RemovePolicy";
-            this.button_RemovePolicy.Size = new System.Drawing.Size(120, 30);
-            this.button_RemovePolicy.TabIndex = 97;
-            this.button_RemovePolicy.Text = "- Remove Policy";
-            this.button_RemovePolicy.UseVisualStyleBackColor = true;
-            this.button_RemovePolicy.Click += new System.EventHandler(this.button_RemovePolicy_Click);
-            // 
-            // label_Error
-            // 
-            this.label_Error.AutoSize = true;
-            this.label_Error.Font = new System.Drawing.Font("Tahoma", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label_Error.ForeColor = System.Drawing.Color.Red;
-            this.label_Error.Location = new System.Drawing.Point(166, 600);
-            this.label_Error.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
-            this.label_Error.Name = "label_Error";
-            this.label_Error.Size = new System.Drawing.Size(648, 18);
-            this.label_Error.TabIndex = 98;
-            this.label_Error.Text = "Label_Error: Lorem Ipsum text text text text. Lorum Ipsum text text text text tex" +
-    "t text text text";
-            this.label_Error.Visible = false;
+            this.Column_Path.Width = 550;
             // 
             // PolicyMerge_Control
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(120F, 120F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(144F, 144F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.Controls.Add(this.label_Error);
             this.Controls.Add(this.button_RemovePolicy);
@@ -184,8 +188,9 @@
             this.Controls.Add(this.label3);
             this.Controls.Add(this.label2);
             this.Controls.Add(this.label1);
+            this.Margin = new System.Windows.Forms.Padding(4);
             this.Name = "PolicyMerge_Control";
-            this.Size = new System.Drawing.Size(1172, 782);
+            this.Size = new System.Drawing.Size(1406, 938);
             ((System.ComponentModel.ISupportInitialize)(this.policiesDataGrid)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
@@ -200,10 +205,10 @@
         private System.Windows.Forms.TextBox finalPolicyTextBox;
         private System.Windows.Forms.Button button_Browse;
         private System.Windows.Forms.DataGridView policiesDataGrid;
-        private System.Windows.Forms.DataGridViewTextBoxColumn Column_Number;
-        private System.Windows.Forms.DataGridViewTextBoxColumn Column_Path;
         private System.Windows.Forms.Button button_AddPolicy;
         private System.Windows.Forms.Button button_RemovePolicy;
         private System.Windows.Forms.Label label_Error;
+        private System.Windows.Forms.DataGridViewTextBoxColumn Column_Number;
+        private System.Windows.Forms.DataGridViewTextBoxColumn Column_Path;
     }
 }

--- a/WDAC-Policy-Wizard/app/src/PolicyMerge_Control.cs
+++ b/WDAC-Policy-Wizard/app/src/PolicyMerge_Control.cs
@@ -85,7 +85,7 @@ namespace WDAC_Wizard.src
                     {
                         if (existingPath.Equals(policyPath))
                         {
-                            showError(String.Format("{0} already selected and in table.", Path.GetFileName(policyPath)));
+                            showError(String.Format("{0} is already selected and in table.", Path.GetFileName(policyPath)));
                             isNewPolicy = false; 
                             break;
                         }
@@ -279,7 +279,6 @@ namespace WDAC_Wizard.src
         {
             this.label_Error.Visible = false;
         }
-
     }
 
     // Class for the datastore


### PR DESCRIPTION
Users can now select up to 100 policies at the same time without having to click "+ Add Policy" 100 times. Selecting the "+ Add Policy" button allows for multiple files to be selected. All files are checked against the current list of files to merge and added to the table. 

Users can also multi-deselect policies from the table to merge into their final merged policy. 

openFileDialog.Multiselect = true; 