### PR TITLE
Fixed bug where settings were being reset every 2nd Settings page load.

### DIFF
--- a/WDAC-Policy-Wizard/app/Properties/Resources.Designer.cs
+++ b/WDAC-Policy-Wizard/app/Properties/Resources.Designer.cs
@@ -480,6 +480,15 @@ namespace WDAC_Wizard.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Are you sure you want to reset settings to their original states?.
+        /// </summary>
+        internal static string ResetSettingsString {
+            get {
+                return ResourceManager.GetString("ResetSettingsString", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Turning this off will disable default FilePath rule protection of enforcing user-writeability and only allowing admin-writeable locations..
         /// </summary>
         internal static string RuntimeRules {

--- a/WDAC-Policy-Wizard/app/Properties/Resources.resx
+++ b/WDAC-Policy-Wizard/app/Properties/Resources.resx
@@ -331,4 +331,7 @@
   <data name="BlobContainerString" xml:space="preserve">
     <value>wdac-wizard-logs</value>
   </data>
+  <data name="ResetSettingsString" xml:space="preserve">
+    <value>Are you sure you want to reset settings to their original states?</value>
+  </data>
 </root>

--- a/WDAC-Policy-Wizard/app/src/SettingsPage.Designer.cs
+++ b/WDAC-Policy-Wizard/app/src/SettingsPage.Designer.cs
@@ -62,11 +62,11 @@ namespace WDAC_Wizard
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Font = new System.Drawing.Font("Tahoma", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label2.Location = new System.Drawing.Point(25, 307);
+            this.label2.Font = new System.Drawing.Font("Tahoma", 11F);
+            this.label2.Location = new System.Drawing.Point(25, 324);
             this.label2.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(62, 24);
+            this.label2.Size = new System.Drawing.Size(59, 23);
             this.label2.TabIndex = 1;
             this.label2.Text = "About";
             // 
@@ -75,7 +75,7 @@ namespace WDAC_Wizard
             this.appVersion_Label.AutoSize = true;
             this.appVersion_Label.Font = new System.Drawing.Font("Tahoma", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.appVersion_Label.ForeColor = System.Drawing.SystemColors.ControlDark;
-            this.appVersion_Label.Location = new System.Drawing.Point(27, 342);
+            this.appVersion_Label.Location = new System.Drawing.Point(27, 359);
             this.appVersion_Label.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.appVersion_Label.Name = "appVersion_Label";
             this.appVersion_Label.Size = new System.Drawing.Size(168, 21);
@@ -87,12 +87,12 @@ namespace WDAC_Wizard
             this.label3.AutoSize = true;
             this.label3.Font = new System.Drawing.Font("Tahoma", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label3.ForeColor = System.Drawing.SystemColors.ControlDark;
-            this.label3.Location = new System.Drawing.Point(27, 371);
+            this.label3.Location = new System.Drawing.Point(27, 388);
             this.label3.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(231, 42);
+            this.label3.Size = new System.Drawing.Size(243, 42);
             this.label3.TabIndex = 3;
-            this.label3.Text = "2019 Microsoft Corporation ©\r\nJogeurte@microsoft.com";
+            this.label3.Text = "2019 Microsoft Corporation ©\r\nJordan.Geurten@microsoft.com";
             // 
             // terms_Label
             // 
@@ -102,13 +102,13 @@ namespace WDAC_Wizard
             this.terms_Label.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(16)))), ((int)(((byte)(110)))), ((int)(((byte)(190)))));
             this.terms_Label.Image = global::WDAC_Wizard.Properties.Resources.external_link_symbol_highlight;
             this.terms_Label.ImageAlign = System.Drawing.ContentAlignment.MiddleRight;
-            this.terms_Label.Location = new System.Drawing.Point(25, 437);
+            this.terms_Label.Location = new System.Drawing.Point(25, 444);
             this.terms_Label.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.terms_Label.Name = "terms_Label";
             this.terms_Label.Size = new System.Drawing.Size(129, 21);
             this.terms_Label.TabIndex = 4;
             this.terms_Label.Text = "Terms of Use    ";
-            this.terms_Label.Click += new System.EventHandler(this.terms_Label_Click);
+            this.terms_Label.Click += new System.EventHandler(this.Terms_Label_Click);
             // 
             // privacy_Label
             // 
@@ -124,16 +124,16 @@ namespace WDAC_Wizard
             this.privacy_Label.Size = new System.Drawing.Size(164, 21);
             this.privacy_Label.TabIndex = 5;
             this.privacy_Label.Text = "Privacy Statement    ";
-            this.privacy_Label.Click += new System.EventHandler(this.privacy_Label_Click);
+            this.privacy_Label.Click += new System.EventHandler(this.Privacy_Label_Click);
             // 
             // label4
             // 
             this.label4.AutoSize = true;
-            this.label4.Font = new System.Drawing.Font("Tahoma", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label4.Font = new System.Drawing.Font("Tahoma", 11F);
             this.label4.Location = new System.Drawing.Point(25, 157);
             this.label4.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(84, 24);
+            this.label4.Size = new System.Drawing.Size(78, 23);
             this.label4.TabIndex = 6;
             this.label4.Text = "Defaults";
             // 
@@ -161,7 +161,7 @@ namespace WDAC_Wizard
             this.useDefaultStrings_CheckBox.TabIndex = 8;
             this.useDefaultStrings_CheckBox.TabStop = false;
             this.useDefaultStrings_CheckBox.Tag = "Checked";
-            this.useDefaultStrings_CheckBox.Click += new System.EventHandler(this.SettingCheckBox_Click);
+            this.useDefaultStrings_CheckBox.Click += new System.EventHandler(this.DefaultString_CheckBox_Click);
             this.useDefaultStrings_CheckBox.MouseLeave += new System.EventHandler(this.SettingCheckBox_Leave);
             this.useDefaultStrings_CheckBox.MouseHover += new System.EventHandler(this.SettingCheckBox_Hover);
             // 
@@ -198,7 +198,7 @@ namespace WDAC_Wizard
             this.panel1.Location = new System.Drawing.Point(164, 93);
             this.panel1.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.panel1.Name = "panel1";
-            this.panel1.Size = new System.Drawing.Size(888, 509);
+            this.panel1.Size = new System.Drawing.Size(713, 509);
             this.panel1.TabIndex = 12;
             // 
             // convertPolicyToBinary_CheckBox
@@ -213,7 +213,7 @@ namespace WDAC_Wizard
             this.convertPolicyToBinary_CheckBox.TabIndex = 19;
             this.convertPolicyToBinary_CheckBox.TabStop = false;
             this.convertPolicyToBinary_CheckBox.Tag = "Unchecked";
-            this.convertPolicyToBinary_CheckBox.Click += new System.EventHandler(this.SettingCheckBox_Click);
+            this.convertPolicyToBinary_CheckBox.Click += new System.EventHandler(this.ConvertPolicy_CheckBox_Click);
             this.convertPolicyToBinary_CheckBox.MouseLeave += new System.EventHandler(this.SettingCheckBox_Leave);
             this.convertPolicyToBinary_CheckBox.MouseHover += new System.EventHandler(this.SettingCheckBox_Hover);
             // 
@@ -241,7 +241,7 @@ namespace WDAC_Wizard
             this.allowTelemetry_CheckBox.TabIndex = 17;
             this.allowTelemetry_CheckBox.TabStop = false;
             this.allowTelemetry_CheckBox.Tag = "Checked";
-            this.allowTelemetry_CheckBox.Click += new System.EventHandler(this.SettingCheckBox_Click);
+            this.allowTelemetry_CheckBox.Click += new System.EventHandler(this.Telemetry_CheckBox_Click);
             this.allowTelemetry_CheckBox.MouseLeave += new System.EventHandler(this.SettingCheckBox_Leave);
             this.allowTelemetry_CheckBox.MouseHover += new System.EventHandler(this.SettingCheckBox_Hover);
             // 
@@ -260,11 +260,11 @@ namespace WDAC_Wizard
             // label9
             // 
             this.label9.AutoSize = true;
-            this.label9.Font = new System.Drawing.Font("Tahoma", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label9.Font = new System.Drawing.Font("Tahoma", 11F);
             this.label9.Location = new System.Drawing.Point(27, 15);
             this.label9.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label9.Name = "label9";
-            this.label9.Size = new System.Drawing.Size(61, 24);
+            this.label9.Size = new System.Drawing.Size(56, 23);
             this.label9.TabIndex = 15;
             this.label9.Text = "Policy";
             // 
@@ -280,7 +280,7 @@ namespace WDAC_Wizard
             this.useEnvVars_CheckBox.TabIndex = 14;
             this.useEnvVars_CheckBox.TabStop = false;
             this.useEnvVars_CheckBox.Tag = "Checked";
-            this.useEnvVars_CheckBox.Click += new System.EventHandler(this.SettingCheckBox_Click);
+            this.useEnvVars_CheckBox.Click += new System.EventHandler(this.EnvVar_CheckBox_Click);
             this.useEnvVars_CheckBox.MouseLeave += new System.EventHandler(this.SettingCheckBox_Leave);
             this.useEnvVars_CheckBox.MouseHover += new System.EventHandler(this.SettingCheckBox_Hover);
             // 
@@ -311,26 +311,26 @@ namespace WDAC_Wizard
             // 
             this.resetButton.BackColor = System.Drawing.Color.WhiteSmoke;
             this.resetButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 9F);
-            this.resetButton.Location = new System.Drawing.Point(960, 618);
-            this.resetButton.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.resetButton.Location = new System.Drawing.Point(785, 607);
+            this.resetButton.Margin = new System.Windows.Forms.Padding(2);
             this.resetButton.Name = "resetButton";
             this.resetButton.Size = new System.Drawing.Size(92, 32);
             this.resetButton.TabIndex = 14;
             this.resetButton.Text = "Reset";
             this.resetButton.UseVisualStyleBackColor = false;
-            this.resetButton.Click += new System.EventHandler(this.resetButton_Click);
+            this.resetButton.Click += new System.EventHandler(this.ResetButton_Click);
             // 
             // Update_Label
             // 
             this.Update_Label.AutoSize = true;
             this.Update_Label.Font = new System.Drawing.Font("Tahoma", 10F);
-            this.Update_Label.ForeColor = System.Drawing.Color.DodgerBlue;
-            this.Update_Label.Location = new System.Drawing.Point(192, 630);
+            this.Update_Label.ForeColor = System.Drawing.Color.Black;
+            this.Update_Label.Location = new System.Drawing.Point(165, 612);
             this.Update_Label.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.Update_Label.Name = "Update_Label";
-            this.Update_Label.Size = new System.Drawing.Size(153, 21);
+            this.Update_Label.Size = new System.Drawing.Size(135, 21);
             this.Update_Label.TabIndex = 15;
-            this.Update_Label.Text = "Updating Setting ...";
+            this.Update_Label.Text = "Saving Setting ...";
             this.Update_Label.Visible = false;
             // 
             // SettingsPage

--- a/WDAC-Policy-Wizard/app/src/SettingsPage.cs
+++ b/WDAC-Policy-Wizard/app/src/SettingsPage.cs
@@ -54,19 +54,86 @@ namespace WDAC_Wizard
         //      
         // Returns:
         //     None.
-        private void SettingCheckBox_Click(object sender, EventArgs e)
-        {
-            // Map the checkbox [really a picturebox] to the setting
-            // Names of the checkbox are always <setting_name>_CheckBox
-            int CHAR_OFFSET = 9;
-            PictureBox checkBox = ((PictureBox)sender);
-            string settingName = checkBox.Name.Substring(0, checkBox.Name.Length - CHAR_OFFSET);
 
-            // Prompt user for additional confirmation before disabling telemetry
-            if(settingName == "allowTelemetry" && checkBox.Tag.ToString() == "Checked")
+        private void EnvVar_CheckBox_Click(object sender, EventArgs e)
+        {
+            // Toggle the UI and set the setting
+            // Currently true, set to false
+            PictureBox checkBox = ((PictureBox)sender);
+
+            if (Properties.Settings.Default.useEnvVars)
             {
-                DialogResult res = MessageBox.Show("Turning this off will not allow developers to improve this tool or help" +
-                    " debug your case." + Environment.NewLine + "Are you sure you want to disable this?", "Confirmation", MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
+                checkBox.BackgroundImage = Properties.Resources.check_box_unchecked;
+                checkBox.Tag = "Unchecked";
+                Properties.Settings.Default.useEnvVars = false; 
+            }
+            else // false, set to true
+            {
+                checkBox.BackgroundImage = Properties.Resources.check_box_checked;
+                checkBox.Tag = "Checked";
+                Properties.Settings.Default.useEnvVars = true;
+            }
+
+            // Save setting and show update message to user
+            SaveSetting(); 
+        }
+
+        private void ConvertPolicy_CheckBox_Click(object sender, EventArgs e)
+        {
+            // Toggle the UI and set the setting
+            // Currently true, set to false
+            PictureBox checkBox = ((PictureBox)sender);
+
+            if (Properties.Settings.Default.convertPolicyToBinary)
+            {
+                checkBox.BackgroundImage = Properties.Resources.check_box_unchecked;
+                checkBox.Tag = "Unchecked";
+                Properties.Settings.Default.convertPolicyToBinary = false;
+            }
+            else // false, set to true
+            {
+                checkBox.BackgroundImage = Properties.Resources.check_box_checked;
+                checkBox.Tag = "Checked";
+                Properties.Settings.Default.convertPolicyToBinary = true;
+            }
+
+            // Save setting and show update message to user
+            SaveSetting();
+        }
+
+        private void DefaultString_CheckBox_Click(object sender, EventArgs e)
+        {
+            // Toggle the UI and set the setting
+            // Currently true, set to false
+            PictureBox checkBox = ((PictureBox)sender);
+
+            if (Properties.Settings.Default.useDefaultStrings)
+            {
+                checkBox.BackgroundImage = Properties.Resources.check_box_unchecked;
+                checkBox.Tag = "Unchecked";
+                Properties.Settings.Default.useDefaultStrings = false;
+            }
+            else // false, set to true
+            {
+                checkBox.BackgroundImage = Properties.Resources.check_box_checked;
+                checkBox.Tag = "Checked";
+                Properties.Settings.Default.useDefaultStrings = true;
+            }
+
+            // Save setting and show update message to user
+            SaveSetting();
+        }
+
+        private void Telemetry_CheckBox_Click(object sender, EventArgs e)
+        {
+            PictureBox checkBox = ((PictureBox)sender);
+
+            // Toggle the UI and set the setting
+            // Currently true, set to false
+            if (Properties.Settings.Default.allowTelemetry)
+            {
+                DialogResult res = MessageBox.Show("Turning this off will not allow developers to improve this tool or help debug your case."
+                + "\r\nAre you sure you want to disable this?", "Confirmation", MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
 
                 if (res == DialogResult.No)
                 {
@@ -79,54 +146,36 @@ namespace WDAC_Wizard
                     this.Log.UploadLog();
 
                     // new log object since upload closes and flushes current object
-                    this._MainWindow.Log = new Logger(this._MainWindow.TempFolderPath); 
+                    this._MainWindow.Log = new Logger(this._MainWindow.TempFolderPath);
                 }
-            }
 
-            // Check if system supports Multi-Policy before enabling
-            // TODO: move this to new policy page
-            int REQ_RELN_MULTI_POL = 1903; 
-            if(settingName == "createMultiPolicyByDefault" && checkBox.Tag.ToString() == "Unchecked")
-            {
-                int releaseN = this._MainWindow.getReleaseId(); 
-                if(releaseN < REQ_RELN_MULTI_POL)
-                {
-                    this.Log.AddWarningMsg(String.Format("Release ID: {0} does not meet multi policy format requirements", releaseN));
-
-                    // Show warn/error message to user
-                    DialogResult res = MessageBox.Show("Your system does not meet the requirements for Multiple Policy Format. Please upgrade to Windows 10 version 1903 or higher.",
-                        "Unmet System Requirements", MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
-
-                    return;
-                }
-            }
-
-            if (checkBox.Tag.ToString() == "Checked")
-            {
-                // Set setting --> false and checkbox --> unchecked
                 checkBox.BackgroundImage = Properties.Resources.check_box_unchecked;
                 checkBox.Tag = "Unchecked";
-                Properties.Settings.Default[settingName] = false;
+                Properties.Settings.Default.allowTelemetry = false;
+
             }
-            else
+            else // false, set to true
             {
-                // Set setting --> true and checkbox --> checked
                 checkBox.BackgroundImage = Properties.Resources.check_box_checked;
                 checkBox.Tag = "Checked";
-                Properties.Settings.Default[settingName] = true;
+                Properties.Settings.Default.allowTelemetry = true;
             }
 
+            // Save setting and show update message to user
+            SaveSetting();
+        }
+
+        private void SaveSetting()
+        {
             // Save settings and show settings update to user
             Properties.Settings.Default.Save();
-            this.Update_Label.Visible = true; 
+            this.Update_Label.Visible = true;
 
             Timer settingsUpdateNotificationTimer = new Timer();
             settingsUpdateNotificationTimer.Interval = (1500); // 1.5 secs
             settingsUpdateNotificationTimer.Tick += new EventHandler(SettingUpdateTimer_Tick);
             settingsUpdateNotificationTimer.Start();
-            
         }
-
 
         //
         // Summary:
@@ -134,7 +183,7 @@ namespace WDAC_Wizard
         //      
         // Returns:
         //     None.
-        private void terms_Label_Click(object sender, EventArgs e)
+        private void Terms_Label_Click(object sender, EventArgs e)
         {
             // Launch the terms of use page
             try
@@ -149,7 +198,7 @@ namespace WDAC_Wizard
 
         }
 
-        private void privacy_Label_Click(object sender, EventArgs e)
+        private void Privacy_Label_Click(object sender, EventArgs e)
         {
             // Launch the privacy agreement page
             try
@@ -164,10 +213,10 @@ namespace WDAC_Wizard
 
         }
 
-        private void resetButton_Click(object sender, EventArgs e)
+        private void ResetButton_Click(object sender, EventArgs e)
         {
             // Prompt user for additional confirmation
-            DialogResult res = MessageBox.Show("Are you sure you want to reset settings to their original state?",
+            DialogResult res = MessageBox.Show(Properties.Resources.ResetSettingsString,
                 "Confirmation", MessageBoxButtons.YesNo, MessageBoxIcon.Information);
 
             if (res == DialogResult.Yes)
@@ -189,6 +238,7 @@ namespace WDAC_Wizard
                 }
 
                 SetSettingsValues(this.SettingsDict);
+                Properties.Settings.Default.Reset();
             }
         }
 
@@ -198,10 +248,10 @@ namespace WDAC_Wizard
             // On load, configure UI to match the app settings
             this.Log.AddNewSeparationLine("Settings Page Load"); 
 
-            this.SettingsDict.Add("useEnvVars", (bool)Properties.Settings.Default["useEnvVars"]);
-            this.SettingsDict.Add("useDefaultStrings", (bool)Properties.Settings.Default["useDefaultStrings"]);
-            this.SettingsDict.Add("allowTelemetry", (bool)Properties.Settings.Default["allowTelemetry"]);
-            this.SettingsDict.Add("convertPolicyToBinary", (bool)Properties.Settings.Default["convertPolicyToBinary"]); 
+            this.SettingsDict.Add("useEnvVars", (bool)Properties.Settings.Default.useEnvVars);
+            this.SettingsDict.Add("useDefaultStrings", (bool)Properties.Settings.Default.useDefaultStrings);
+            this.SettingsDict.Add("allowTelemetry", (bool)Properties.Settings.Default.allowTelemetry);
+            this.SettingsDict.Add("convertPolicyToBinary", (bool)Properties.Settings.Default.convertPolicyToBinary); 
 
             this.Log.AddInfoMsg("Successfully read in the following Default Settings: ");
             foreach (var key in this.SettingsDict.Keys)
@@ -236,7 +286,6 @@ namespace WDAC_Wizard
                     this.Controls.Find(checkBoxName, true).FirstOrDefault().BackgroundImage = Properties.Resources.check_box_checked;
                 }
 
-                Properties.Settings.Default.Reset(); 
                 this.Log.AddInfoMsg(String.Format("Setting {0} set to {1}", settingName, settingDict[settingName])); 
             }            
         }
@@ -263,5 +312,6 @@ namespace WDAC_Wizard
             PictureBox checkBox = ((PictureBox)sender);
             checkBox.BackColor = Color.White;
         }
+
     }
 }


### PR DESCRIPTION
Fixed issue #25 where modifying the app settings, returning to home/workflow, and revisiting the settings page would overwrite/reset the settings and UI to their default states. 

Moved the location of the reset call, Properties.Settings.Default.Reset(), from onLoad() to the proper function, onReset(). 

Also refactored the settingsPage checkbox click code to one function per checkBox. It is cleaner that way. 