### PR TITLE
Multi format policy bins named {guid}.cip

### DIFF
--- a/WDAC-Policy-Wizard/app/src/BuildPage.cs
+++ b/WDAC-Policy-Wizard/app/src/BuildPage.cs
@@ -52,11 +52,22 @@ namespace WDAC_Wizard
         /// </summary>
         public void ShowFinishMsg(string policyFilePath)
         {
-            this.finishPanel.Visible = true;
-            this.FilePath = policyFilePath;
+            // Check if the policyFilePath contains a .bin/.cip file too
+            // Parse for the xml file only to add to this.FilePath
+            if(policyFilePath.Contains(Environment.NewLine))
+            {
+                var eol = policyFilePath.IndexOf(Environment.NewLine);
+                this.FilePath = policyFilePath.Substring(0, eol); 
+            }
+            else
+            {
+                this.FilePath = policyFilePath;
+            }
+
             this.hyperlinkLabel.Text = policyFilePath;
             this.hyperlinkLabel.Enabled = true;
 
+            this.finishPanel.Visible = true;
             this.label_WaitMsg.Visible = false; 
         }
 
@@ -88,11 +99,14 @@ namespace WDAC_Wizard
                 }
                 catch (Exception excpt)
                 {
+                    // Log file already closed/uploaded
                     Console.WriteLine(String.Format("{0} exception caught", excpt));
                 }
             }
             else
+            {
                 Console.WriteLine(String.Format("Unable to open {0}", this.FilePath));
+            }
         }
     }
 }

--- a/WDAC-Policy-Wizard/app/src/MainForm.cs
+++ b/WDAC-Policy-Wizard/app/src/MainForm.cs
@@ -781,7 +781,9 @@ namespace WDAC_Wizard
             }
             else
             {
-                if(this.Policy.BinPath != null)
+                this._BuildPage.UpdateProgressBar(100, " ");
+
+                if (this.Policy.BinPath != null)
                 {
                     this._BuildPage.ShowFinishMsg(this.Policy.SchemaPath + "\r\n" + this.Policy.BinPath);
                 }
@@ -789,8 +791,6 @@ namespace WDAC_Wizard
                 {
                     this._BuildPage.ShowFinishMsg(this.Policy.SchemaPath); 
                 }
-
-                this._BuildPage.UpdateProgressBar(100, " ");
             }
 
             this.Log.AddNewSeparationLine("Workflow -- DONE"); 

--- a/WDAC-Policy-Wizard/app/src/MainForm.cs
+++ b/WDAC-Policy-Wizard/app/src/MainForm.cs
@@ -1074,7 +1074,9 @@ namespace WDAC_Wizard
                 // Since we set the format in ProcessCustomRules(), the customRulesPathList will be the correct format
                 mergeScript = "Merge-CIPolicy -PolicyPaths ";
                 foreach (string path in customRulesPathList)
+                {
                     mergeScript += String.Format("\"{0}\",", path);
+                }
 
                 // Remove last comma and add outputFilePath
                 mergeScript = mergeScript.Remove(mergeScript.Length - 1);
@@ -1132,7 +1134,7 @@ namespace WDAC_Wizard
                 this.Policy.SchemaPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), Path.GetFileName(this.Policy.SchemaPath)); 
             }
 
-           this.Log.AddInfoMsg("--- Merge Templates Policy ---");
+            this.Log.AddInfoMsg("--- Merge Templates Policy ---");
             string DEST_PATH = System.IO.Path.Combine(this.TempFolderPath, "OutputSchema.xml"); //this.TempFolderPath + @"\OutputSchema.xml";
 
             List<string> policyPaths = new List<string>();

--- a/WDAC-Policy-Wizard/app/src/MainForm.cs
+++ b/WDAC-Policy-Wizard/app/src/MainForm.cs
@@ -781,7 +781,15 @@ namespace WDAC_Wizard
             }
             else
             {
-                this._BuildPage.ShowFinishMsg(this.Policy.SchemaPath);
+                if(this.Policy.BinPath != null)
+                {
+                    this._BuildPage.ShowFinishMsg(this.Policy.SchemaPath + "\r\n" + this.Policy.BinPath);
+                }
+                else
+                {
+                    this._BuildPage.ShowFinishMsg(this.Policy.SchemaPath); 
+                }
+
                 this._BuildPage.UpdateProgressBar(100, " ");
             }
 
@@ -1310,8 +1318,8 @@ namespace WDAC_Wizard
                 binaryFileName = Path.GetFileNameWithoutExtension(this.Policy.SchemaPath) +".bin";
             }
 
-            string binaryFilePath = Path.Combine(Path.GetDirectoryName(this.Policy.SchemaPath), binaryFileName);  
-            string binConvertCmd = String.Format("ConvertFrom-CIPolicy -XmlFilePath \"{0}\" -BinaryFilePath \"{1}\"", this.Policy.SchemaPath, binaryFilePath);
+            this.Policy.BinPath = Path.Combine(Path.GetDirectoryName(this.Policy.SchemaPath), binaryFileName);  
+            string binConvertCmd = String.Format("ConvertFrom-CIPolicy -XmlFilePath \"{0}\" -BinaryFilePath \"{1}\"", this.Policy.SchemaPath, this.Policy.BinPath);
 
             pipeline.Commands.AddScript(binConvertCmd);
 

--- a/WDAC-Policy-Wizard/app/src/Policy.cs
+++ b/WDAC-Policy-Wizard/app/src/Policy.cs
@@ -54,6 +54,7 @@ namespace WDAC_Wizard
         public string TemplatePath { get; set; }        // ReadOnly Path to template policy - TODO: make const
         public string BaseToSupplementPath { get; set; } // Path to base policy to supplement, if applicable
         public string EditPolicyPath { get; set; }      // Path to the policy we are editing. Used for parsing.
+        public string BinPath { get; set;  }
 
         public List<string> PoliciesToMerge { get; set; }
 

--- a/WDAC-Policy-Wizard/app/src/SigningRules_Control.cs
+++ b/WDAC-Policy-Wizard/app/src/SigningRules_Control.cs
@@ -1166,7 +1166,7 @@ namespace WDAC_Wizard
                 }
 
                 // Else, process Level=FileAttributes
-                else
+                else if(ruleType.Equals("File Attributes"))
                 {
                     this.Log.AddInfoMsg("Removing FileAttributes Rule");
 


### PR DESCRIPTION
If the binary conversion setting is enabled, the Wizard will determine the naming convention of the compiled policy to either

- {PolicyGUID}.cip if multi-policy format is selected
- Schema path (user defined).bin if legacy format

Also showing the destination of the binary file on the final page to show the user where the binary file was placed. 