### PR TITLE
WDAC Wizard supports custom path, hash and version values for file rules

### DIFF
--- a/WDAC-Policy-Wizard/app/MSIX/AppxManifest.xml
+++ b/WDAC-Policy-Wizard/app/MSIX/AppxManifest.xml
@@ -4,7 +4,7 @@
   xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
   xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities">
   <Identity Name="Microsoft.WDAC.WDACWizard"
-            Version="1.6.2.2"
+            Version="1.6.3.0"
             Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US"
             ProcessorArchitecture="x64"/>
    <Properties>

--- a/WDAC-Policy-Wizard/app/MSIX/RulesDict.xml
+++ b/WDAC-Policy-Wizard/app/MSIX/RulesDict.xml
@@ -141,7 +141,7 @@
     AllowedValue="Enabled"
     Supported="True"
     RuleNumber="17"
-    ValidSupplemental="True"
+    ValidSupplemental="False-NoInherit"
 	  ButtonMapping="button_1">
   </Rule>
   <Rule

--- a/WDAC-Policy-Wizard/app/MSIX/WDACWizard.appinstaller
+++ b/WDAC-Policy-Wizard/app/MSIX/WDACWizard.appinstaller
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <AppInstaller
 	Uri="https://webapp-wdac-wizard.azurewebsites.net/packages/WDACWizard.appinstaller"
-    Version="1.6.2.2"
+    Version="1.6.3.0"
     xmlns="http://schemas.microsoft.com/appx/appinstaller/2018">
 
     <MainPackage
         Name="Microsoft.WDAC.WDACWizard"
-		    Version="1.6.2.2"
+		    Version="1.6.3.0"
         Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US"
-        Uri="https://webapp-wdac-wizard.azurewebsites.net/packages/WDACWizard_1.6.2.2_x64_8wekyb3d8bbwe.MSIX"
+        Uri="https://webapp-wdac-wizard.azurewebsites.net/packages/WDACWizard_1.6.3.0_x64_8wekyb3d8bbwe.MSIX"
 		ProcessorArchitecture="x64"/>
 
     <UpdateSettings>

--- a/WDAC-Policy-Wizard/app/Properties/AssemblyInfo.cs
+++ b/WDAC-Policy-Wizard/app/Properties/AssemblyInfo.cs
@@ -36,5 +36,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.6.2.2")]
-[assembly: AssemblyFileVersion("1.6.2.2")]
+[assembly: AssemblyVersion("1.6.3.0")]
+[assembly: AssemblyFileVersion("1.6.3.0")]

--- a/WDAC-Policy-Wizard/app/src/CustomRuleConditionsPanel.Designer.cs
+++ b/WDAC-Policy-Wizard/app/src/CustomRuleConditionsPanel.Designer.cs
@@ -30,6 +30,7 @@
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(CustomRuleConditionsPanel));
             this.panel_CustomRules = new System.Windows.Forms.Panel();
+            this.checkBox_CustomValues = new System.Windows.Forms.CheckBox();
             this.label1 = new System.Windows.Forms.Label();
             this.publisherInfoLabel = new System.Windows.Forms.Label();
             this.panel_FileFolder = new System.Windows.Forms.Panel();
@@ -37,6 +38,7 @@
             this.radioButton_File = new System.Windows.Forms.RadioButton();
             this.label_Info = new System.Windows.Forms.Label();
             this.panel_Publisher_Scroll = new System.Windows.Forms.Panel();
+            this.textBox_MaxVersion = new System.Windows.Forms.TextBox();
             this.textBoxSlider_3 = new System.Windows.Forms.TextBox();
             this.labelSlider_3 = new System.Windows.Forms.Label();
             this.textBoxSlider_2 = new System.Windows.Forms.TextBox();
@@ -65,6 +67,7 @@
             this.headerPanel = new System.Windows.Forms.Panel();
             this.button_AddException = new System.Windows.Forms.Button();
             this.button_Back = new System.Windows.Forms.Button();
+            this.label_To = new System.Windows.Forms.Label();
             this.panel_CustomRules.SuspendLayout();
             this.panel_FileFolder.SuspendLayout();
             this.panel_Publisher_Scroll.SuspendLayout();
@@ -94,6 +97,17 @@
             this.panel_CustomRules.Size = new System.Drawing.Size(615, 701);
             this.panel_CustomRules.TabIndex = 86;
             // 
+            // checkBox_CustomValues
+            // 
+            this.checkBox_CustomValues.AutoSize = true;
+            this.checkBox_CustomValues.Location = new System.Drawing.Point(7, 185);
+            this.checkBox_CustomValues.Name = "checkBox_CustomValues";
+            this.checkBox_CustomValues.Size = new System.Drawing.Size(153, 21);
+            this.checkBox_CustomValues.TabIndex = 111;
+            this.checkBox_CustomValues.Text = "Use Custom Values";
+            this.checkBox_CustomValues.UseVisualStyleBackColor = true;
+            this.checkBox_CustomValues.CheckedChanged += new System.EventHandler(this.UseRuleCustomValues);
+            // 
             // label1
             // 
             this.label1.AutoSize = true;
@@ -111,7 +125,7 @@
             this.publisherInfoLabel.AutoSize = true;
             this.publisherInfoLabel.Font = new System.Drawing.Font("Tahoma", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.publisherInfoLabel.ForeColor = System.Drawing.SystemColors.Desktop;
-            this.publisherInfoLabel.Location = new System.Drawing.Point(13, 591);
+            this.publisherInfoLabel.Location = new System.Drawing.Point(12, 610);
             this.publisherInfoLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.publisherInfoLabel.Name = "publisherInfoLabel";
             this.publisherInfoLabel.Size = new System.Drawing.Size(472, 36);
@@ -176,6 +190,9 @@
             // 
             // panel_Publisher_Scroll
             // 
+            this.panel_Publisher_Scroll.Controls.Add(this.checkBox_CustomValues);
+            this.panel_Publisher_Scroll.Controls.Add(this.label_To);
+            this.panel_Publisher_Scroll.Controls.Add(this.textBox_MaxVersion);
             this.panel_Publisher_Scroll.Controls.Add(this.textBoxSlider_3);
             this.panel_Publisher_Scroll.Controls.Add(this.labelSlider_3);
             this.panel_Publisher_Scroll.Controls.Add(this.textBoxSlider_2);
@@ -185,12 +202,27 @@
             this.panel_Publisher_Scroll.Controls.Add(this.textBoxSlider_0);
             this.panel_Publisher_Scroll.Controls.Add(this.labelSlider_0);
             this.panel_Publisher_Scroll.Controls.Add(this.trackBar_Conditions);
-            this.panel_Publisher_Scroll.Location = new System.Drawing.Point(11, 395);
+            this.panel_Publisher_Scroll.Location = new System.Drawing.Point(15, 376);
             this.panel_Publisher_Scroll.Margin = new System.Windows.Forms.Padding(2);
             this.panel_Publisher_Scroll.Name = "panel_Publisher_Scroll";
-            this.panel_Publisher_Scroll.Size = new System.Drawing.Size(494, 187);
+            this.panel_Publisher_Scroll.Size = new System.Drawing.Size(494, 223);
             this.panel_Publisher_Scroll.TabIndex = 103;
             this.panel_Publisher_Scroll.Visible = false;
+            // 
+            // textBox_MaxVersion
+            // 
+            this.textBox_MaxVersion.BackColor = System.Drawing.SystemColors.Control;
+            this.textBox_MaxVersion.Font = new System.Drawing.Font("Tahoma", 9F);
+            this.textBox_MaxVersion.ForeColor = System.Drawing.SystemColors.WindowText;
+            this.textBox_MaxVersion.Location = new System.Drawing.Point(334, 102);
+            this.textBox_MaxVersion.Margin = new System.Windows.Forms.Padding(2);
+            this.textBox_MaxVersion.Name = "textBox_MaxVersion";
+            this.textBox_MaxVersion.ReadOnly = true;
+            this.textBox_MaxVersion.Size = new System.Drawing.Size(152, 26);
+            this.textBox_MaxVersion.TabIndex = 105;
+            this.textBox_MaxVersion.Text = "65355.65355.65355.65355";
+            this.textBox_MaxVersion.Visible = false;
+            this.textBox_MaxVersion.TextChanged += new System.EventHandler(this.textBox_MaxVersion_TextChanged);
             // 
             // textBoxSlider_3
             // 
@@ -202,6 +234,7 @@
             this.textBoxSlider_3.ReadOnly = true;
             this.textBoxSlider_3.Size = new System.Drawing.Size(327, 26);
             this.textBoxSlider_3.TabIndex = 103;
+            this.textBoxSlider_3.TextChanged += new System.EventHandler(this.textBoxSlider_3_TextChanged);
             // 
             // labelSlider_3
             // 
@@ -223,19 +256,20 @@
             this.textBoxSlider_2.Margin = new System.Windows.Forms.Padding(2);
             this.textBoxSlider_2.Name = "textBoxSlider_2";
             this.textBoxSlider_2.ReadOnly = true;
-            this.textBoxSlider_2.Size = new System.Drawing.Size(327, 26);
+            this.textBoxSlider_2.Size = new System.Drawing.Size(152, 26);
             this.textBoxSlider_2.TabIndex = 101;
+            this.textBoxSlider_2.TextChanged += new System.EventHandler(this.textBoxSlider_2_TextChanged);
             // 
             // labelSlider_2
             // 
             this.labelSlider_2.AutoSize = true;
             this.labelSlider_2.Font = new System.Drawing.Font("Tahoma", 9F);
             this.labelSlider_2.ForeColor = System.Drawing.Color.Black;
-            this.labelSlider_2.Location = new System.Drawing.Point(36, 105);
+            this.labelSlider_2.Location = new System.Drawing.Point(36, 106);
             this.labelSlider_2.Name = "labelSlider_2";
-            this.labelSlider_2.Size = new System.Drawing.Size(84, 18);
+            this.labelSlider_2.Size = new System.Drawing.Size(122, 18);
             this.labelSlider_2.TabIndex = 102;
-            this.labelSlider_2.Text = "File version:";
+            this.labelSlider_2.Text = "Minimum version:";
             this.labelSlider_2.TextAlign = System.Drawing.ContentAlignment.TopCenter;
             // 
             // textBoxSlider_1
@@ -248,6 +282,7 @@
             this.textBoxSlider_1.ReadOnly = true;
             this.textBoxSlider_1.Size = new System.Drawing.Size(327, 26);
             this.textBoxSlider_1.TabIndex = 99;
+            this.textBoxSlider_1.TextChanged += new System.EventHandler(this.textBoxSlider_1_TextChanged);
             // 
             // labelSlider_1
             // 
@@ -271,6 +306,7 @@
             this.textBoxSlider_0.ReadOnly = true;
             this.textBoxSlider_0.Size = new System.Drawing.Size(327, 26);
             this.textBoxSlider_0.TabIndex = 95;
+            this.textBoxSlider_0.TextChanged += new System.EventHandler(this.textBoxSlider_0_TextChanged);
             // 
             // labelSlider_0
             // 
@@ -323,7 +359,7 @@
             this.comboBox_RuleType.Margin = new System.Windows.Forms.Padding(2);
             this.comboBox_RuleType.Name = "comboBox_RuleType";
             this.comboBox_RuleType.Size = new System.Drawing.Size(187, 26);
-            this.comboBox_RuleType.TabIndex = 89;
+            this.comboBox_RuleType.TabIndex = 3;
             this.comboBox_RuleType.SelectedIndexChanged += new System.EventHandler(this.RuleType_ComboboxChanged);
             // 
             // radioButton_Deny
@@ -335,7 +371,7 @@
             this.radioButton_Deny.Margin = new System.Windows.Forms.Padding(2);
             this.radioButton_Deny.Name = "radioButton_Deny";
             this.radioButton_Deny.Size = new System.Drawing.Size(69, 25);
-            this.radioButton_Deny.TabIndex = 90;
+            this.radioButton_Deny.TabIndex = 2;
             this.radioButton_Deny.TabStop = true;
             this.radioButton_Deny.Text = "Deny";
             this.radioButton_Deny.UseVisualStyleBackColor = true;
@@ -351,7 +387,7 @@
             this.radioButton_Allow.Margin = new System.Windows.Forms.Padding(2);
             this.radioButton_Allow.Name = "radioButton_Allow";
             this.radioButton_Allow.Size = new System.Drawing.Size(72, 25);
-            this.radioButton_Allow.TabIndex = 89;
+            this.radioButton_Allow.TabIndex = 1;
             this.radioButton_Allow.TabStop = true;
             this.radioButton_Allow.Text = "Allow";
             this.radioButton_Allow.UseVisualStyleBackColor = true;
@@ -377,7 +413,7 @@
             this.button_Browse.Margin = new System.Windows.Forms.Padding(2);
             this.button_Browse.Name = "button_Browse";
             this.button_Browse.Size = new System.Drawing.Size(99, 29);
-            this.button_Browse.TabIndex = 84;
+            this.button_Browse.TabIndex = 4;
             this.button_Browse.Text = "Browse";
             this.button_Browse.UseVisualStyleBackColor = false;
             this.button_Browse.Click += new System.EventHandler(this.button_Browse_Click);
@@ -563,6 +599,17 @@
             this.button_Back.UseVisualStyleBackColor = false;
             this.button_Back.Click += new System.EventHandler(this.button_Back_Click);
             // 
+            // label_To
+            // 
+            this.label_To.AutoSize = true;
+            this.label_To.Font = new System.Drawing.Font("Tahoma", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label_To.Location = new System.Drawing.Point(314, 105);
+            this.label_To.Name = "label_To";
+            this.label_To.Size = new System.Drawing.Size(16, 21);
+            this.label_To.TabIndex = 112;
+            this.label_To.Text = "-";
+            this.label_To.Visible = false;
+            // 
             // CustomRuleConditionsPanel
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(120F, 120F);
@@ -637,5 +684,8 @@
         private System.Windows.Forms.Panel headerPanel;
         private System.Windows.Forms.Button button_AddException;
         private System.Windows.Forms.Button button_Back;
+        private System.Windows.Forms.CheckBox checkBox_CustomValues;
+        private System.Windows.Forms.TextBox textBox_MaxVersion;
+        private System.Windows.Forms.Label label_To;
     }
 }

