### PR TITLE
Bug fix control panel UI-UX

### DIFF
--- a/WDAC-Policy-Wizard/app/src/MainForm.Designer.cs
+++ b/WDAC-Policy-Wizard/app/src/MainForm.Designer.cs
@@ -45,7 +45,6 @@ namespace WDAC_Wizard
             this.page3_Button = new System.Windows.Forms.Button();
             this.page2_Button = new System.Windows.Forms.Button();
             this.page1_Button = new System.Windows.Forms.Button();
-            this.workflow_Button = new System.Windows.Forms.Button();
             this.controlHighlight_Panel = new System.Windows.Forms.Panel();
             this.home_Button = new System.Windows.Forms.Button();
             this.settings_Button = new System.Windows.Forms.Button();
@@ -54,6 +53,7 @@ namespace WDAC_Wizard
             this.label2 = new System.Windows.Forms.Label();
             this.label3 = new System.Windows.Forms.Label();
             this.label4 = new System.Windows.Forms.Label();
+            this.workflow_Label = new System.Windows.Forms.Label();
             this.control_Panel.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -62,10 +62,9 @@ namespace WDAC_Wizard
             this.label_Welcome.AutoSize = true;
             this.label_Welcome.Font = new System.Drawing.Font("Tahoma", 15F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label_Welcome.ForeColor = System.Drawing.Color.Black;
-            this.label_Welcome.Location = new System.Drawing.Point(222, 50);
-            this.label_Welcome.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label_Welcome.Location = new System.Drawing.Point(185, 42);
             this.label_Welcome.Name = "label_Welcome";
-            this.label_Welcome.Size = new System.Drawing.Size(136, 36);
+            this.label_Welcome.Size = new System.Drawing.Size(115, 30);
             this.label_Welcome.TabIndex = 3;
             this.label_Welcome.Text = "Welcome";
             // 
@@ -77,10 +76,10 @@ namespace WDAC_Wizard
             this.button_New.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.button_New.Font = new System.Drawing.Font("Tahoma", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.button_New.Image = global::WDAC_Wizard.Properties.Resources.newPolicy;
-            this.button_New.Location = new System.Drawing.Point(394, 270);
-            this.button_New.Margin = new System.Windows.Forms.Padding(4, 2, 4, 2);
+            this.button_New.Location = new System.Drawing.Point(328, 225);
+            this.button_New.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.button_New.Name = "button_New";
-            this.button_New.Size = new System.Drawing.Size(234, 260);
+            this.button_New.Size = new System.Drawing.Size(195, 217);
             this.button_New.TabIndex = 10;
             this.button_New.Text = "Policy Creator";
             this.button_New.TextAlign = System.Drawing.ContentAlignment.BottomCenter;
@@ -92,10 +91,9 @@ namespace WDAC_Wizard
             this.label_Info.AutoSize = true;
             this.label_Info.Font = new System.Drawing.Font("Tahoma", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label_Info.ForeColor = System.Drawing.Color.DeepSkyBlue;
-            this.label_Info.Location = new System.Drawing.Point(202, 809);
-            this.label_Info.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label_Info.Location = new System.Drawing.Point(168, 674);
             this.label_Info.Name = "label_Info";
-            this.label_Info.Size = new System.Drawing.Size(84, 22);
+            this.label_Info.Size = new System.Drawing.Size(71, 18);
             this.label_Info.TabIndex = 9;
             this.label_Info.Text = "Info Text";
             this.label_Info.Visible = false;
@@ -115,10 +113,10 @@ namespace WDAC_Wizard
             this.button_Edit.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.button_Edit.Font = new System.Drawing.Font("Tahoma", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.button_Edit.Image = global::WDAC_Wizard.Properties.Resources.tools;
-            this.button_Edit.Location = new System.Drawing.Point(680, 270);
-            this.button_Edit.Margin = new System.Windows.Forms.Padding(4, 2, 4, 2);
+            this.button_Edit.Location = new System.Drawing.Point(567, 225);
+            this.button_Edit.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.button_Edit.Name = "button_Edit";
-            this.button_Edit.Size = new System.Drawing.Size(234, 260);
+            this.button_Edit.Size = new System.Drawing.Size(195, 217);
             this.button_Edit.TabIndex = 25;
             this.button_Edit.Text = "Policy Editor";
             this.button_Edit.TextAlign = System.Drawing.ContentAlignment.BottomCenter;
@@ -133,10 +131,10 @@ namespace WDAC_Wizard
             this.button_Merge.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.button_Merge.Font = new System.Drawing.Font("Tahoma", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.button_Merge.Image = global::WDAC_Wizard.Properties.Resources.merge;
-            this.button_Merge.Location = new System.Drawing.Point(976, 270);
-            this.button_Merge.Margin = new System.Windows.Forms.Padding(4, 2, 4, 2);
+            this.button_Merge.Location = new System.Drawing.Point(813, 225);
+            this.button_Merge.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.button_Merge.Name = "button_Merge";
-            this.button_Merge.Size = new System.Drawing.Size(234, 260);
+            this.button_Merge.Size = new System.Drawing.Size(195, 217);
             this.button_Merge.TabIndex = 26;
             this.button_Merge.Text = "Policy Merger";
             this.button_Merge.TextAlign = System.Drawing.ContentAlignment.BottomCenter;
@@ -146,20 +144,20 @@ namespace WDAC_Wizard
             // control_Panel
             // 
             this.control_Panel.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(230)))), ((int)(((byte)(230)))), ((int)(((byte)(230)))));
+            this.control_Panel.Controls.Add(this.workflow_Label);
             this.control_Panel.Controls.Add(this.page5_Button);
             this.control_Panel.Controls.Add(this.page4_Button);
             this.control_Panel.Controls.Add(this.page3_Button);
             this.control_Panel.Controls.Add(this.page2_Button);
             this.control_Panel.Controls.Add(this.page1_Button);
-            this.control_Panel.Controls.Add(this.workflow_Button);
             this.control_Panel.Controls.Add(this.controlHighlight_Panel);
             this.control_Panel.Controls.Add(this.home_Button);
             this.control_Panel.Controls.Add(this.settings_Button);
             this.control_Panel.ForeColor = System.Drawing.SystemColors.ControlText;
             this.control_Panel.Location = new System.Drawing.Point(0, 0);
-            this.control_Panel.Margin = new System.Windows.Forms.Padding(4, 2, 4, 2);
+            this.control_Panel.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.control_Panel.Name = "control_Panel";
-            this.control_Panel.Size = new System.Drawing.Size(180, 840);
+            this.control_Panel.Size = new System.Drawing.Size(150, 700);
             this.control_Panel.TabIndex = 30;
             // 
             // page5_Button
@@ -173,10 +171,10 @@ namespace WDAC_Wizard
             this.page5_Button.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.page5_Button.Font = new System.Drawing.Font("Tahoma", 9.5F);
             this.page5_Button.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            this.page5_Button.Location = new System.Drawing.Point(18, 480);
-            this.page5_Button.Margin = new System.Windows.Forms.Padding(4, 2, 4, 2);
+            this.page5_Button.Location = new System.Drawing.Point(15, 400);
+            this.page5_Button.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.page5_Button.Name = "page5_Button";
-            this.page5_Button.Size = new System.Drawing.Size(175, 54);
+            this.page5_Button.Size = new System.Drawing.Size(146, 45);
             this.page5_Button.TabIndex = 39;
             this.page5_Button.Text = "Page 5";
             this.page5_Button.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -195,10 +193,10 @@ namespace WDAC_Wizard
             this.page4_Button.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.page4_Button.Font = new System.Drawing.Font("Tahoma", 9.5F);
             this.page4_Button.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            this.page4_Button.Location = new System.Drawing.Point(18, 420);
-            this.page4_Button.Margin = new System.Windows.Forms.Padding(4, 2, 4, 2);
+            this.page4_Button.Location = new System.Drawing.Point(15, 350);
+            this.page4_Button.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.page4_Button.Name = "page4_Button";
-            this.page4_Button.Size = new System.Drawing.Size(175, 54);
+            this.page4_Button.Size = new System.Drawing.Size(146, 45);
             this.page4_Button.TabIndex = 38;
             this.page4_Button.Text = "Page 4";
             this.page4_Button.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -217,10 +215,10 @@ namespace WDAC_Wizard
             this.page3_Button.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.page3_Button.Font = new System.Drawing.Font("Tahoma", 9.5F);
             this.page3_Button.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            this.page3_Button.Location = new System.Drawing.Point(18, 360);
-            this.page3_Button.Margin = new System.Windows.Forms.Padding(4, 2, 4, 2);
+            this.page3_Button.Location = new System.Drawing.Point(15, 300);
+            this.page3_Button.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.page3_Button.Name = "page3_Button";
-            this.page3_Button.Size = new System.Drawing.Size(175, 54);
+            this.page3_Button.Size = new System.Drawing.Size(146, 45);
             this.page3_Button.TabIndex = 37;
             this.page3_Button.Text = "Page 3";
             this.page3_Button.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -239,10 +237,10 @@ namespace WDAC_Wizard
             this.page2_Button.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.page2_Button.Font = new System.Drawing.Font("Tahoma", 9.5F);
             this.page2_Button.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            this.page2_Button.Location = new System.Drawing.Point(18, 300);
-            this.page2_Button.Margin = new System.Windows.Forms.Padding(4, 2, 4, 2);
+            this.page2_Button.Location = new System.Drawing.Point(15, 250);
+            this.page2_Button.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.page2_Button.Name = "page2_Button";
-            this.page2_Button.Size = new System.Drawing.Size(175, 54);
+            this.page2_Button.Size = new System.Drawing.Size(146, 45);
             this.page2_Button.TabIndex = 36;
             this.page2_Button.Text = "Page 2";
             this.page2_Button.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -261,10 +259,10 @@ namespace WDAC_Wizard
             this.page1_Button.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.page1_Button.Font = new System.Drawing.Font("Tahoma", 9.5F);
             this.page1_Button.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            this.page1_Button.Location = new System.Drawing.Point(18, 240);
-            this.page1_Button.Margin = new System.Windows.Forms.Padding(4, 2, 4, 2);
+            this.page1_Button.Location = new System.Drawing.Point(15, 200);
+            this.page1_Button.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.page1_Button.Name = "page1_Button";
-            this.page1_Button.Size = new System.Drawing.Size(175, 54);
+            this.page1_Button.Size = new System.Drawing.Size(146, 45);
             this.page1_Button.TabIndex = 35;
             this.page1_Button.Text = "Page 1";
             this.page1_Button.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -272,33 +270,12 @@ namespace WDAC_Wizard
             this.page1_Button.Visible = false;
             this.page1_Button.Click += new System.EventHandler(this.PageNButton_Click);
             // 
-            // workflow_Button
-            // 
-            this.workflow_Button.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            this.workflow_Button.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(230)))), ((int)(((byte)(230)))), ((int)(((byte)(230)))));
-            this.workflow_Button.FlatAppearance.BorderSize = 0;
-            this.workflow_Button.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(149)))), ((int)(((byte)(149)))), ((int)(((byte)(149)))));
-            this.workflow_Button.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(149)))), ((int)(((byte)(149)))), ((int)(((byte)(149)))));
-            this.workflow_Button.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.workflow_Button.Font = new System.Drawing.Font("Tahoma", 10F);
-            this.workflow_Button.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            this.workflow_Button.Location = new System.Drawing.Point(6, 180);
-            this.workflow_Button.Margin = new System.Windows.Forms.Padding(4, 2, 4, 2);
-            this.workflow_Button.Name = "workflow_Button";
-            this.workflow_Button.Size = new System.Drawing.Size(156, 54);
-            this.workflow_Button.TabIndex = 34;
-            this.workflow_Button.Text = "Workflow";
-            this.workflow_Button.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            this.workflow_Button.UseVisualStyleBackColor = false;
-            this.workflow_Button.Visible = false;
-            // 
             // controlHighlight_Panel
             // 
             this.controlHighlight_Panel.BackColor = System.Drawing.Color.CornflowerBlue;
