### PR TITLE
Fixed a bug where editing a multi format policy would revert to legac…

### DIFF
--- a/WDAC-Policy-Wizard/app/src/MainForm.cs
+++ b/WDAC-Policy-Wizard/app/src/MainForm.cs
@@ -1074,7 +1074,9 @@ namespace WDAC_Wizard
                 // Since we set the format in ProcessCustomRules(), the customRulesPathList will be the correct format
                 mergeScript = "Merge-CIPolicy -PolicyPaths ";
                 foreach (string path in customRulesPathList)
+                {
                     mergeScript += String.Format("\"{0}\",", path);
+                }
 
                 // Remove last comma and add outputFilePath
                 mergeScript = mergeScript.Remove(mergeScript.Length - 1);
@@ -1132,7 +1134,7 @@ namespace WDAC_Wizard
                 this.Policy.SchemaPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), Path.GetFileName(this.Policy.SchemaPath)); 
             }
 
-           this.Log.AddInfoMsg("--- Merge Templates Policy ---");
+            this.Log.AddInfoMsg("--- Merge Templates Policy ---");
             string DEST_PATH = System.IO.Path.Combine(this.TempFolderPath, "OutputSchema.xml"); //this.TempFolderPath + @"\OutputSchema.xml";
 
             List<string> policyPaths = new List<string>();


### PR DESCRIPTION
…y format.

The Policy.Format was not being set in the workflow. If the edited policy workflow created a custom rule, the custom rule policy was being created in legacy format. Custom rule policies are in the front of the ci merge command resulting in a CI legacy policy output.