--- a/WDAC-Policy-Wizard/app/src/CustomRuleConditionsPanel.Designer.cs
+++ b/WDAC-Policy-Wizard/app/src/CustomRuleConditionsPanel.Designer.cs
@@ -30,14 +30,10 @@
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(CustomRuleConditionsPanel));
             this.panel_CustomRules = new System.Windows.Forms.Panel();
-            this.checkBox_CustomValues = new System.Windows.Forms.CheckBox();
-            this.label1 = new System.Windows.Forms.Label();
-            this.publisherInfoLabel = new System.Windows.Forms.Label();
-            this.panel_FileFolder = new System.Windows.Forms.Panel();
-            this.radioButton_Folder = new System.Windows.Forms.RadioButton();
-            this.radioButton_File = new System.Windows.Forms.RadioButton();
-            this.label_Info = new System.Windows.Forms.Label();
+            this.richTextBox_CustomHashes = new System.Windows.Forms.RichTextBox();
             this.panel_Publisher_Scroll = new System.Windows.Forms.Panel();
+            this.checkBox_CustomValues = new System.Windows.Forms.CheckBox();
+            this.label_To = new System.Windows.Forms.Label();
             this.textBox_MaxVersion = new System.Windows.Forms.TextBox();
             this.textBoxSlider_3 = new System.Windows.Forms.TextBox();
             this.labelSlider_3 = new System.Windows.Forms.Label();
@@ -48,6 +44,12 @@
             this.textBoxSlider_0 = new System.Windows.Forms.TextBox();
             this.labelSlider_0 = new System.Windows.Forms.Label();
             this.trackBar_Conditions = new System.Windows.Forms.TrackBar();
+            this.label1 = new System.Windows.Forms.Label();
+            this.publisherInfoLabel = new System.Windows.Forms.Label();
+            this.panel_FileFolder = new System.Windows.Forms.Panel();
+            this.radioButton_Folder = new System.Windows.Forms.RadioButton();
+            this.radioButton_File = new System.Windows.Forms.RadioButton();
+            this.label_Info = new System.Windows.Forms.Label();
             this.label9 = new System.Windows.Forms.Label();
             this.comboBox_RuleType = new System.Windows.Forms.ComboBox();
             this.radioButton_Deny = new System.Windows.Forms.RadioButton();
@@ -55,6 +57,7 @@
             this.textBox_ReferenceFile = new System.Windows.Forms.TextBox();
             this.button_Browse = new System.Windows.Forms.Button();
             this.label_condition = new System.Windows.Forms.Label();
+            this.checkBox_CustomPath = new System.Windows.Forms.CheckBox();
             this.label_Error = new System.Windows.Forms.Label();
             this.button_CreateRule = new System.Windows.Forms.Button();
             this.button_Next = new System.Windows.Forms.Button();
@@ -67,13 +70,10 @@
             this.headerPanel = new System.Windows.Forms.Panel();
             this.button_AddException = new System.Windows.Forms.Button();
             this.button_Back = new System.Windows.Forms.Button();
-            this.label_To = new System.Windows.Forms.Label();
-            this.checkBox_CustomPath = new System.Windows.Forms.CheckBox();
-            this.richTextBox_CustomHashes = new System.Windows.Forms.RichTextBox();
             this.panel_CustomRules.SuspendLayout();
-            this.panel_FileFolder.SuspendLayout();
             this.panel_Publisher_Scroll.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.trackBar_Conditions)).BeginInit();
+            this.panel_FileFolder.SuspendLayout();
             this.control_Panel.SuspendLayout();
             this.headerPanel.SuspendLayout();
             this.SuspendLayout();
@@ -101,6 +101,38 @@
             this.panel_CustomRules.Size = new System.Drawing.Size(615, 701);
             this.panel_CustomRules.TabIndex = 86;
             // 
+            // richTextBox_CustomHashes
+            // 
+            this.richTextBox_CustomHashes.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.richTextBox_CustomHashes.Location = new System.Drawing.Point(328, 191);
+            this.richTextBox_CustomHashes.Name = "richTextBox_CustomHashes";
+            this.richTextBox_CustomHashes.Size = new System.Drawing.Size(559, 96);
+            this.richTextBox_CustomHashes.TabIndex = 114;
+            this.richTextBox_CustomHashes.Text = "Insert comma separated list of SHA-256 Authenticode Hashes";
+            this.richTextBox_CustomHashes.Visible = false;
+            this.richTextBox_CustomHashes.Click += new System.EventHandler(this.richTextBox_CustomHashes_Click);
+            // 
+            // panel_Publisher_Scroll
+            // 
+            this.panel_Publisher_Scroll.Controls.Add(this.checkBox_CustomValues);
+            this.panel_Publisher_Scroll.Controls.Add(this.label_To);
+            this.panel_Publisher_Scroll.Controls.Add(this.textBox_MaxVersion);
+            this.panel_Publisher_Scroll.Controls.Add(this.textBoxSlider_3);
+            this.panel_Publisher_Scroll.Controls.Add(this.labelSlider_3);
+            this.panel_Publisher_Scroll.Controls.Add(this.textBoxSlider_2);
+            this.panel_Publisher_Scroll.Controls.Add(this.labelSlider_2);
+            this.panel_Publisher_Scroll.Controls.Add(this.textBoxSlider_1);
+            this.panel_Publisher_Scroll.Controls.Add(this.labelSlider_1);
+            this.panel_Publisher_Scroll.Controls.Add(this.textBoxSlider_0);
+            this.panel_Publisher_Scroll.Controls.Add(this.labelSlider_0);
+            this.panel_Publisher_Scroll.Controls.Add(this.trackBar_Conditions);
+            this.panel_Publisher_Scroll.Location = new System.Drawing.Point(10, 389);
+            this.panel_Publisher_Scroll.Margin = new System.Windows.Forms.Padding(2);
+            this.panel_Publisher_Scroll.Name = "panel_Publisher_Scroll";
+            this.panel_Publisher_Scroll.Size = new System.Drawing.Size(494, 223);
+            this.panel_Publisher_Scroll.TabIndex = 103;
+            this.panel_Publisher_Scroll.Visible = false;
+            // 
             // checkBox_CustomValues
             // 
             this.checkBox_CustomValues.AutoSize = true;
@@ -111,6 +143,142 @@
             this.checkBox_CustomValues.Text = "Use Custom Values";
             this.checkBox_CustomValues.UseVisualStyleBackColor = true;
             this.checkBox_CustomValues.CheckedChanged += new System.EventHandler(this.UseRuleCustomValues);