-            this.controlHighlight_Panel.Location = new System.Drawing.Point(0, 115);
-            this.controlHighlight_Panel.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.controlHighlight_Panel.Location = new System.Drawing.Point(0, 96);
             this.controlHighlight_Panel.Name = "controlHighlight_Panel";
-            this.controlHighlight_Panel.Size = new System.Drawing.Size(10, 42);
+            this.controlHighlight_Panel.Size = new System.Drawing.Size(8, 35);
             this.controlHighlight_Panel.TabIndex = 33;
             // 
             // home_Button
@@ -312,10 +289,10 @@ namespace WDAC_Wizard
             this.home_Button.Font = new System.Drawing.Font("Tahoma", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.home_Button.Image = ((System.Drawing.Image)(resources.GetObject("home_Button.Image")));
             this.home_Button.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            this.home_Button.Location = new System.Drawing.Point(18, 110);
-            this.home_Button.Margin = new System.Windows.Forms.Padding(4, 2, 4, 2);
+            this.home_Button.Location = new System.Drawing.Point(15, 92);
+            this.home_Button.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.home_Button.Name = "home_Button";
-            this.home_Button.Size = new System.Drawing.Size(155, 54);
+            this.home_Button.Size = new System.Drawing.Size(129, 45);
             this.home_Button.TabIndex = 32;
             this.home_Button.Text = "     Home";
             this.home_Button.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -333,10 +310,10 @@ namespace WDAC_Wizard
             this.settings_Button.Font = new System.Drawing.Font("Tahoma", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.settings_Button.Image = ((System.Drawing.Image)(resources.GetObject("settings_Button.Image")));
             this.settings_Button.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            this.settings_Button.Location = new System.Drawing.Point(18, 776);
-            this.settings_Button.Margin = new System.Windows.Forms.Padding(4, 2, 4, 2);
+            this.settings_Button.Location = new System.Drawing.Point(15, 647);
+            this.settings_Button.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.settings_Button.Name = "settings_Button";
-            this.settings_Button.Size = new System.Drawing.Size(155, 54);
+            this.settings_Button.Size = new System.Drawing.Size(129, 45);
             this.settings_Button.TabIndex = 31;
             this.settings_Button.Text = "     Settings";
             this.settings_Button.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -345,10 +322,10 @@ namespace WDAC_Wizard
             // 
             // button_Next
             // 
-            this.button_Next.Location = new System.Drawing.Point(1361, 796);
-            this.button_Next.Margin = new System.Windows.Forms.Padding(4, 2, 4, 2);
+            this.button_Next.Location = new System.Drawing.Point(1134, 663);
+            this.button_Next.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.button_Next.Name = "button_Next";
-            this.button_Next.Size = new System.Drawing.Size(112, 40);
+            this.button_Next.Size = new System.Drawing.Size(93, 33);
             this.button_Next.TabIndex = 31;
             this.button_Next.Text = "Next";
             this.button_Next.UseVisualStyleBackColor = true;
@@ -360,10 +337,9 @@ namespace WDAC_Wizard
             this.label1.AutoSize = true;
             this.label1.Font = new System.Drawing.Font("Tahoma", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label1.ForeColor = System.Drawing.Color.Black;
-            this.label1.Location = new System.Drawing.Point(222, 98);
-            this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label1.Location = new System.Drawing.Point(185, 82);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(373, 29);
+            this.label1.Size = new System.Drawing.Size(311, 24);
             this.label1.TabIndex = 32;
             this.label1.Text = "Select a task below to get started";
             // 
@@ -371,10 +347,10 @@ namespace WDAC_Wizard
             // 
             this.label2.AutoSize = true;
             this.label2.Font = new System.Drawing.Font("Tahoma", 9F);
-            this.label2.Location = new System.Drawing.Point(355, 544);
+            this.label2.Location = new System.Drawing.Point(296, 453);
             this.label2.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(293, 44);
+            this.label2.Size = new System.Drawing.Size(244, 36);
             this.label2.TabIndex = 33;
             this.label2.Text = "Create a new base or supplemental \r\npolicy";
             // 
@@ -382,10 +358,10 @@ namespace WDAC_Wizard
             // 
             this.label3.AutoSize = true;
             this.label3.Font = new System.Drawing.Font("Tahoma", 9F);
-            this.label3.Location = new System.Drawing.Point(676, 544);
+            this.label3.Location = new System.Drawing.Point(563, 453);
             this.label3.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(245, 22);
+            this.label3.Size = new System.Drawing.Size(195, 18);
             this.label3.TabIndex = 34;
             this.label3.Text = "Edit an existing policy on disk";
             // 
@@ -393,19 +369,30 @@ namespace WDAC_Wizard
             // 
             this.label4.AutoSize = true;
             this.label4.Font = new System.Drawing.Font("Tahoma", 9F);
-            this.label4.Location = new System.Drawing.Point(962, 544);
+            this.label4.Location = new System.Drawing.Point(802, 453);
             this.label4.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(293, 22);
+            this.label4.Size = new System.Drawing.Size(236, 18);
             this.label4.TabIndex = 35;
             this.label4.Text = "Merge two existing policies into one\r\n";
             // 
+            // workflow_Label
+            // 
+            this.workflow_Label.AutoSize = true;
+            this.workflow_Label.Font = new System.Drawing.Font("Tahoma", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.workflow_Label.Location = new System.Drawing.Point(12, 162);
+            this.workflow_Label.Name = "workflow_Label";
+            this.workflow_Label.Size = new System.Drawing.Size(79, 21);
+            this.workflow_Label.TabIndex = 40;
+            this.workflow_Label.Text = "Workflow";
+            this.workflow_Label.Visible = false;
+            // 
             // MainWindow
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(144F, 144F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(120F, 120F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.Color.White;
-            this.ClientSize = new System.Drawing.Size(1478, 844);
+            this.ClientSize = new System.Drawing.Size(1232, 703);
             this.Controls.Add(this.label4);
             this.Controls.Add(this.label3);
             this.Controls.Add(this.label2);
@@ -420,12 +407,13 @@ namespace WDAC_Wizard
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
             this.HelpButton = true;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-            this.Margin = new System.Windows.Forms.Padding(4, 2, 4, 2);
+            this.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.Name = "MainWindow";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "Windows Defender App Control Policy Wizard";
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.FormClosing_Event);
             this.control_Panel.ResumeLayout(false);
+            this.control_Panel.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -445,7 +433,6 @@ namespace WDAC_Wizard
         private System.Windows.Forms.Button button_Next;
         private System.Windows.Forms.Label label1;
         private System.Windows.Forms.Panel controlHighlight_Panel;
-        private System.Windows.Forms.Button workflow_Button;
         private System.Windows.Forms.Button page3_Button;
         private System.Windows.Forms.Button page2_Button;
         private System.Windows.Forms.Button page4_Button;
@@ -454,6 +441,7 @@ namespace WDAC_Wizard
         private System.Windows.Forms.Label label2;
         private System.Windows.Forms.Label label3;
         private System.Windows.Forms.Label label4;
+        private System.Windows.Forms.Label workflow_Label;
     }
 }
 

--- a/WDAC-Policy-Wizard/app/src/MainForm.cs
+++ b/WDAC-Policy-Wizard/app/src/MainForm.cs
@@ -1565,7 +1565,10 @@ namespace WDAC_Wizard
             {
                 controlHighlight_Panel.Location = new System.Drawing.Point(this.home_Button.Location.X - X_OFFSET, this.home_Button.Location.Y + Y_OFFSET);
             }
-            
+
+            // Enable Settings Button -- if on building page, it will be disabled below
+            this.settings_Button.Enabled = true; 
+
             // Set link text
             switch (this.Policy._PolicyType)
             {
@@ -1717,6 +1720,7 @@ namespace WDAC_Wizard
                     this.page5_Button.Enabled = false;
                     controlHighlight_Panel.Location = new System.Drawing.Point(this.page3_Button.Location.X - X_OFFSET, this.page3_Button.Location.Y + Y_OFFSET);
                     break;
+
                 case 4:
                     if(this.view == 2)
                     {
@@ -1739,6 +1743,7 @@ namespace WDAC_Wizard
                     
                     controlHighlight_Panel.Location = new System.Drawing.Point(this.page4_Button.Location.X - X_OFFSET, this.page4_Button.Location.Y + Y_OFFSET);
                     break;
+
                 case 5:
                     // Building page
 

--- a/WDAC-Policy-Wizard/app/src/MainForm.cs
+++ b/WDAC-Policy-Wizard/app/src/MainForm.cs
@@ -1605,6 +1605,8 @@ namespace WDAC_Wizard
                     this.page2_Button.Visible = true;
                     this.page3_Button.Visible = true;
                     this.page4_Button.Visible = true;
+                    this.page5_Button.Visible = false;
+
                     this.workflow_Label.Text = "Policy Editor";
                     this.page1_Button.Text = "Select Policy";
                     this.page2_Button.Text = "Policy Rules";
@@ -1618,6 +1620,8 @@ namespace WDAC_Wizard
                     this.page2_Button.Visible = true;
                     this.page3_Button.Visible = false;
                     this.page4_Button.Visible = false;
+                    this.page5_Button.Visible = false;
+
                     this.workflow_Label.Text = "Policy Merger";
                     this.page1_Button.Text = "Select Policies";
                     this.page2_Button.Text = "Creating Policy";
@@ -1639,7 +1643,7 @@ namespace WDAC_Wizard
                             this.page1_Button.Text = "Policy Type";
                             break;
 
-                        case 2: // view policy
+                        case 2: // edit policy
                             this.workflow_Label.Visible = true;
                             this.page1_Button.Visible = true;
                             this.page2_Button.Visible = true;

--- a/WDAC-Policy-Wizard/app/src/MainForm.cs
+++ b/WDAC-Policy-Wizard/app/src/MainForm.cs
@@ -1570,13 +1570,13 @@ namespace WDAC_Wizard
             switch (this.Policy._PolicyType)
             {
                 case WDAC_Policy.PolicyType.BasePolicy: // Policy creator
-                    this.workflow_Button.Visible = true;
+                    this.workflow_Label.Visible = true;
                     this.page1_Button.Visible = true;
                     this.page2_Button.Visible = true;
                     this.page3_Button.Visible = true;
                     this.page4_Button.Visible = true;
                     this.page5_Button.Visible = true;
-                    this.workflow_Button.Text = "Policy Creator";
+                    this.workflow_Label.Text = "Policy Creator";
                     this.page1_Button.Text = "Policy Type"; 
                     this.page2_Button.Text = "Policy Template"; 
                     this.page3_Button.Text = "Policy Rules"; 
@@ -1585,14 +1585,14 @@ namespace WDAC_Wizard
                     break;
 
                 case WDAC_Policy.PolicyType.SupplementalPolicy: // Policy creator
-                    this.workflow_Button.Visible = true;
+                    this.workflow_Label.Visible = true;
                     this.page1_Button.Visible = true;
                     this.page2_Button.Visible = true;
                     this.page3_Button.Visible = true;
                     this.page4_Button.Visible = true;
                     this.page5_Button.Visible = false;
 
-                    this.workflow_Button.Text = "Policy Creator";
+                    this.workflow_Label.Text = "Policy Creator";
                     this.page1_Button.Text = "Policy Type";
                     this.page2_Button.Text = "Policy Rules";
                     this.page3_Button.Text = "Signing Rules";
@@ -1600,12 +1600,12 @@ namespace WDAC_Wizard
                     break;
 
                 case WDAC_Policy.PolicyType.Edit: // policy editor
-                    this.workflow_Button.Visible = true;
+                    this.workflow_Label.Visible = true;
                     this.page1_Button.Visible = true;
                     this.page2_Button.Visible = true;
                     this.page3_Button.Visible = true;
                     this.page4_Button.Visible = true;
-                    this.workflow_Button.Text = "Policy Editor";
+                    this.workflow_Label.Text = "Policy Editor";
                     this.page1_Button.Text = "Select Policy";
                     this.page2_Button.Text = "Policy Rules";
                     this.page3_Button.Text = "Signing Rules";
@@ -1613,12 +1613,12 @@ namespace WDAC_Wizard
                     break;
 
                 case WDAC_Policy.PolicyType.Merge: // merger
-                    this.workflow_Button.Visible = true;
+                    this.workflow_Label.Visible = true;
                     this.page1_Button.Visible = true;
                     this.page2_Button.Visible = true;
                     this.page3_Button.Visible = false;
                     this.page4_Button.Visible = false;
-                    this.workflow_Button.Text = "Policy Merger";
+                    this.workflow_Label.Text = "Policy Merger";
                     this.page1_Button.Text = "Select Policies";
                     this.page2_Button.Text = "Creating Policy";
 
@@ -1629,23 +1629,23 @@ namespace WDAC_Wizard
                     switch(this.view)
                     {
                         case 1: // New policy
-                            this.workflow_Button.Visible = true;
+                            this.workflow_Label.Visible = true;
                             this.page1_Button.Visible = true;
                             this.page2_Button.Visible = false;
                             this.page3_Button.Visible = false;
                             this.page4_Button.Visible = false;
                             this.page5_Button.Visible = false;
-                            this.workflow_Button.Text = "Policy Creator";
+                            this.workflow_Label.Text = "Policy Creator";
                             this.page1_Button.Text = "Policy Type";
                             break;
 
                         case 2: // view policy
-                            this.workflow_Button.Visible = true;
+                            this.workflow_Label.Visible = true;
                             this.page1_Button.Visible = true;
                             this.page2_Button.Visible = true;
                             this.page3_Button.Visible = true;
                             this.page4_Button.Visible = true;
-                            this.workflow_Button.Text = "Policy Editor";
+                            this.workflow_Label.Text = "Policy Editor";
                             this.page1_Button.Text = "Select Policy";
                             this.page2_Button.Text = "Policy Rules";
                             this.page3_Button.Text = "Signing Rules";
@@ -1661,7 +1661,7 @@ namespace WDAC_Wizard
 
 
                 default:
-                    this.workflow_Button.Visible = false;
+                    this.workflow_Label.Visible = false;
                     this.page1_Button.Visible = false;
                     this.page2_Button.Visible = false;
                     this.page3_Button.Visible = false;


### PR DESCRIPTION
Fixed the following 3 bugs (RC + fix):

1. Workflow button (eg. Policy Creator underneath Home button) on the rhs control panel when hovered, shows it can be clicked. Clicking does not appear to do anything. Fix: changed object from WindowsForms.Button to WindowsForms.Label so it can no longer be clicked. 
2. Appearance of 2 "Creating Policy" buttons in the Policy Editor workflow. This would appear if the user began creating a policy, abandoned it and began editing a policy. Fix: Button 5 in the control panel is now set to Enabled=False in the editor and merger workflows. 
3. Settings page was inaccessible after creating, editing or merging a policy. Fix=ControlPanel() sets settingsPage.Enabled=True