+            // 
+            // label_To
+            // 
+            this.label_To.AutoSize = true;
+            this.label_To.Font = new System.Drawing.Font("Tahoma", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label_To.Location = new System.Drawing.Point(314, 105);
+            this.label_To.Name = "label_To";
+            this.label_To.Size = new System.Drawing.Size(16, 21);
+            this.label_To.TabIndex = 112;
+            this.label_To.Text = "-";
+            this.label_To.Visible = false;
+            // 
+            // textBox_MaxVersion
+            // 
+            this.textBox_MaxVersion.BackColor = System.Drawing.SystemColors.Control;
+            this.textBox_MaxVersion.Font = new System.Drawing.Font("Tahoma", 9F);
+            this.textBox_MaxVersion.ForeColor = System.Drawing.SystemColors.WindowText;
+            this.textBox_MaxVersion.Location = new System.Drawing.Point(334, 102);
+            this.textBox_MaxVersion.Margin = new System.Windows.Forms.Padding(2);
+            this.textBox_MaxVersion.Name = "textBox_MaxVersion";
+            this.textBox_MaxVersion.ReadOnly = true;
+            this.textBox_MaxVersion.Size = new System.Drawing.Size(152, 26);
+            this.textBox_MaxVersion.TabIndex = 105;
+            this.textBox_MaxVersion.Text = "Max version";
+            this.textBox_MaxVersion.Visible = false;
+            this.textBox_MaxVersion.TextChanged += new System.EventHandler(this.textBox_MaxVersion_TextChanged);
+            // 
+            // textBoxSlider_3
+            // 
+            this.textBoxSlider_3.BackColor = System.Drawing.SystemColors.Control;
+            this.textBoxSlider_3.Font = new System.Drawing.Font("Tahoma", 9F);
+            this.textBoxSlider_3.Location = new System.Drawing.Point(159, 144);
+            this.textBoxSlider_3.Margin = new System.Windows.Forms.Padding(2);
+            this.textBoxSlider_3.Name = "textBoxSlider_3";
+            this.textBoxSlider_3.ReadOnly = true;
+            this.textBoxSlider_3.Size = new System.Drawing.Size(327, 26);
+            this.textBoxSlider_3.TabIndex = 103;
+            this.textBoxSlider_3.TextChanged += new System.EventHandler(this.textBoxSlider_3_TextChanged);
+            // 
+            // labelSlider_3
+            // 
+            this.labelSlider_3.AutoSize = true;
+            this.labelSlider_3.Font = new System.Drawing.Font("Tahoma", 9F);
+            this.labelSlider_3.ForeColor = System.Drawing.Color.Black;
+            this.labelSlider_3.Location = new System.Drawing.Point(36, 147);
+            this.labelSlider_3.Name = "labelSlider_3";
+            this.labelSlider_3.Size = new System.Drawing.Size(75, 18);
+            this.labelSlider_3.TabIndex = 104;
+            this.labelSlider_3.Text = "File name:";
+            this.labelSlider_3.TextAlign = System.Drawing.ContentAlignment.TopCenter;
+            // 
+            // textBoxSlider_2
+            // 
+            this.textBoxSlider_2.BackColor = System.Drawing.SystemColors.Control;
+            this.textBoxSlider_2.Font = new System.Drawing.Font("Tahoma", 9F);
+            this.textBoxSlider_2.Location = new System.Drawing.Point(159, 102);
+            this.textBoxSlider_2.Margin = new System.Windows.Forms.Padding(2);
+            this.textBoxSlider_2.Name = "textBoxSlider_2";
+            this.textBoxSlider_2.ReadOnly = true;
+            this.textBoxSlider_2.Size = new System.Drawing.Size(152, 26);
+            this.textBoxSlider_2.TabIndex = 101;
+            this.textBoxSlider_2.TextChanged += new System.EventHandler(this.textBoxSlider_2_TextChanged);
+            // 
+            // labelSlider_2
+            // 
+            this.labelSlider_2.AutoSize = true;
+            this.labelSlider_2.Font = new System.Drawing.Font("Tahoma", 9F);
+            this.labelSlider_2.ForeColor = System.Drawing.Color.Black;
+            this.labelSlider_2.Location = new System.Drawing.Point(36, 106);
+            this.labelSlider_2.Name = "labelSlider_2";
+            this.labelSlider_2.Size = new System.Drawing.Size(86, 18);
+            this.labelSlider_2.TabIndex = 102;
+            this.labelSlider_2.Text = "Min version:";
+            this.labelSlider_2.TextAlign = System.Drawing.ContentAlignment.TopCenter;
+            // 
+            // textBoxSlider_1
+            // 
+            this.textBoxSlider_1.BackColor = System.Drawing.SystemColors.Control;
+            this.textBoxSlider_1.Font = new System.Drawing.Font("Tahoma", 9F);
+            this.textBoxSlider_1.Location = new System.Drawing.Point(159, 60);
+            this.textBoxSlider_1.Margin = new System.Windows.Forms.Padding(2);
+            this.textBoxSlider_1.Name = "textBoxSlider_1";
+            this.textBoxSlider_1.ReadOnly = true;
+            this.textBoxSlider_1.Size = new System.Drawing.Size(327, 26);
+            this.textBoxSlider_1.TabIndex = 99;
+            this.textBoxSlider_1.TextChanged += new System.EventHandler(this.textBoxSlider_1_TextChanged);
+            // 
+            // labelSlider_1
+            // 
+            this.labelSlider_1.AutoSize = true;
+            this.labelSlider_1.Font = new System.Drawing.Font("Tahoma", 9F);
+            this.labelSlider_1.ForeColor = System.Drawing.Color.Black;
+            this.labelSlider_1.Location = new System.Drawing.Point(36, 62);
+            this.labelSlider_1.Name = "labelSlider_1";
+            this.labelSlider_1.Size = new System.Drawing.Size(69, 18);
+            this.labelSlider_1.TabIndex = 100;
+            this.labelSlider_1.Text = "Publisher:";
+            this.labelSlider_1.TextAlign = System.Drawing.ContentAlignment.TopCenter;
+            // 
+            // textBoxSlider_0
+            // 
+            this.textBoxSlider_0.BackColor = System.Drawing.SystemColors.Control;
+            this.textBoxSlider_0.Font = new System.Drawing.Font("Tahoma", 9F);
+            this.textBoxSlider_0.Location = new System.Drawing.Point(159, 19);
+            this.textBoxSlider_0.Margin = new System.Windows.Forms.Padding(2);
+            this.textBoxSlider_0.Name = "textBoxSlider_0";
+            this.textBoxSlider_0.ReadOnly = true;
+            this.textBoxSlider_0.Size = new System.Drawing.Size(327, 26);
+            this.textBoxSlider_0.TabIndex = 95;
+            this.textBoxSlider_0.TextChanged += new System.EventHandler(this.textBoxSlider_0_TextChanged);
+            // 
+            // labelSlider_0
+            // 
+            this.labelSlider_0.AutoSize = true;
+            this.labelSlider_0.Font = new System.Drawing.Font("Tahoma", 9F);
+            this.labelSlider_0.ForeColor = System.Drawing.Color.Black;
+            this.labelSlider_0.Location = new System.Drawing.Point(36, 21);
+            this.labelSlider_0.Name = "labelSlider_0";
+            this.labelSlider_0.Size = new System.Drawing.Size(82, 18);
+            this.labelSlider_0.TabIndex = 98;
+            this.labelSlider_0.Text = "Issuing CA:";
+            this.labelSlider_0.TextAlign = System.Drawing.ContentAlignment.TopCenter;
+            // 
+            // trackBar_Conditions
+            // 
+            this.trackBar_Conditions.LargeChange = 4;
+            this.trackBar_Conditions.Location = new System.Drawing.Point(2, 13);
+            this.trackBar_Conditions.Margin = new System.Windows.Forms.Padding(2);
+            this.trackBar_Conditions.Maximum = 12;
+            this.trackBar_Conditions.Name = "trackBar_Conditions";
+            this.trackBar_Conditions.Orientation = System.Windows.Forms.Orientation.Vertical;
+            this.trackBar_Conditions.Size = new System.Drawing.Size(56, 165);
+            this.trackBar_Conditions.SmallChange = 4;
+            this.trackBar_Conditions.TabIndex = 96;
+            this.trackBar_Conditions.TickFrequency = 4;
+            this.trackBar_Conditions.Scroll += new System.EventHandler(this.trackBar_Conditions_Scroll);
             // 
             // label1
             // 
@@ -191,152 +359,6 @@
             this.label_Info.TabIndex = 95;
             this.label_Info.Text = "Label_Info";
             this.label_Info.Visible = false;
-            // 
-            // panel_Publisher_Scroll
-            // 
-            this.panel_Publisher_Scroll.Controls.Add(this.checkBox_CustomValues);
-            this.panel_Publisher_Scroll.Controls.Add(this.label_To);
-            this.panel_Publisher_Scroll.Controls.Add(this.textBox_MaxVersion);
-            this.panel_Publisher_Scroll.Controls.Add(this.textBoxSlider_3);
-            this.panel_Publisher_Scroll.Controls.Add(this.labelSlider_3);
-            this.panel_Publisher_Scroll.Controls.Add(this.textBoxSlider_2);
-            this.panel_Publisher_Scroll.Controls.Add(this.labelSlider_2);
-            this.panel_Publisher_Scroll.Controls.Add(this.textBoxSlider_1);
-            this.panel_Publisher_Scroll.Controls.Add(this.labelSlider_1);
-            this.panel_Publisher_Scroll.Controls.Add(this.textBoxSlider_0);
-            this.panel_Publisher_Scroll.Controls.Add(this.labelSlider_0);
-            this.panel_Publisher_Scroll.Controls.Add(this.trackBar_Conditions);
-            this.panel_Publisher_Scroll.Location = new System.Drawing.Point(10, 389);
-            this.panel_Publisher_Scroll.Margin = new System.Windows.Forms.Padding(2);
-            this.panel_Publisher_Scroll.Name = "panel_Publisher_Scroll";
-            this.panel_Publisher_Scroll.Size = new System.Drawing.Size(494, 223);
-            this.panel_Publisher_Scroll.TabIndex = 103;
-            this.panel_Publisher_Scroll.Visible = false;
-            // 
-            // textBox_MaxVersion
-            // 
-            this.textBox_MaxVersion.BackColor = System.Drawing.SystemColors.Control;
-            this.textBox_MaxVersion.Font = new System.Drawing.Font("Tahoma", 9F);
-            this.textBox_MaxVersion.ForeColor = System.Drawing.SystemColors.WindowText;
-            this.textBox_MaxVersion.Location = new System.Drawing.Point(334, 102);
-            this.textBox_MaxVersion.Margin = new System.Windows.Forms.Padding(2);
-            this.textBox_MaxVersion.Name = "textBox_MaxVersion";
-            this.textBox_MaxVersion.ReadOnly = true;
-            this.textBox_MaxVersion.Size = new System.Drawing.Size(152, 26);
-            this.textBox_MaxVersion.TabIndex = 105;
-            this.textBox_MaxVersion.Text = "65355.65355.65355.65355";
-            this.textBox_MaxVersion.Visible = false;
-            this.textBox_MaxVersion.TextChanged += new System.EventHandler(this.textBox_MaxVersion_TextChanged);
-            // 
-            // textBoxSlider_3
-            // 
-            this.textBoxSlider_3.BackColor = System.Drawing.SystemColors.Control;
-            this.textBoxSlider_3.Font = new System.Drawing.Font("Tahoma", 9F);
-            this.textBoxSlider_3.Location = new System.Drawing.Point(159, 144);
-            this.textBoxSlider_3.Margin = new System.Windows.Forms.Padding(2);
-            this.textBoxSlider_3.Name = "textBoxSlider_3";
-            this.textBoxSlider_3.ReadOnly = true;
-            this.textBoxSlider_3.Size = new System.Drawing.Size(327, 26);
-            this.textBoxSlider_3.TabIndex = 103;
-            this.textBoxSlider_3.TextChanged += new System.EventHandler(this.textBoxSlider_3_TextChanged);
-            // 
-            // labelSlider_3
-            // 
-            this.labelSlider_3.AutoSize = true;
-            this.labelSlider_3.Font = new System.Drawing.Font("Tahoma", 9F);
-            this.labelSlider_3.ForeColor = System.Drawing.Color.Black;
-            this.labelSlider_3.Location = new System.Drawing.Point(36, 147);
-            this.labelSlider_3.Name = "labelSlider_3";
-            this.labelSlider_3.Size = new System.Drawing.Size(75, 18);
-            this.labelSlider_3.TabIndex = 104;
-            this.labelSlider_3.Text = "File name:";
-            this.labelSlider_3.TextAlign = System.Drawing.ContentAlignment.TopCenter;
-            // 
-            // textBoxSlider_2
-            // 
-            this.textBoxSlider_2.BackColor = System.Drawing.SystemColors.Control;
-            this.textBoxSlider_2.Font = new System.Drawing.Font("Tahoma", 9F);
-            this.textBoxSlider_2.Location = new System.Drawing.Point(159, 102);
-            this.textBoxSlider_2.Margin = new System.Windows.Forms.Padding(2);
-            this.textBoxSlider_2.Name = "textBoxSlider_2";
-            this.textBoxSlider_2.ReadOnly = true;
-            this.textBoxSlider_2.Size = new System.Drawing.Size(152, 26);
-            this.textBoxSlider_2.TabIndex = 101;
-            this.textBoxSlider_2.TextChanged += new System.EventHandler(this.textBoxSlider_2_TextChanged);
-            // 
-            // labelSlider_2
-            // 
-            this.labelSlider_2.AutoSize = true;
-            this.labelSlider_2.Font = new System.Drawing.Font("Tahoma", 9F);
-            this.labelSlider_2.ForeColor = System.Drawing.Color.Black;
-            this.labelSlider_2.Location = new System.Drawing.Point(36, 106);
-            this.labelSlider_2.Name = "labelSlider_2";
-            this.labelSlider_2.Size = new System.Drawing.Size(122, 18);
-            this.labelSlider_2.TabIndex = 102;
-            this.labelSlider_2.Text = "Minimum version:";
-            this.labelSlider_2.TextAlign = System.Drawing.ContentAlignment.TopCenter;
-            // 
-            // textBoxSlider_1
-            // 
-            this.textBoxSlider_1.BackColor = System.Drawing.SystemColors.Control;
-            this.textBoxSlider_1.Font = new System.Drawing.Font("Tahoma", 9F);
-            this.textBoxSlider_1.Location = new System.Drawing.Point(159, 60);
-            this.textBoxSlider_1.Margin = new System.Windows.Forms.Padding(2);
-            this.textBoxSlider_1.Name = "textBoxSlider_1";
-            this.textBoxSlider_1.ReadOnly = true;
-            this.textBoxSlider_1.Size = new System.Drawing.Size(327, 26);
-            this.textBoxSlider_1.TabIndex = 99;
-            this.textBoxSlider_1.TextChanged += new System.EventHandler(this.textBoxSlider_1_TextChanged);
-            // 
-            // labelSlider_1
-            // 
-            this.labelSlider_1.AutoSize = true;
-            this.labelSlider_1.Font = new System.Drawing.Font("Tahoma", 9F);
-            this.labelSlider_1.ForeColor = System.Drawing.Color.Black;
-            this.labelSlider_1.Location = new System.Drawing.Point(36, 62);
-            this.labelSlider_1.Name = "labelSlider_1";
-            this.labelSlider_1.Size = new System.Drawing.Size(69, 18);
-            this.labelSlider_1.TabIndex = 100;
-            this.labelSlider_1.Text = "Publisher:";
-            this.labelSlider_1.TextAlign = System.Drawing.ContentAlignment.TopCenter;
-            // 
-            // textBoxSlider_0
-            // 
-            this.textBoxSlider_0.BackColor = System.Drawing.SystemColors.Control;
-            this.textBoxSlider_0.Font = new System.Drawing.Font("Tahoma", 9F);
-            this.textBoxSlider_0.Location = new System.Drawing.Point(159, 19);
-            this.textBoxSlider_0.Margin = new System.Windows.Forms.Padding(2);
-            this.textBoxSlider_0.Name = "textBoxSlider_0";
-            this.textBoxSlider_0.ReadOnly = true;
-            this.textBoxSlider_0.Size = new System.Drawing.Size(327, 26);
-            this.textBoxSlider_0.TabIndex = 95;
-            this.textBoxSlider_0.TextChanged += new System.EventHandler(this.textBoxSlider_0_TextChanged);
-            // 
-            // labelSlider_0
-            // 
-            this.labelSlider_0.AutoSize = true;
-            this.labelSlider_0.Font = new System.Drawing.Font("Tahoma", 9F);
-            this.labelSlider_0.ForeColor = System.Drawing.Color.Black;
-            this.labelSlider_0.Location = new System.Drawing.Point(36, 21);
-            this.labelSlider_0.Name = "labelSlider_0";
-            this.labelSlider_0.Size = new System.Drawing.Size(82, 18);
-            this.labelSlider_0.TabIndex = 98;
-            this.labelSlider_0.Text = "Issuing CA:";
-            this.labelSlider_0.TextAlign = System.Drawing.ContentAlignment.TopCenter;
-            // 
-            // trackBar_Conditions
-            // 
-            this.trackBar_Conditions.LargeChange = 4;
-            this.trackBar_Conditions.Location = new System.Drawing.Point(2, 13);
-            this.trackBar_Conditions.Margin = new System.Windows.Forms.Padding(2);
-            this.trackBar_Conditions.Maximum = 12;
-            this.trackBar_Conditions.Name = "trackBar_Conditions";
-            this.trackBar_Conditions.Orientation = System.Windows.Forms.Orientation.Vertical;
-            this.trackBar_Conditions.Size = new System.Drawing.Size(56, 165);
-            this.trackBar_Conditions.SmallChange = 4;
-            this.trackBar_Conditions.TabIndex = 96;
-            this.trackBar_Conditions.TickFrequency = 4;
-            this.trackBar_Conditions.Scroll += new System.EventHandler(this.trackBar_Conditions_Scroll);
             // 
             // label9
             // 
@@ -435,6 +457,18 @@
             this.label_condition.TabIndex = 87;
             this.label_condition.Text = "Reference File:";
             this.label_condition.TextAlign = System.Drawing.ContentAlignment.TopCenter;
+            // 
+            // checkBox_CustomPath
+            // 
+            this.checkBox_CustomPath.AutoSize = true;
+            this.checkBox_CustomPath.Location = new System.Drawing.Point(12, 363);
+            this.checkBox_CustomPath.Name = "checkBox_CustomPath";
+            this.checkBox_CustomPath.Size = new System.Drawing.Size(139, 21);
+            this.checkBox_CustomPath.TabIndex = 113;
+            this.checkBox_CustomPath.Text = "Use Custom Path";
+            this.checkBox_CustomPath.UseVisualStyleBackColor = true;
+            this.checkBox_CustomPath.Visible = false;
+            this.checkBox_CustomPath.CheckedChanged += new System.EventHandler(this.UseCustomPath);
             // 
             // label_Error
             // 
@@ -605,40 +639,6 @@
             this.button_Back.UseVisualStyleBackColor = false;
             this.button_Back.Click += new System.EventHandler(this.button_Back_Click);
             // 
-            // label_To
-            // 
-            this.label_To.AutoSize = true;
-            this.label_To.Font = new System.Drawing.Font("Tahoma", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label_To.Location = new System.Drawing.Point(314, 105);
-            this.label_To.Name = "label_To";
-            this.label_To.Size = new System.Drawing.Size(16, 21);
-            this.label_To.TabIndex = 112;
-            this.label_To.Text = "-";
-            this.label_To.Visible = false;
-            // 
-            // checkBox_CustomPath
-            // 
-            this.checkBox_CustomPath.AutoSize = true;
-            this.checkBox_CustomPath.Location = new System.Drawing.Point(12, 363);
-            this.checkBox_CustomPath.Name = "checkBox_CustomPath";
-            this.checkBox_CustomPath.Size = new System.Drawing.Size(139, 21);
-            this.checkBox_CustomPath.TabIndex = 113;
-            this.checkBox_CustomPath.Text = "Use Custom Path";
-            this.checkBox_CustomPath.UseVisualStyleBackColor = true;
-            this.checkBox_CustomPath.Visible = false;
-            this.checkBox_CustomPath.CheckedChanged += new System.EventHandler(this.UseCustomPath);
-            // 
-            // richTextBox_CustomHashes
-            // 
-            this.richTextBox_CustomHashes.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.richTextBox_CustomHashes.Location = new System.Drawing.Point(328, 191);
-            this.richTextBox_CustomHashes.Name = "richTextBox_CustomHashes";
-            this.richTextBox_CustomHashes.Size = new System.Drawing.Size(559, 96);
-            this.richTextBox_CustomHashes.TabIndex = 114;
-            this.richTextBox_CustomHashes.Text = "Insert comma separated list of SHA-256 Authenticode Hashes";
-            this.richTextBox_CustomHashes.Visible = false;
-            this.richTextBox_CustomHashes.Click += new System.EventHandler(this.richTextBox_CustomHashes_Click);
-            // 
             // CustomRuleConditionsPanel
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(120F, 120F);
@@ -661,11 +661,11 @@
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.CustomRulesPanel_FormClosing);
             this.panel_CustomRules.ResumeLayout(false);
             this.panel_CustomRules.PerformLayout();
-            this.panel_FileFolder.ResumeLayout(false);
-            this.panel_FileFolder.PerformLayout();
             this.panel_Publisher_Scroll.ResumeLayout(false);
             this.panel_Publisher_Scroll.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.trackBar_Conditions)).EndInit();
+            this.panel_FileFolder.ResumeLayout(false);
+            this.panel_FileFolder.PerformLayout();
             this.control_Panel.ResumeLayout(false);
             this.control_Panel.PerformLayout();
             this.headerPanel.ResumeLayout(false);

--- a/WDAC-Policy-Wizard/app/src/CustomRuleConditionsPanel.Designer.cs
+++ b/WDAC-Policy-Wizard/app/src/CustomRuleConditionsPanel.Designer.cs
@@ -69,6 +69,7 @@
             this.button_Back = new System.Windows.Forms.Button();
             this.label_To = new System.Windows.Forms.Label();
             this.checkBox_CustomPath = new System.Windows.Forms.CheckBox();
+            this.richTextBox_CustomHashes = new System.Windows.Forms.RichTextBox();
             this.panel_CustomRules.SuspendLayout();
             this.panel_FileFolder.SuspendLayout();
             this.panel_Publisher_Scroll.SuspendLayout();
@@ -80,11 +81,12 @@
             // panel_CustomRules
             // 
             this.panel_CustomRules.BackColor = System.Drawing.Color.White;
+            this.panel_CustomRules.Controls.Add(this.richTextBox_CustomHashes);
+            this.panel_CustomRules.Controls.Add(this.panel_Publisher_Scroll);
             this.panel_CustomRules.Controls.Add(this.label1);
             this.panel_CustomRules.Controls.Add(this.publisherInfoLabel);
             this.panel_CustomRules.Controls.Add(this.panel_FileFolder);
             this.panel_CustomRules.Controls.Add(this.label_Info);
-            this.panel_CustomRules.Controls.Add(this.panel_Publisher_Scroll);
             this.panel_CustomRules.Controls.Add(this.label9);
             this.panel_CustomRules.Controls.Add(this.comboBox_RuleType);
             this.panel_CustomRules.Controls.Add(this.radioButton_Deny);
@@ -204,7 +206,7 @@
             this.panel_Publisher_Scroll.Controls.Add(this.textBoxSlider_0);
             this.panel_Publisher_Scroll.Controls.Add(this.labelSlider_0);
             this.panel_Publisher_Scroll.Controls.Add(this.trackBar_Conditions);
-            this.panel_Publisher_Scroll.Location = new System.Drawing.Point(15, 376);
+            this.panel_Publisher_Scroll.Location = new System.Drawing.Point(10, 389);
             this.panel_Publisher_Scroll.Margin = new System.Windows.Forms.Padding(2);
             this.panel_Publisher_Scroll.Name = "panel_Publisher_Scroll";
             this.panel_Publisher_Scroll.Size = new System.Drawing.Size(494, 223);
@@ -626,6 +628,17 @@
             this.checkBox_CustomPath.Visible = false;
             this.checkBox_CustomPath.CheckedChanged += new System.EventHandler(this.UseCustomPath);
             // 
+            // richTextBox_CustomHashes
+            // 
+            this.richTextBox_CustomHashes.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.richTextBox_CustomHashes.Location = new System.Drawing.Point(328, 191);
+            this.richTextBox_CustomHashes.Name = "richTextBox_CustomHashes";
+            this.richTextBox_CustomHashes.Size = new System.Drawing.Size(559, 96);
+            this.richTextBox_CustomHashes.TabIndex = 114;
+            this.richTextBox_CustomHashes.Text = "Insert comma separated list of SHA-256 Authenticode Hashes";
+            this.richTextBox_CustomHashes.Visible = false;
+            this.richTextBox_CustomHashes.Click += new System.EventHandler(this.richTextBox_CustomHashes_Click);
+            // 
             // CustomRuleConditionsPanel
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(120F, 120F);
@@ -704,5 +717,6 @@
         private System.Windows.Forms.TextBox textBox_MaxVersion;
         private System.Windows.Forms.Label label_To;
         private System.Windows.Forms.CheckBox checkBox_CustomPath;
+        private System.Windows.Forms.RichTextBox richTextBox_CustomHashes;
     }
 }

--- a/WDAC-Policy-Wizard/app/src/CustomRuleConditionsPanel.Designer.cs
+++ b/WDAC-Policy-Wizard/app/src/CustomRuleConditionsPanel.Designer.cs
@@ -68,6 +68,7 @@
             this.button_AddException = new System.Windows.Forms.Button();
             this.button_Back = new System.Windows.Forms.Button();
             this.label_To = new System.Windows.Forms.Label();
+            this.checkBox_CustomPath = new System.Windows.Forms.CheckBox();
             this.panel_CustomRules.SuspendLayout();
             this.panel_FileFolder.SuspendLayout();
             this.panel_Publisher_Scroll.SuspendLayout();
@@ -91,6 +92,7 @@
             this.panel_CustomRules.Controls.Add(this.textBox_ReferenceFile);
             this.panel_CustomRules.Controls.Add(this.button_Browse);
             this.panel_CustomRules.Controls.Add(this.label_condition);
+            this.panel_CustomRules.Controls.Add(this.checkBox_CustomPath);
             this.panel_CustomRules.Location = new System.Drawing.Point(123, 0);
             this.panel_CustomRules.Margin = new System.Windows.Forms.Padding(2);
             this.panel_CustomRules.Name = "panel_CustomRules";
@@ -138,10 +140,10 @@
             // 
             this.panel_FileFolder.Controls.Add(this.radioButton_Folder);
             this.panel_FileFolder.Controls.Add(this.radioButton_File);
-            this.panel_FileFolder.Location = new System.Drawing.Point(440, 369);
+            this.panel_FileFolder.Location = new System.Drawing.Point(464, 366);
             this.panel_FileFolder.Margin = new System.Windows.Forms.Padding(2);
             this.panel_FileFolder.Name = "panel_FileFolder";
-            this.panel_FileFolder.Size = new System.Drawing.Size(162, 42);
+            this.panel_FileFolder.Size = new System.Drawing.Size(131, 42);
             this.panel_FileFolder.TabIndex = 104;
             this.panel_FileFolder.Visible = false;
             // 
@@ -399,8 +401,10 @@
             this.textBox_ReferenceFile.Location = new System.Drawing.Point(12, 334);
             this.textBox_ReferenceFile.Margin = new System.Windows.Forms.Padding(2);
             this.textBox_ReferenceFile.Name = "textBox_ReferenceFile";
-            this.textBox_ReferenceFile.Size = new System.Drawing.Size(408, 26);
+            this.textBox_ReferenceFile.ReadOnly = true;
+            this.textBox_ReferenceFile.Size = new System.Drawing.Size(448, 26);
             this.textBox_ReferenceFile.TabIndex = 88;
+            this.textBox_ReferenceFile.TextChanged += new System.EventHandler(this.ReferenceFileTextChanged);
             // 
             // button_Browse
             // 
@@ -409,10 +413,10 @@
             this.button_Browse.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.button_Browse.Font = new System.Drawing.Font("Tahoma", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.button_Browse.ForeColor = System.Drawing.Color.DodgerBlue;
-            this.button_Browse.Location = new System.Drawing.Point(440, 333);
+            this.button_Browse.Location = new System.Drawing.Point(464, 333);
             this.button_Browse.Margin = new System.Windows.Forms.Padding(2);
             this.button_Browse.Name = "button_Browse";
-            this.button_Browse.Size = new System.Drawing.Size(99, 29);
+            this.button_Browse.Size = new System.Drawing.Size(107, 28);
             this.button_Browse.TabIndex = 4;
             this.button_Browse.Text = "Browse";
             this.button_Browse.UseVisualStyleBackColor = false;
@@ -610,6 +614,18 @@
             this.label_To.Text = "-";
             this.label_To.Visible = false;
             // 
+            // checkBox_CustomPath
+            // 
+            this.checkBox_CustomPath.AutoSize = true;
+            this.checkBox_CustomPath.Location = new System.Drawing.Point(12, 363);
+            this.checkBox_CustomPath.Name = "checkBox_CustomPath";
+            this.checkBox_CustomPath.Size = new System.Drawing.Size(139, 21);
+            this.checkBox_CustomPath.TabIndex = 113;
+            this.checkBox_CustomPath.Text = "Use Custom Path";
+            this.checkBox_CustomPath.UseVisualStyleBackColor = true;
+            this.checkBox_CustomPath.Visible = false;
+            this.checkBox_CustomPath.CheckedChanged += new System.EventHandler(this.UseCustomPath);
+            // 
             // CustomRuleConditionsPanel
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(120F, 120F);
@@ -687,5 +703,6 @@
         private System.Windows.Forms.CheckBox checkBox_CustomValues;
         private System.Windows.Forms.TextBox textBox_MaxVersion;
         private System.Windows.Forms.Label label_To;
+        private System.Windows.Forms.CheckBox checkBox_CustomPath;
     }
 }

--- a/WDAC-Policy-Wizard/app/src/CustomRuleConditionsPanel.cs
+++ b/WDAC-Policy-Wizard/app/src/CustomRuleConditionsPanel.cs
@@ -1161,6 +1161,7 @@ namespace WDAC_Wizard
 
                     // Format the version text boxes
                     this.textBoxSlider_2.Size = this.textBox_MaxVersion.Size;
+                    this.labelSlider_2.Text = "Version range:";
                     this.textBox_MaxVersion.Visible = true;
                     this.label_To.Visible = true;
                 }
@@ -1181,6 +1182,7 @@ namespace WDAC_Wizard
 
                 // Format the version text boxes
                 this.textBoxSlider_2.Size = this.textBoxSlider_0.Size;
+                this.labelSlider_2.Text = "Min version:";
                 this.textBox_MaxVersion.Visible = false;
                 this.label_To.Visible = false;
 

--- a/WDAC-Policy-Wizard/app/src/CustomRuleConditionsPanel.cs
+++ b/WDAC-Policy-Wizard/app/src/CustomRuleConditionsPanel.cs
@@ -91,7 +91,7 @@ namespace WDAC_Wizard
                     if(!Helper.IsValidVersion(this.PolicyCustomRule.CustomValues.MinVersion))
                     {
                         label_Error.Visible = true;
-                        label_Error.Text = "Invalid custom version input. Version input must follow w.x.y.z format and < 65535.65535.65535.65535";
+                        label_Error.Text = "Invalid custom version input. Version input must follow w.x.y.z format \r\nand < 65535.65535.65535.65535";
                         this.Log.AddWarningMsg("Invalid version format for CustomMinVersion");
                         return;
                     }
@@ -102,7 +102,7 @@ namespace WDAC_Wizard
                     if (!Helper.IsValidVersion(this.PolicyCustomRule.CustomValues.MaxVersion))
                     {
                         label_Error.Visible = true;
-                        label_Error.Text = "Invalid custom version input. Version input must follow w.x.y.z format and < 65535.65535.65535.65535";
+                        label_Error.Text = "Invalid custom version input. Version input must follow w.x.y.z format \r\nand < 65535.65535.65535.65535";
                         this.Log.AddWarningMsg("Invalid version format for CustomMinVersion");
                         return;
                     }
@@ -550,7 +550,7 @@ namespace WDAC_Wizard
                     this.textBox_ReferenceFile.ScrollToCaret();
                     this.labelSlider_0.Text = "Issuing CA:";
                     this.labelSlider_1.Text = "Publisher:";
-                    this.labelSlider_2.Text = "Minimum version:";
+                    this.labelSlider_2.Text = "Min version:";
                     this.labelSlider_3.Text = "File name:";
 
                     // Version textbox should be set to normal size
@@ -1320,7 +1320,7 @@ namespace WDAC_Wizard
 
         private void richTextBox_CustomHashes_Click(object sender, EventArgs e)
         {
-            if(this.richTextBox_CustomHashes.Tag == "Title")
+            if(this.richTextBox_CustomHashes.Tag.ToString() == "Title")
             {
                 this.richTextBox_CustomHashes.ResetText();
                 this.richTextBox_CustomHashes.Tag = "Values"; 

--- a/WDAC-Policy-Wizard/app/src/CustomRuleConditionsPanel.cs
+++ b/WDAC-Policy-Wizard/app/src/CustomRuleConditionsPanel.cs
@@ -106,8 +106,18 @@ namespace WDAC_Wizard
                         this.Log.AddWarningMsg("Invalid version format for CustomMinVersion");
                         return;
                     }
-                }
 
+                    if(this.PolicyCustomRule.CustomValues.MinVersion !=null)
+                    {
+                        if (Helper.CompareVersions(this.PolicyCustomRule.CustomValues.MinVersion, this.PolicyCustomRule.CustomValues.MaxVersion) < 0)
+                        {
+                            label_Error.Visible = true;
+                            label_Error.Text = "Invalid custom version input. Minimum version must be less than the maximum version";
+                            this.Log.AddWarningMsg("CustomMinVersion !< CustomMaxVersion");
+                            return;
+                        }
+                    }
+                }
 
                 if (this.PolicyCustomRule.CustomValues.FileName != null)
                 {

--- a/WDAC-Policy-Wizard/app/src/CustomRuleConditionsPanel.cs
+++ b/WDAC-Policy-Wizard/app/src/CustomRuleConditionsPanel.cs
@@ -201,29 +201,79 @@ namespace WDAC_Wizard
                     break;
 
                 case PolicyCustomRules.RuleLevel.SignedVersion:
-                    name += String.Format("{0}: {1}, {2}, {3} ", this.PolicyCustomRule.Level, this.PolicyCustomRule.FileInfo["PCACertificate"],
+                    
+                    if (this.PolicyCustomRule.UsingCustomValues)
+                    {
+                        name = String.Format("{0}: {1}, {2}, {3} {4}", this.PolicyCustomRule.Level, this.PolicyCustomRule.FileInfo["PCACertificate"], this.PolicyCustomRule.FileInfo["LeafCertificate"],
+                             String.IsNullOrEmpty(this.PolicyCustomRule.CustomValues.MinVersion) ? this.PolicyCustomRule.FileInfo["FileVersion"] : this.PolicyCustomRule.CustomValues.MinVersion,
+                             String.IsNullOrEmpty(this.PolicyCustomRule.CustomValues.MaxVersion) ? "and greater" : " up to " + this.PolicyCustomRule.CustomValues.MaxVersion);
+                    }
+                    else
+                    {
+                        name = String.Format("{0}: {1}, {2}, {3} and greater ", this.PolicyCustomRule.Level, this.PolicyCustomRule.FileInfo["PCACertificate"],
                         this.PolicyCustomRule.FileInfo["LeafCertificate"], this.PolicyCustomRule.FileInfo["FileVersion"]);
+                    }
                     break;
 
                 case PolicyCustomRules.RuleLevel.FilePublisher:
-                    name += String.Format("{0}: {1}, {2}, {3}, {4} ", this.PolicyCustomRule.Level, this.PolicyCustomRule.FileInfo["PCACertificate"],
-                        this.PolicyCustomRule.FileInfo["LeafCertificate"], this.PolicyCustomRule.FileInfo["FileVersion"], this.PolicyCustomRule.FileInfo["FileName"]);
+                    if (this.PolicyCustomRule.UsingCustomValues)
+                    {
+                         name = String.Format("{0}: {1}, {2}, {3} {4}, {5}", this.PolicyCustomRule.Level, this.PolicyCustomRule.FileInfo["PCACertificate"], this.PolicyCustomRule.FileInfo["LeafCertificate"],
+                             String.IsNullOrEmpty(this.PolicyCustomRule.CustomValues.MinVersion) ? this.PolicyCustomRule.FileInfo["FileVersion"] : this.PolicyCustomRule.CustomValues.MinVersion,
+                             String.IsNullOrEmpty(this.PolicyCustomRule.CustomValues.MaxVersion) ? "and greater" : " up to " + this.PolicyCustomRule.CustomValues.MaxVersion,
+                             String.IsNullOrEmpty(this.PolicyCustomRule.CustomValues.FileName) ? this.PolicyCustomRule.FileInfo["FileName"] : this.PolicyCustomRule.CustomValues.FileName); 
+
+                    }
+                    else
+                    {
+                        name = String.Format("{0}: {1}, {2}, {3}, {4} ", this.PolicyCustomRule.Level, this.PolicyCustomRule.FileInfo["PCACertificate"],
+                       this.PolicyCustomRule.FileInfo["LeafCertificate"], this.PolicyCustomRule.FileInfo["FileVersion"], this.PolicyCustomRule.FileInfo["FileName"]);
+                    }
+                   
                     break;
 
                 case PolicyCustomRules.RuleLevel.OriginalFileName:
-                    name = String.Format("{0}; {1}", this.PolicyCustomRule.Level, this.PolicyCustomRule.FileInfo["OriginalFilename"]);
+                    if (this.PolicyCustomRule.UsingCustomValues)
+                    {
+                        name = String.Format("{0}; {1}", this.PolicyCustomRule.Level, this.PolicyCustomRule.CustomValues.FileName); 
+                    }
+                    else
+                    {
+                        name = String.Format("{0}; {1}", this.PolicyCustomRule.Level, this.PolicyCustomRule.FileInfo["OriginalFilename"]);
+                    }
                     break;
 
                 case PolicyCustomRules.RuleLevel.InternalName:
-                    name = String.Format("{0}; {1}", this.PolicyCustomRule.Level, this.PolicyCustomRule.FileInfo["InternalName"]);
+                    if (this.PolicyCustomRule.UsingCustomValues)
+                    {
+                        name = String.Format("{0}; {1}", this.PolicyCustomRule.Level, this.PolicyCustomRule.CustomValues.InternalName);
+                    }
+                    else
+                    {
+                        name = String.Format("{0}; {1}", this.PolicyCustomRule.Level, this.PolicyCustomRule.FileInfo["InternalName"]);
+                    }
                     break;
 
                 case PolicyCustomRules.RuleLevel.FileDescription:
-                    name = String.Format("{0}; {1}", this.PolicyCustomRule.Level, this.PolicyCustomRule.FileInfo["FileDescription"]);
+                    if (this.PolicyCustomRule.UsingCustomValues)
+                    {
+                        name = String.Format("{0}; {1}", this.PolicyCustomRule.Level, this.PolicyCustomRule.CustomValues.Description);
+                    }
+                    else
+                    {
+                        name = String.Format("{0}; {1}", this.PolicyCustomRule.Level, this.PolicyCustomRule.FileInfo["FileDescription"]);
+                    }
                     break;
 
                 case PolicyCustomRules.RuleLevel.ProductName:
-                    name = String.Format("{0}; {1}", this.PolicyCustomRule.Level, this.PolicyCustomRule.FileInfo["ProductName"]);
+                    if (this.PolicyCustomRule.UsingCustomValues)
+                    {
+                        name = String.Format("{0}; {1}", this.PolicyCustomRule.Level, this.PolicyCustomRule.CustomValues.ProductName);
+                    }
+                    else
+                    {
+                        name = String.Format("{0}; {1}", this.PolicyCustomRule.Level, this.PolicyCustomRule.FileInfo["ProductName"]);
+                    }
                     break;
 
                 default:

--- a/WDAC-Policy-Wizard/app/src/CustomRuleConditionsPanel.cs
+++ b/WDAC-Policy-Wizard/app/src/CustomRuleConditionsPanel.cs
@@ -129,6 +129,30 @@ namespace WDAC_Wizard
                         return;
                     }
                 }
+
+                // Parse hashes into PolicyCustomRule.CustomValues.Hash
+                if(this.PolicyCustomRule.Type == PolicyCustomRules.RuleType.Hash)
+                {
+                    var hashList = this.richTextBox_CustomHashes.Text.Split(',');
+                    foreach(var hash in hashList)
+                    {
+                        if(!String.IsNullOrEmpty(hash))
+                        {
+                            if(hash.Length == 64)
+                            {
+                                this.PolicyCustomRule.CustomValues.Hashes.Add(hash);
+                            }
+                        }
+                    }
+
+                    if(this.PolicyCustomRule.CustomValues.Hashes.Count == 0)
+                    {
+                        label_Error.Visible = true;
+                        label_Error.Text = "Invalid custom hashes specified. The WDAC Wizard was unable to detect at least 1 hash.";
+                        this.Log.AddWarningMsg("Zero hash values located.");
+                        return;
+                    }
+                }
             }
 
 
@@ -293,7 +317,7 @@ namespace WDAC_Wizard
                     break;
 
                 default:
-                    name = String.Format("{0}; {1}", this.PolicyCustomRule.Level, String.IsNullOrEmpty(this.PolicyCustomRule.CustomValues.Path) ? this.PolicyCustomRule.ReferenceFile : this.PolicyCustomRule.CustomValues.Path);
+                    name = String.Format("{0}; {1}", this.PolicyCustomRule.Level, String.IsNullOrEmpty(this.PolicyCustomRule.ReferenceFile) ? "Custom Hash List" : this.PolicyCustomRule.ReferenceFile);
                     break;
             }
 
@@ -371,6 +395,7 @@ namespace WDAC_Wizard
                     radioButton_File.Checked = true; // By default, 
 
                     this.checkBox_CustomPath.Visible = true;
+                    this.checkBox_CustomPath.Text = "Use Custom Path";
                     break;
 
                 case "File Attributes":
@@ -385,6 +410,9 @@ namespace WDAC_Wizard
                     this.PolicyCustomRule.SetRuleLevel(PolicyCustomRules.RuleLevel.Hash);
                     label_Info.Text = "Creates a rule for a file that is not signed. \r\n" +
                         "Select the file for which you wish to create a hash rule.";
+                    
+                    this.checkBox_CustomPath.Visible = true;
+                    this.checkBox_CustomPath.Text = "Use Custom Hash Values"; 
                     break;
                 default:
                     break;
@@ -1258,15 +1286,44 @@ namespace WDAC_Wizard
 
         private void UseCustomPath(object sender, EventArgs e)
         {
-            if(this.checkBox_CustomPath.Checked)
+            if(this.PolicyCustomRule.Type == PolicyCustomRules.RuleType.Hash)
             {
-                this.PolicyCustomRule.UsingCustomValues = true;
-                this.textBox_ReferenceFile.ReadOnly = false; 
+                if (this.checkBox_CustomPath.Checked)
+                {
+                    this.richTextBox_CustomHashes.Visible = true;
+                    this.richTextBox_CustomHashes.Location = this.panel_Publisher_Scroll.Location;
+                    this.richTextBox_CustomHashes.Tag = "Title";
+
+                    this.PolicyCustomRule.UsingCustomValues = true;
+                }
+                else
+                {
+                    this.richTextBox_CustomHashes.Visible = false;
+                    this.PolicyCustomRule.UsingCustomValues = false;
+                }
             }
             else
             {
-                this.PolicyCustomRule.UsingCustomValues = false;
-                this.textBox_ReferenceFile.ReadOnly = true; 
+                if (this.checkBox_CustomPath.Checked)
+                {
+                    this.PolicyCustomRule.UsingCustomValues = true;
+                    this.textBox_ReferenceFile.ReadOnly = false;
+                }
+                else
+                {
+                    this.PolicyCustomRule.UsingCustomValues = false;
+                    this.textBox_ReferenceFile.ReadOnly = true;
+                }
+            }
+           
+        }
+
+        private void richTextBox_CustomHashes_Click(object sender, EventArgs e)
+        {
+            if(this.richTextBox_CustomHashes.Tag == "Title")
+            {
+                this.richTextBox_CustomHashes.ResetText();
+                this.richTextBox_CustomHashes.Tag = "Values"; 
             }
         }
     }   

--- a/WDAC-Policy-Wizard/app/src/EditWorkflow.cs
+++ b/WDAC-Policy-Wizard/app/src/EditWorkflow.cs
@@ -368,9 +368,8 @@ namespace WDAC_Wizard
                 case PolicyCustomRules.RuleType.Folder:
                     {
                         // Check if part of the folder path can be replaced with an env variable eg. %OSDRIVE% == "C:\"
-                        if (customRule.GetRuleType() == PolicyCustomRules.RuleType.FilePath &&
-                            Properties.Settings.Default.useEnvVars && customRule.isEnvVar())
-                            customRuleScript = String.Format("$Rule_{0} = New-CIPolicyRule -FilePathRule \"{1}\"", customRule.PSVariable, customRule.GetEnvVar());
+                        if (customRule.GetRuleType() == PolicyCustomRules.RuleType.FilePath && Properties.Settings.Default.useEnvVars )
+                            customRuleScript = String.Format("$Rule_{0} = New-CIPolicyRule -FilePathRule \"{1}\"", customRule.PSVariable, Helper.GetEnvPath(customRule.ReferenceFile));
                         else
                             customRuleScript = String.Format("$Rule_{0} = New-CIPolicyRule -FilePathRule \"{1}\"", customRule.PSVariable, customRule.ReferenceFile);
                     }

--- a/WDAC-Policy-Wizard/app/src/Helper.cs
+++ b/WDAC-Policy-Wizard/app/src/Helper.cs
@@ -296,6 +296,36 @@ namespace WDAC_Wizard
             serializer.Serialize(writer, siPolicy);
             writer.Close();
         }
+
+        // Check that version has 4 parts (follows ww.xx.yy.zz format)
+        // And each part < 2^16
+        public static bool IsValidVersion(string version)
+        {
+            var versionParts = version.Split('.');
+            if(versionParts.Length != 4)
+            {
+                return false; 
+            }
+
+            foreach(var part in versionParts)
+            {
+                try
+                {
+                    int _part = Convert.ToInt32(part);
+                    if (_part > UInt16.MaxValue || _part < 0)
+                    {
+                        return false;
+                    }
+                }
+                catch(Exception e)
+                {
+                    return false; 
+                }
+            }
+            return true; 
+        }
+
+
     }
 
     public class packedInfo
@@ -487,6 +517,23 @@ namespace WDAC_Wizard
 
     }
 
+    // Custom Values object to organize custom values in Custom Rules object
+    public class CustomValue
+    {
+        public string MinVersion;
+        public string MaxVersion;
+        public string FileName;
+        public string ProductName;
+        public string Description;
+        public string InternalName; 
+
+        public CustomValue()
+        {
+
+        }
+
+    }
+
     public class PolicyCustomRules
     {
         public enum RuleType
@@ -532,6 +579,9 @@ namespace WDAC_Wizard
         public string RuleIndex { get; set; } // Index of return struct in Get-SystemDriver cmdlet
         public int RowNumber { get; set;  }     // Index of the row in the datagrid
 
+        // Custom values
+        public bool UsingCustomValues { get; set; }
+        public CustomValue CustomValues { get; set; }
 
         // Filepath params
         public List<string> FolderContents { get; set; }
@@ -549,6 +599,9 @@ namespace WDAC_Wizard
             this.FileInfo = new Dictionary<string, string>();
             this.ExceptionList = new List<PolicyCustomRules>();
             this.FolderContents = new List<string>();
+
+            this.UsingCustomValues = false;
+            this.CustomValues = new CustomValue(); 
         }
 
         /// <summary>
@@ -568,6 +621,8 @@ namespace WDAC_Wizard
             this.RuleIndex = ruleIndex;
             this.ExceptionList = new List<PolicyCustomRules>();
             this.FileInfo = new Dictionary<string, string>();
+
+            this.UsingCustomValues = false;
         }
 
         public void SetRuleLevel(RuleLevel ruleLevel)

--- a/WDAC-Policy-Wizard/app/src/Helper.cs
+++ b/WDAC-Policy-Wizard/app/src/Helper.cs
@@ -409,12 +409,12 @@ namespace WDAC_Wizard
 
             if (upperPath.Contains(sys)) // C:/WINDOWS/system32/foo/bar --> %SYSTEM32%/foo/bar
             {
-                envPath = "%SYSTEM32%\\" + _path.Substring(sys.Length); 
+                envPath = "%SYSTEM32%" + _path.Substring(sys.Length); 
                 return envPath; 
             }
             else if (upperPath.Contains(win)) // WINDIR
             {
-                envPath = "%WINDIR%\\" + _path.Substring(win.Length);
+                envPath = "%WINDIR%" + _path.Substring(win.Length);
                 return envPath;
             }
             else if (upperPath.Contains(os)) // OSDRIVE
@@ -628,11 +628,12 @@ namespace WDAC_Wizard
         public string ProductName;
         public string Description;
         public string InternalName;
-        public string Path; 
+        public string Path;
+        public List<string> Hashes; 
 
         public CustomValue()
         {
-
+            this.Hashes = new List<string>();
         }
 
     }

--- a/WDAC-Policy-Wizard/app/src/Helper.cs
+++ b/WDAC-Policy-Wizard/app/src/Helper.cs
@@ -324,6 +324,30 @@ namespace WDAC_Wizard
             }
             return true; 
         }
+
+        public static int CompareVersions(string minVersion, string maxVersion)
+        {
+
+            var minversionParts = minVersion.Split('.');
+            var maxversionParts = maxVersion.Split('.'); 
+
+            for(int i = 0; i < 4; i++)
+            {
+                int minVerPart = Convert.ToInt32(minversionParts[i]);
+                int maxVerPart = Convert.ToInt32(maxversionParts[i]);
+
+                if (minVerPart > maxVerPart)
+                {
+                    return -1;
+                }
+                else if (minVerPart < maxVerPart)
+                {
+                    return 1;
+                }
+            }
+
+            return 0; 
+        }
     }
 
     public class packedInfo

--- a/WDAC-Policy-Wizard/app/src/Helper.cs
+++ b/WDAC-Policy-Wizard/app/src/Helper.cs
@@ -324,8 +324,6 @@ namespace WDAC_Wizard
             }
             return true; 
         }
-
-
     }
 
     public class packedInfo

--- a/WDAC-Policy-Wizard/app/src/Helper.cs
+++ b/WDAC-Policy-Wizard/app/src/Helper.cs
@@ -327,7 +327,6 @@ namespace WDAC_Wizard
 
         public static int CompareVersions(string minVersion, string maxVersion)
         {
-
             var minversionParts = minVersion.Split('.');
             var maxversionParts = maxVersion.Split('.'); 
 
@@ -347,6 +346,55 @@ namespace WDAC_Wizard
             }
 
             return 0; 
+        }
+
+        public static bool IsValidPathRule(string customPath)
+        {
+            // Check for at most 1 wildcard param (*)
+            if(customPath.Contains("*"))
+            {
+                var wildCardParts = customPath.Split('*');
+                if (wildCardParts.Length < 2)
+                {
+                    return false;
+                }
+                else
+                {
+                    // Start or end must be empty
+                    if (String.IsNullOrEmpty(wildCardParts[0]) || String.IsNullOrEmpty(wildCardParts[1]))
+                    {
+                        // Continue - either side is empty
+                    }
+                    else
+                    {
+                        // wildcard in middle of path - not supported
+                        return false;
+                    }
+                }
+            }
+            
+            // Check for macros (%OSDRIVE%, %WINDIR%, %SYSTEM32%)
+            if(customPath.Contains("%"))
+            {
+                var macroParts = customPath.Split('%');
+                if (macroParts.Length == 3)
+                {
+                    if (macroParts[1] == "OSDRIVE" || macroParts[1] == "WINDIR" || macroParts[1] == "SYSTEM32")
+                    {
+                        // continue with rest of checks
+                    }
+                    else
+                    {
+                        return false;
+                    }
+                }
+                else
+                {
+                    // Too many or too few '%'
+                    return false;
+                }
+            }
+            return true; 
         }
     }
 
@@ -547,7 +595,8 @@ namespace WDAC_Wizard
         public string FileName;
         public string ProductName;
         public string Description;
-        public string InternalName; 
+        public string InternalName;
+        public string Path; 
 
         public CustomValue()
         {
@@ -723,7 +772,7 @@ namespace WDAC_Wizard
 
         public string GetEnvVar()
         {
-            string sys = Environment.GetFolderPath(Environment.SpecialFolder.System);
+            string sys = Path.GetPathRoot(Environment.SystemDirectory);
             string win = Environment.GetFolderPath(Environment.SpecialFolder.Windows);
             string os = Path.GetPathRoot(Environment.SystemDirectory);
 

--- a/WDAC-Policy-Wizard/app/src/Helper.cs
+++ b/WDAC-Policy-Wizard/app/src/Helper.cs
@@ -396,6 +396,38 @@ namespace WDAC_Wizard
             }
             return true; 
         }
+
+        public static string GetEnvPath(string _path)
+        {
+            // if the path contains one of the following environment variables -- return true as the cmdlets can replace it
+            string sys = Environment.GetFolderPath(Environment.SpecialFolder.System).ToUpper();
+            string win = Environment.GetFolderPath(Environment.SpecialFolder.Windows).ToUpper();
+            string os = Path.GetPathRoot(Environment.SystemDirectory).ToUpper();
+
+            string envPath = String.Empty;
+            string upperPath = _path.ToUpper();
+
+            if (upperPath.Contains(sys)) // C:/WINDOWS/system32/foo/bar --> %SYSTEM32%/foo/bar
+            {
+                envPath = "%SYSTEM32%\\" + _path.Substring(sys.Length); 
+                return envPath; 
+            }
+            else if (upperPath.Contains(win)) // WINDIR
+            {
+                envPath = "%WINDIR%\\" + _path.Substring(win.Length);
+                return envPath;
+            }
+            else if (upperPath.Contains(os)) // OSDRIVE
+            {
+                envPath = "%OSDRIVE%\\" + _path.Substring(os.Length); 
+                return envPath;
+            }
+            else
+            {
+                return _path; // otherwise, not an env variable we support
+            }
+
+        }
     }
 
     public class packedInfo
@@ -755,42 +787,6 @@ namespace WDAC_Wizard
             {
                 // Log error or something
             }
-        }
-
-        public bool isEnvVar()
-        {
-            // if the path contains one of the following environment variables -- return true as the cmdlets can replace it
-            if (this.ReferenceFile.Contains(Path.GetPathRoot(Environment.SystemDirectory)) || 
-                this.ReferenceFile.Contains(Environment.GetFolderPath(Environment.SpecialFolder.Windows)) ||
-                this.ReferenceFile.Contains(Environment.GetFolderPath(Environment.SpecialFolder.System)))
-                return true;
-
-            // otherwise, not an env variable we support
-            else
-                return false; 
-        }
-
-        public string GetEnvVar()
-        {
-            string sys = Path.GetPathRoot(Environment.SystemDirectory);
-            string win = Environment.GetFolderPath(Environment.SpecialFolder.Windows);
-            string os = Path.GetPathRoot(Environment.SystemDirectory);
-
-            string retVal = String.Empty; 
-
-            if (this.ReferenceFile.Contains(Environment.GetFolderPath(Environment.SpecialFolder.System))) //OSDRIVE/WINDOWS/system32
-                retVal =  "%SYSTEM32%/" + this.ReferenceFile.Substring(Environment.GetFolderPath(Environment.SpecialFolder.System).Length); 
-
-            else if (this.ReferenceFile.Contains(Environment.GetFolderPath(Environment.SpecialFolder.Windows))) //OSDRIVE/WINDOWS
-                retVal = "%WINDIR%/" + this.ReferenceFile.Substring(Environment.GetFolderPath(Environment.SpecialFolder.Windows).Length);
-
-            else if (this.ReferenceFile.Contains(Path.GetPathRoot(Environment.SystemDirectory))) // OSDRIVE
-                retVal = "%OSDRIVE%/" + this.ReferenceFile.Substring(Path.GetPathRoot(Environment.SystemDirectory).Length);
-
-            else
-                retVal = "";
-
-            return retVal;
         }
     }
 

--- a/WDAC-Policy-Wizard/app/src/MainForm.cs
+++ b/WDAC-Policy-Wizard/app/src/MainForm.cs
@@ -1119,22 +1119,37 @@ namespace WDAC_Wizard
 
                 case PolicyCustomRules.RuleType.FilePath:
                     {
-                        customRuleScript = String.Format("{0} = New-CIPolicyRule -Level FilePath -DriverFilePath \"{1}\"" +
+                        if(customRule.UsingCustomValues)
+                        {
+                            customRuleScript = String.Format("{0} = New-CIPolicyRule -FilePathRule \"{1}\" -UserWriteablePaths", rulePrefix, customRule.CustomValues.Path); 
+                            // -UserWriteablePaths allows all paths (userWriteable and non) to be added as filepath rules
+                        }
+                        else
+                        {
+                            customRuleScript = String.Format("{0} = New-CIPolicyRule -Level FilePath -DriverFilePath \"{1}\"" +
                             " -Fallback Hash -UserWriteablePaths", rulePrefix, customRule.ReferenceFile); // -UserWriteablePaths allows all paths (userWriteable and non) to be added as filepath rules
+                        }
                     }
                     break;
 
                 case PolicyCustomRules.RuleType.Folder:
                     {
-                        // Check if part of the folder path can be replaced with an env variable eg. %OSDRIVE% == "C:\"
-                        if (customRule.Type == PolicyCustomRules.RuleType.FilePath &&
-                            Properties.Settings.Default.useEnvVars && customRule.isEnvVar())
+                        if (customRule.UsingCustomValues)
                         {
-                            customRuleScript = String.Format("{0} = New-CIPolicyRule -FilePathRule \"{1}\"", rulePrefix, customRule.GetEnvVar());
+                            customRuleScript = String.Format("{0} = New-CIPolicyRule -FilePathRule \"{1}\" -UserWriteablePaths", rulePrefix, customRule.CustomValues.Path); 
+                            // -UserWriteablePaths allows all paths (userWriteable and non) to be added as filepath rules
                         }
                         else
                         {
-                            customRuleScript = String.Format("{0} = New-CIPolicyRule -FilePathRule \"{1}\"", rulePrefix,  customRule.ReferenceFile);
+                            // Check if part of the folder path can be replaced with an env variable eg. %OSDRIVE% == "C:\"
+                            if (Properties.Settings.Default.useEnvVars && customRule.isEnvVar())
+                            {
+                                customRuleScript = String.Format("{0} = New-CIPolicyRule -FilePathRule \"{1}\"", rulePrefix, customRule.GetEnvVar());
+                            }
+                            else
+                            {
+                                customRuleScript = String.Format("{0} = New-CIPolicyRule -FilePathRule \"{1}\"", rulePrefix, customRule.ReferenceFile);
+                            }
                         }
                     }
                     break;

--- a/WDAC-Policy-Wizard/app/src/MainForm.cs
+++ b/WDAC-Policy-Wizard/app/src/MainForm.cs
@@ -1142,9 +1142,9 @@ namespace WDAC_Wizard
                         else
                         {
                             // Check if part of the folder path can be replaced with an env variable eg. %OSDRIVE% == "C:\"
-                            if (Properties.Settings.Default.useEnvVars && customRule.isEnvVar())
+                            if (Properties.Settings.Default.useEnvVars)
                             {
-                                customRuleScript = String.Format("{0} = New-CIPolicyRule -FilePathRule \"{1}\"", rulePrefix, customRule.GetEnvVar());
+                                customRuleScript = String.Format("{0} = New-CIPolicyRule -FilePathRule \"{1}\"", rulePrefix, Helper.GetEnvPath(customRule.ReferenceFile));
                             }
                             else
                             {


### PR DESCRIPTION
**Custom Path Rules**

- Implemented support for macros, specifically, %OSDRIVE%, %WINDIR%, %SYSTEM32%
- Implemented support for wildcards at the front and end of paths, e.g. */foo/bar.exe and C:\foo\*
- Folder rules will replace C:\, C:\Windows and C:\Windows\System32\ with %OSDRIVE%, %WINDIR%, %SYSTEM32%, if the setting is enabled

![image](https://user-images.githubusercontent.com/23045608/115938244-d30a3d00-a44e-11eb-811d-28ae2635c48a.png)


**Custom Version and file name**

- Implemented support for arbitrary min and max versions. Min < Max version, and max version must be < 65355.65355.....
- Implemented support for arbitrary filename

![image](https://user-images.githubusercontent.com/23045608/115938224-c1c13080-a44e-11eb-92ca-3b79652e4f79.png)

**Custom SHA256 PE hash rules**

- Implemented support for arbitrary hash rules. Each hash must be 64 characters and comma separated

Before clicking the textbox - title disappears on click
![image](https://user-images.githubusercontent.com/23045608/115938299-fd5bfa80-a44e-11eb-8e91-54cf4bffccd9.png)

![image](https://user-images.githubusercontent.com/23045608/115938328-1369bb00-a44f-11eb-9c35-ee2592961749.png)
