### PR TITLE
The WDAC Wizard supports arbitrary package family name rules

### DIFF
--- a/WDAC-Policy-Wizard/app/Properties/Resources.Designer.cs
+++ b/WDAC-Policy-Wizard/app/Properties/Resources.Designer.cs
@@ -225,6 +225,15 @@ namespace WDAC_Wizard.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to 1.0.0.0.
+        /// </summary>
+        internal static string DefaultPFNVersion {
+            get {
+                return ResourceManager.GetString("DefaultPFNVersion", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to 0.0.0.0.
         /// </summary>
         internal static string DefaultVersionString {

--- a/WDAC-Policy-Wizard/app/Properties/Resources.resx
+++ b/WDAC-Policy-Wizard/app/Properties/Resources.resx
@@ -378,4 +378,7 @@ with a version at or above this specified file version number.</value>
   <data name="UnsuccessfulEventLogConversion" xml:space="preserve">
     <value>Conversion of the event log to a WDAC Policy XML file was unsuccessful. Please try another file. </value>
   </data>
+  <data name="DefaultPFNVersion" xml:space="preserve">
+    <value>1.0.0.0</value>
+  </data>
 </root>

--- a/WDAC-Policy-Wizard/app/src/CustomRuleConditionsPanel.Designer.cs
+++ b/WDAC-Policy-Wizard/app/src/CustomRuleConditionsPanel.Designer.cs
@@ -80,6 +80,7 @@
             this.button_AddException = new System.Windows.Forms.Button();
             this.button_Back = new System.Windows.Forms.Button();
             this.backgroundWorker = new System.ComponentModel.BackgroundWorker();
+            this.checkBox_CustomPFN = new System.Windows.Forms.CheckBox();
             this.panel_CustomRules.SuspendLayout();
             this.panelPackagedApps.SuspendLayout();
             this.panel_Progress.SuspendLayout();
@@ -109,23 +110,25 @@
             this.panel_CustomRules.Controls.Add(this.button_Browse);
             this.panel_CustomRules.Controls.Add(this.label_condition);
             this.panel_CustomRules.Controls.Add(this.checkBox_CustomPath);
-            this.panel_CustomRules.Location = new System.Drawing.Point(123, 0);
+            this.panel_CustomRules.Location = new System.Drawing.Point(148, 0);
             this.panel_CustomRules.Margin = new System.Windows.Forms.Padding(2);
             this.panel_CustomRules.Name = "panel_CustomRules";
-            this.panel_CustomRules.Size = new System.Drawing.Size(615, 701);
+            this.panel_CustomRules.Size = new System.Drawing.Size(738, 841);
             this.panel_CustomRules.TabIndex = 86;
             // 
             // panelPackagedApps
             // 
+            this.panelPackagedApps.Controls.Add(this.checkBox_CustomPFN);
             this.panelPackagedApps.Controls.Add(this.panel_Progress);
             this.panelPackagedApps.Controls.Add(this.label3);
             this.panelPackagedApps.Controls.Add(this.checkedListBoxPackagedApps);
             this.panelPackagedApps.Controls.Add(this.buttonSearch);
             this.panelPackagedApps.Controls.Add(this.textBox_Packaged_App);
             this.panelPackagedApps.Controls.Add(this.label2);
-            this.panelPackagedApps.Location = new System.Drawing.Point(586, 260);
+            this.panelPackagedApps.Location = new System.Drawing.Point(204, 215);
+            this.panelPackagedApps.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.panelPackagedApps.Name = "panelPackagedApps";
-            this.panelPackagedApps.Size = new System.Drawing.Size(609, 402);
+            this.panelPackagedApps.Size = new System.Drawing.Size(731, 482);
             this.panelPackagedApps.TabIndex = 115;
             this.panelPackagedApps.Visible = false;
             // 
@@ -133,18 +136,20 @@
             // 
             this.panel_Progress.Controls.Add(this.label_Progress);
             this.panel_Progress.Controls.Add(this.pictureBox_Progress);
-            this.panel_Progress.Location = new System.Drawing.Point(97, 115);
+            this.panel_Progress.Location = new System.Drawing.Point(115, 172);
+            this.panel_Progress.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.panel_Progress.Name = "panel_Progress";
-            this.panel_Progress.Size = new System.Drawing.Size(280, 179);
+            this.panel_Progress.Size = new System.Drawing.Size(336, 215);
             this.panel_Progress.TabIndex = 118;
             this.panel_Progress.Visible = false;
             // 
             // label_Progress
             // 
             this.label_Progress.AutoSize = true;
-            this.label_Progress.Location = new System.Drawing.Point(33, 18);
+            this.label_Progress.Location = new System.Drawing.Point(40, 22);
+            this.label_Progress.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label_Progress.Name = "label_Progress";
-            this.label_Progress.Size = new System.Drawing.Size(196, 17);
+            this.label_Progress.Size = new System.Drawing.Size(220, 20);
             this.label_Progress.TabIndex = 1;
             this.label_Progress.Text = "Searching for Packaged Apps";
             this.label_Progress.TextAlign = System.Drawing.ContentAlignment.TopCenter;
@@ -153,7 +158,8 @@
             // 
             this.pictureBox_Progress.Image = global::WDAC_Wizard.Properties.Resources.loading;
             this.pictureBox_Progress.InitialImage = global::WDAC_Wizard.Properties.Resources.loading;
-            this.pictureBox_Progress.Location = new System.Drawing.Point(67, 48);
+            this.pictureBox_Progress.Location = new System.Drawing.Point(80, 58);
+            this.pictureBox_Progress.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.pictureBox_Progress.Name = "pictureBox_Progress";
             this.pictureBox_Progress.Size = new System.Drawing.Size(128, 128);
             this.pictureBox_Progress.SizeMode = System.Windows.Forms.PictureBoxSizeMode.AutoSize;
@@ -163,18 +169,20 @@
             // label3
             // 
             this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(3, 50);
+            this.label3.Location = new System.Drawing.Point(4, 60);
+            this.label3.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(477, 17);
+            this.label3.Size = new System.Drawing.Size(531, 20);
             this.label3.TabIndex = 117;
             this.label3.Text = "Search for a package name and select the packages to include in the rule.";
             // 
             // checkedListBoxPackagedApps
             // 
             this.checkedListBoxPackagedApps.FormattingEnabled = true;
-            this.checkedListBoxPackagedApps.Location = new System.Drawing.Point(6, 88);
+            this.checkedListBoxPackagedApps.Location = new System.Drawing.Point(7, 139);
+            this.checkedListBoxPackagedApps.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.checkedListBoxPackagedApps.Name = "checkedListBoxPackagedApps";
-            this.checkedListBoxPackagedApps.Size = new System.Drawing.Size(458, 225);
+            this.checkedListBoxPackagedApps.Size = new System.Drawing.Size(549, 257);
             this.checkedListBoxPackagedApps.TabIndex = 116;
             // 
             // buttonSearch
@@ -184,10 +192,10 @@
             this.buttonSearch.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.buttonSearch.Font = new System.Drawing.Font("Tahoma", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.buttonSearch.ForeColor = System.Drawing.Color.DodgerBlue;
-            this.buttonSearch.Location = new System.Drawing.Point(357, 12);
+            this.buttonSearch.Location = new System.Drawing.Point(428, 14);
             this.buttonSearch.Margin = new System.Windows.Forms.Padding(2);
             this.buttonSearch.Name = "buttonSearch";
-            this.buttonSearch.Size = new System.Drawing.Size(107, 28);
+            this.buttonSearch.Size = new System.Drawing.Size(128, 34);
             this.buttonSearch.TabIndex = 115;
             this.buttonSearch.Text = "Search";
             this.buttonSearch.UseVisualStyleBackColor = false;
@@ -196,28 +204,30 @@
             // textBox_Packaged_App
             // 
             this.textBox_Packaged_App.Font = new System.Drawing.Font("Tahoma", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.textBox_Packaged_App.Location = new System.Drawing.Point(115, 13);
+            this.textBox_Packaged_App.Location = new System.Drawing.Point(138, 16);
             this.textBox_Packaged_App.Margin = new System.Windows.Forms.Padding(2);
             this.textBox_Packaged_App.Name = "textBox_Packaged_App";
-            this.textBox_Packaged_App.Size = new System.Drawing.Size(215, 26);
+            this.textBox_Packaged_App.Size = new System.Drawing.Size(257, 29);
             this.textBox_Packaged_App.TabIndex = 115;
             this.textBox_Packaged_App.KeyDown += new System.Windows.Forms.KeyEventHandler(this.textBox_Packaged_App_KeyDown);
             // 
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(3, 18);
+            this.label2.Location = new System.Drawing.Point(4, 22);
+            this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(108, 17);
+            this.label2.Size = new System.Drawing.Size(121, 20);
             this.label2.TabIndex = 0;
             this.label2.Text = "Package Name:";
             // 
             // richTextBox_CustomHashes
             // 
             this.richTextBox_CustomHashes.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.richTextBox_CustomHashes.Location = new System.Drawing.Point(328, 191);
+            this.richTextBox_CustomHashes.Location = new System.Drawing.Point(375, 216);
+            this.richTextBox_CustomHashes.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.richTextBox_CustomHashes.Name = "richTextBox_CustomHashes";
-            this.richTextBox_CustomHashes.Size = new System.Drawing.Size(559, 96);
+            this.richTextBox_CustomHashes.Size = new System.Drawing.Size(670, 114);
             this.richTextBox_CustomHashes.TabIndex = 114;
             this.richTextBox_CustomHashes.Text = "Insert comma separated list of SHA-256 Authenticode Hashes";
             this.richTextBox_CustomHashes.Visible = false;
@@ -237,19 +247,20 @@
             this.panel_Publisher_Scroll.Controls.Add(this.textBoxSlider_0);
             this.panel_Publisher_Scroll.Controls.Add(this.labelSlider_0);
             this.panel_Publisher_Scroll.Controls.Add(this.trackBar_Conditions);
-            this.panel_Publisher_Scroll.Location = new System.Drawing.Point(10, 389);
+            this.panel_Publisher_Scroll.Location = new System.Drawing.Point(12, 467);
             this.panel_Publisher_Scroll.Margin = new System.Windows.Forms.Padding(2);
             this.panel_Publisher_Scroll.Name = "panel_Publisher_Scroll";
-            this.panel_Publisher_Scroll.Size = new System.Drawing.Size(494, 223);
+            this.panel_Publisher_Scroll.Size = new System.Drawing.Size(593, 268);
             this.panel_Publisher_Scroll.TabIndex = 103;
             this.panel_Publisher_Scroll.Visible = false;
             // 
             // checkBox_CustomValues
             // 
             this.checkBox_CustomValues.AutoSize = true;
-            this.checkBox_CustomValues.Location = new System.Drawing.Point(7, 185);
+            this.checkBox_CustomValues.Location = new System.Drawing.Point(8, 222);
+            this.checkBox_CustomValues.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.checkBox_CustomValues.Name = "checkBox_CustomValues";
-            this.checkBox_CustomValues.Size = new System.Drawing.Size(153, 21);
+            this.checkBox_CustomValues.Size = new System.Drawing.Size(176, 24);
             this.checkBox_CustomValues.TabIndex = 111;
             this.checkBox_CustomValues.Text = "Use Custom Values";
             this.checkBox_CustomValues.UseVisualStyleBackColor = true;
@@ -259,9 +270,10 @@
             // 
             this.label_To.AutoSize = true;
             this.label_To.Font = new System.Drawing.Font("Tahoma", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label_To.Location = new System.Drawing.Point(314, 105);
+            this.label_To.Location = new System.Drawing.Point(377, 126);
+            this.label_To.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label_To.Name = "label_To";
-            this.label_To.Size = new System.Drawing.Size(16, 21);
+            this.label_To.Size = new System.Drawing.Size(17, 24);
             this.label_To.TabIndex = 112;
             this.label_To.Text = "-";
             this.label_To.Visible = false;
@@ -271,11 +283,11 @@
             this.textBox_MaxVersion.BackColor = System.Drawing.SystemColors.Control;
             this.textBox_MaxVersion.Font = new System.Drawing.Font("Tahoma", 9F);
             this.textBox_MaxVersion.ForeColor = System.Drawing.SystemColors.WindowText;
-            this.textBox_MaxVersion.Location = new System.Drawing.Point(334, 102);
+            this.textBox_MaxVersion.Location = new System.Drawing.Point(401, 122);
             this.textBox_MaxVersion.Margin = new System.Windows.Forms.Padding(2);
             this.textBox_MaxVersion.Name = "textBox_MaxVersion";
             this.textBox_MaxVersion.ReadOnly = true;
-            this.textBox_MaxVersion.Size = new System.Drawing.Size(152, 26);
+            this.textBox_MaxVersion.Size = new System.Drawing.Size(182, 29);
             this.textBox_MaxVersion.TabIndex = 105;
             this.textBox_MaxVersion.Text = "Max version";
             this.textBox_MaxVersion.Visible = false;
@@ -285,11 +297,11 @@
             // 
             this.textBoxSlider_3.BackColor = System.Drawing.SystemColors.Control;
             this.textBoxSlider_3.Font = new System.Drawing.Font("Tahoma", 9F);
-            this.textBoxSlider_3.Location = new System.Drawing.Point(159, 144);
+            this.textBoxSlider_3.Location = new System.Drawing.Point(191, 173);
             this.textBoxSlider_3.Margin = new System.Windows.Forms.Padding(2);
             this.textBoxSlider_3.Name = "textBoxSlider_3";
             this.textBoxSlider_3.ReadOnly = true;
-            this.textBoxSlider_3.Size = new System.Drawing.Size(327, 26);
+            this.textBoxSlider_3.Size = new System.Drawing.Size(392, 29);
             this.textBoxSlider_3.TabIndex = 103;
             this.textBoxSlider_3.TextChanged += new System.EventHandler(this.textBoxSlider_3_TextChanged);
             // 
@@ -298,9 +310,10 @@
             this.labelSlider_3.AutoSize = true;
             this.labelSlider_3.Font = new System.Drawing.Font("Tahoma", 9F);
             this.labelSlider_3.ForeColor = System.Drawing.Color.Black;
-            this.labelSlider_3.Location = new System.Drawing.Point(36, 147);
+            this.labelSlider_3.Location = new System.Drawing.Point(43, 176);
+            this.labelSlider_3.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.labelSlider_3.Name = "labelSlider_3";
-            this.labelSlider_3.Size = new System.Drawing.Size(75, 18);
+            this.labelSlider_3.Size = new System.Drawing.Size(91, 22);
             this.labelSlider_3.TabIndex = 104;
             this.labelSlider_3.Text = "File name:";
             this.labelSlider_3.TextAlign = System.Drawing.ContentAlignment.TopCenter;
@@ -309,11 +322,11 @@
             // 
             this.textBoxSlider_2.BackColor = System.Drawing.SystemColors.Control;
             this.textBoxSlider_2.Font = new System.Drawing.Font("Tahoma", 9F);
-            this.textBoxSlider_2.Location = new System.Drawing.Point(159, 102);
+            this.textBoxSlider_2.Location = new System.Drawing.Point(191, 122);
             this.textBoxSlider_2.Margin = new System.Windows.Forms.Padding(2);
             this.textBoxSlider_2.Name = "textBoxSlider_2";
             this.textBoxSlider_2.ReadOnly = true;
-            this.textBoxSlider_2.Size = new System.Drawing.Size(152, 26);
+            this.textBoxSlider_2.Size = new System.Drawing.Size(182, 29);
             this.textBoxSlider_2.TabIndex = 101;
             this.textBoxSlider_2.TextChanged += new System.EventHandler(this.textBoxSlider_2_TextChanged);
             // 
@@ -322,9 +335,10 @@
             this.labelSlider_2.AutoSize = true;
             this.labelSlider_2.Font = new System.Drawing.Font("Tahoma", 9F);
             this.labelSlider_2.ForeColor = System.Drawing.Color.Black;
-            this.labelSlider_2.Location = new System.Drawing.Point(36, 106);
+            this.labelSlider_2.Location = new System.Drawing.Point(43, 127);
+            this.labelSlider_2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.labelSlider_2.Name = "labelSlider_2";
-            this.labelSlider_2.Size = new System.Drawing.Size(86, 18);
+            this.labelSlider_2.Size = new System.Drawing.Size(106, 22);
             this.labelSlider_2.TabIndex = 102;
             this.labelSlider_2.Text = "Min version:";
             this.labelSlider_2.TextAlign = System.Drawing.ContentAlignment.TopCenter;
@@ -333,11 +347,11 @@
             // 
             this.textBoxSlider_1.BackColor = System.Drawing.SystemColors.Control;
             this.textBoxSlider_1.Font = new System.Drawing.Font("Tahoma", 9F);
-            this.textBoxSlider_1.Location = new System.Drawing.Point(159, 60);
+            this.textBoxSlider_1.Location = new System.Drawing.Point(191, 72);
             this.textBoxSlider_1.Margin = new System.Windows.Forms.Padding(2);
             this.textBoxSlider_1.Name = "textBoxSlider_1";
             this.textBoxSlider_1.ReadOnly = true;
-            this.textBoxSlider_1.Size = new System.Drawing.Size(327, 26);
+            this.textBoxSlider_1.Size = new System.Drawing.Size(392, 29);
             this.textBoxSlider_1.TabIndex = 99;
             this.textBoxSlider_1.TextChanged += new System.EventHandler(this.textBoxSlider_1_TextChanged);
             // 
@@ -346,9 +360,10 @@
             this.labelSlider_1.AutoSize = true;
             this.labelSlider_1.Font = new System.Drawing.Font("Tahoma", 9F);
             this.labelSlider_1.ForeColor = System.Drawing.Color.Black;
-            this.labelSlider_1.Location = new System.Drawing.Point(36, 62);
+            this.labelSlider_1.Location = new System.Drawing.Point(43, 74);
+            this.labelSlider_1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.labelSlider_1.Name = "labelSlider_1";
-            this.labelSlider_1.Size = new System.Drawing.Size(69, 18);
+            this.labelSlider_1.Size = new System.Drawing.Size(87, 22);
             this.labelSlider_1.TabIndex = 100;
             this.labelSlider_1.Text = "Publisher:";
             this.labelSlider_1.TextAlign = System.Drawing.ContentAlignment.TopCenter;
@@ -357,11 +372,11 @@
             // 
             this.textBoxSlider_0.BackColor = System.Drawing.SystemColors.Control;
             this.textBoxSlider_0.Font = new System.Drawing.Font("Tahoma", 9F);
-            this.textBoxSlider_0.Location = new System.Drawing.Point(159, 19);
+            this.textBoxSlider_0.Location = new System.Drawing.Point(191, 23);
             this.textBoxSlider_0.Margin = new System.Windows.Forms.Padding(2);
             this.textBoxSlider_0.Name = "textBoxSlider_0";
             this.textBoxSlider_0.ReadOnly = true;
-            this.textBoxSlider_0.Size = new System.Drawing.Size(327, 26);
+            this.textBoxSlider_0.Size = new System.Drawing.Size(392, 29);
             this.textBoxSlider_0.TabIndex = 95;
             this.textBoxSlider_0.TextChanged += new System.EventHandler(this.textBoxSlider_0_TextChanged);
             // 
@@ -370,9 +385,10 @@
             this.labelSlider_0.AutoSize = true;
             this.labelSlider_0.Font = new System.Drawing.Font("Tahoma", 9F);
             this.labelSlider_0.ForeColor = System.Drawing.Color.Black;
-            this.labelSlider_0.Location = new System.Drawing.Point(36, 21);
+            this.labelSlider_0.Location = new System.Drawing.Point(43, 25);
+            this.labelSlider_0.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.labelSlider_0.Name = "labelSlider_0";
-            this.labelSlider_0.Size = new System.Drawing.Size(82, 18);
+            this.labelSlider_0.Size = new System.Drawing.Size(101, 22);
             this.labelSlider_0.TabIndex = 98;
             this.labelSlider_0.Text = "Issuing CA:";
             this.labelSlider_0.TextAlign = System.Drawing.ContentAlignment.TopCenter;
@@ -380,12 +396,12 @@
             // trackBar_Conditions
             // 
             this.trackBar_Conditions.LargeChange = 4;
-            this.trackBar_Conditions.Location = new System.Drawing.Point(2, 13);
+            this.trackBar_Conditions.Location = new System.Drawing.Point(2, 16);
             this.trackBar_Conditions.Margin = new System.Windows.Forms.Padding(2);
             this.trackBar_Conditions.Maximum = 12;
             this.trackBar_Conditions.Name = "trackBar_Conditions";
             this.trackBar_Conditions.Orientation = System.Windows.Forms.Orientation.Vertical;
-            this.trackBar_Conditions.Size = new System.Drawing.Size(56, 165);
+            this.trackBar_Conditions.Size = new System.Drawing.Size(69, 198);
             this.trackBar_Conditions.SmallChange = 4;
             this.trackBar_Conditions.TabIndex = 96;
             this.trackBar_Conditions.TickFrequency = 4;
@@ -396,9 +412,10 @@
             this.label1.AutoSize = true;
             this.label1.Font = new System.Drawing.Font("Tahoma", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label1.ForeColor = System.Drawing.Color.Black;
-            this.label1.Location = new System.Drawing.Point(7, 72);
+            this.label1.Location = new System.Drawing.Point(8, 86);
+            this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(523, 36);
+            this.label1.Size = new System.Drawing.Size(634, 44);
             this.label1.TabIndex = 110;
             this.label1.Text = "Select the rule type, browse for the reference file and choose whether to allow \r" +
     "\nor deny. ";
@@ -408,10 +425,10 @@
             this.publisherInfoLabel.AutoSize = true;
             this.publisherInfoLabel.Font = new System.Drawing.Font("Tahoma", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.publisherInfoLabel.ForeColor = System.Drawing.SystemColors.Desktop;
-            this.publisherInfoLabel.Location = new System.Drawing.Point(12, 610);
+            this.publisherInfoLabel.Location = new System.Drawing.Point(14, 732);
             this.publisherInfoLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.publisherInfoLabel.Name = "publisherInfoLabel";
-            this.publisherInfoLabel.Size = new System.Drawing.Size(472, 36);
+            this.publisherInfoLabel.Size = new System.Drawing.Size(590, 44);
             this.publisherInfoLabel.TabIndex = 106;
             this.publisherInfoLabel.Text = "Rule applies to all files signed by this Issuing CA and publisher with this  \r\nfi" +
     "le name with a version at or above the specified version number.";
@@ -421,10 +438,10 @@
             // 
             this.panel_FileFolder.Controls.Add(this.radioButton_Folder);
             this.panel_FileFolder.Controls.Add(this.radioButton_File);
-            this.panel_FileFolder.Location = new System.Drawing.Point(464, 366);
+            this.panel_FileFolder.Location = new System.Drawing.Point(557, 439);
             this.panel_FileFolder.Margin = new System.Windows.Forms.Padding(2);
             this.panel_FileFolder.Name = "panel_FileFolder";
-            this.panel_FileFolder.Size = new System.Drawing.Size(131, 42);
+            this.panel_FileFolder.Size = new System.Drawing.Size(157, 50);
             this.panel_FileFolder.TabIndex = 104;
             this.panel_FileFolder.Visible = false;
             // 
@@ -433,10 +450,10 @@
             this.radioButton_Folder.AutoSize = true;
             this.radioButton_Folder.Font = new System.Drawing.Font("Tahoma", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.radioButton_Folder.ForeColor = System.Drawing.Color.Black;
-            this.radioButton_Folder.Location = new System.Drawing.Point(63, 7);
+            this.radioButton_Folder.Location = new System.Drawing.Point(76, 8);
             this.radioButton_Folder.Margin = new System.Windows.Forms.Padding(2);
             this.radioButton_Folder.Name = "radioButton_Folder";
-            this.radioButton_Folder.Size = new System.Drawing.Size(68, 22);
+            this.radioButton_Folder.Size = new System.Drawing.Size(83, 26);
             this.radioButton_Folder.TabIndex = 96;
             this.radioButton_Folder.TabStop = true;
             this.radioButton_Folder.Text = "Folder";
@@ -448,10 +465,10 @@
             this.radioButton_File.AutoSize = true;
             this.radioButton_File.Font = new System.Drawing.Font("Tahoma", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.radioButton_File.ForeColor = System.Drawing.Color.Black;
-            this.radioButton_File.Location = new System.Drawing.Point(2, 7);
+            this.radioButton_File.Location = new System.Drawing.Point(2, 8);
             this.radioButton_File.Margin = new System.Windows.Forms.Padding(2);
             this.radioButton_File.Name = "radioButton_File";
-            this.radioButton_File.Size = new System.Drawing.Size(49, 22);
+            this.radioButton_File.Size = new System.Drawing.Size(61, 26);
             this.radioButton_File.TabIndex = 95;
             this.radioButton_File.TabStop = true;
             this.radioButton_File.Text = "File";
@@ -463,10 +480,10 @@
             this.label_Info.AutoSize = true;
             this.label_Info.Font = new System.Drawing.Font("Tahoma", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label_Info.ForeColor = System.Drawing.SystemColors.MenuHighlight;
-            this.label_Info.Location = new System.Drawing.Point(9, 245);
+            this.label_Info.Location = new System.Drawing.Point(11, 294);
             this.label_Info.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label_Info.Name = "label_Info";
-            this.label_Info.Size = new System.Drawing.Size(76, 18);
+            this.label_Info.Size = new System.Drawing.Size(94, 22);
             this.label_Info.TabIndex = 95;
             this.label_Info.Text = "Label_Info";
             this.label_Info.Visible = false;
@@ -476,9 +493,10 @@
             this.label9.AutoSize = true;
             this.label9.Font = new System.Drawing.Font("Tahoma", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label9.ForeColor = System.Drawing.Color.Black;
-            this.label9.Location = new System.Drawing.Point(9, 179);
+            this.label9.Location = new System.Drawing.Point(11, 215);
+            this.label9.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label9.Name = "label9";
-            this.label9.Size = new System.Drawing.Size(79, 18);
+            this.label9.Size = new System.Drawing.Size(95, 22);
             this.label9.TabIndex = 89;
             this.label9.Text = "Rule Type:";
             this.label9.TextAlign = System.Drawing.ContentAlignment.TopCenter;
@@ -493,10 +511,10 @@
             "File Attributes",
             "Packaged App",
             "File Hash"});
-            this.comboBox_RuleType.Location = new System.Drawing.Point(10, 208);
+            this.comboBox_RuleType.Location = new System.Drawing.Point(12, 250);
             this.comboBox_RuleType.Margin = new System.Windows.Forms.Padding(2);
             this.comboBox_RuleType.Name = "comboBox_RuleType";
-            this.comboBox_RuleType.Size = new System.Drawing.Size(187, 26);
+            this.comboBox_RuleType.Size = new System.Drawing.Size(224, 30);
             this.comboBox_RuleType.TabIndex = 3;
             this.comboBox_RuleType.SelectedIndexChanged += new System.EventHandler(this.RuleType_ComboboxChanged);
             // 
@@ -505,10 +523,10 @@
             this.radioButton_Deny.AutoSize = true;
             this.radioButton_Deny.Font = new System.Drawing.Font("Tahoma", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.radioButton_Deny.ForeColor = System.Drawing.Color.Black;
-            this.radioButton_Deny.Location = new System.Drawing.Point(88, 130);
+            this.radioButton_Deny.Location = new System.Drawing.Point(106, 156);
             this.radioButton_Deny.Margin = new System.Windows.Forms.Padding(2);
             this.radioButton_Deny.Name = "radioButton_Deny";
-            this.radioButton_Deny.Size = new System.Drawing.Size(69, 25);
+            this.radioButton_Deny.Size = new System.Drawing.Size(84, 29);
             this.radioButton_Deny.TabIndex = 2;
             this.radioButton_Deny.TabStop = true;
             this.radioButton_Deny.Text = "Deny";
@@ -521,10 +539,10 @@
             this.radioButton_Allow.Checked = true;
             this.radioButton_Allow.Font = new System.Drawing.Font("Tahoma", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.radioButton_Allow.ForeColor = System.Drawing.Color.Black;
-            this.radioButton_Allow.Location = new System.Drawing.Point(8, 130);
+            this.radioButton_Allow.Location = new System.Drawing.Point(10, 156);
             this.radioButton_Allow.Margin = new System.Windows.Forms.Padding(2);
             this.radioButton_Allow.Name = "radioButton_Allow";
-            this.radioButton_Allow.Size = new System.Drawing.Size(72, 25);
+            this.radioButton_Allow.Size = new System.Drawing.Size(87, 29);
             this.radioButton_Allow.TabIndex = 1;
             this.radioButton_Allow.TabStop = true;
             this.radioButton_Allow.Text = "Allow";
@@ -534,11 +552,11 @@
             // textBox_ReferenceFile
             // 
             this.textBox_ReferenceFile.Font = new System.Drawing.Font("Tahoma", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.textBox_ReferenceFile.Location = new System.Drawing.Point(12, 334);
+            this.textBox_ReferenceFile.Location = new System.Drawing.Point(14, 401);
             this.textBox_ReferenceFile.Margin = new System.Windows.Forms.Padding(2);
             this.textBox_ReferenceFile.Name = "textBox_ReferenceFile";
             this.textBox_ReferenceFile.ReadOnly = true;
-            this.textBox_ReferenceFile.Size = new System.Drawing.Size(448, 26);
+            this.textBox_ReferenceFile.Size = new System.Drawing.Size(537, 29);
             this.textBox_ReferenceFile.TabIndex = 88;
             this.textBox_ReferenceFile.TextChanged += new System.EventHandler(this.ReferenceFileTextChanged);
             // 
@@ -549,10 +567,10 @@
             this.button_Browse.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.button_Browse.Font = new System.Drawing.Font("Tahoma", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.button_Browse.ForeColor = System.Drawing.Color.DodgerBlue;
-            this.button_Browse.Location = new System.Drawing.Point(464, 333);
+            this.button_Browse.Location = new System.Drawing.Point(557, 400);
             this.button_Browse.Margin = new System.Windows.Forms.Padding(2);
             this.button_Browse.Name = "button_Browse";
-            this.button_Browse.Size = new System.Drawing.Size(107, 28);
+            this.button_Browse.Size = new System.Drawing.Size(128, 34);
             this.button_Browse.TabIndex = 4;
             this.button_Browse.Text = "Browse";
             this.button_Browse.UseVisualStyleBackColor = false;
@@ -563,9 +581,10 @@
             this.label_condition.AutoSize = true;
             this.label_condition.Font = new System.Drawing.Font("Tahoma", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label_condition.ForeColor = System.Drawing.Color.Black;
-            this.label_condition.Location = new System.Drawing.Point(12, 310);
+            this.label_condition.Location = new System.Drawing.Point(14, 372);
+            this.label_condition.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label_condition.Name = "label_condition";
-            this.label_condition.Size = new System.Drawing.Size(104, 18);
+            this.label_condition.Size = new System.Drawing.Size(125, 22);
             this.label_condition.TabIndex = 87;
             this.label_condition.Text = "Reference File:";
             this.label_condition.TextAlign = System.Drawing.ContentAlignment.TopCenter;
@@ -573,9 +592,10 @@
             // checkBox_CustomPath
             // 
             this.checkBox_CustomPath.AutoSize = true;
-            this.checkBox_CustomPath.Location = new System.Drawing.Point(12, 363);
+            this.checkBox_CustomPath.Location = new System.Drawing.Point(14, 436);
+            this.checkBox_CustomPath.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.checkBox_CustomPath.Name = "checkBox_CustomPath";
-            this.checkBox_CustomPath.Size = new System.Drawing.Size(139, 21);
+            this.checkBox_CustomPath.Size = new System.Drawing.Size(160, 24);
             this.checkBox_CustomPath.TabIndex = 113;
             this.checkBox_CustomPath.Text = "Use Custom Path";
             this.checkBox_CustomPath.UseVisualStyleBackColor = true;
@@ -585,9 +605,10 @@
             // label_Error
             // 
             this.label_Error.AutoSize = true;
-            this.label_Error.Location = new System.Drawing.Point(125, 726);
+            this.label_Error.Location = new System.Drawing.Point(150, 871);
+            this.label_Error.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label_Error.Name = "label_Error";
-            this.label_Error.Size = new System.Drawing.Size(78, 17);
+            this.label_Error.Size = new System.Drawing.Size(86, 20);
             this.label_Error.TabIndex = 87;
             this.label_Error.Text = "label_Error";
             this.label_Error.Visible = false;
@@ -599,10 +620,10 @@
             this.button_CreateRule.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.button_CreateRule.Font = new System.Drawing.Font("Tahoma", 8.5F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.button_CreateRule.ForeColor = System.Drawing.Color.Black;
-            this.button_CreateRule.Location = new System.Drawing.Point(533, 786);
+            this.button_CreateRule.Location = new System.Drawing.Point(640, 943);
             this.button_CreateRule.Margin = new System.Windows.Forms.Padding(2);
             this.button_CreateRule.Name = "button_CreateRule";
-            this.button_CreateRule.Size = new System.Drawing.Size(110, 30);
+            this.button_CreateRule.Size = new System.Drawing.Size(132, 36);
             this.button_CreateRule.TabIndex = 92;
             this.button_CreateRule.Text = "Create Rule";
             this.button_CreateRule.UseVisualStyleBackColor = false;
@@ -615,10 +636,10 @@
             this.button_Next.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.button_Next.Font = new System.Drawing.Font("Tahoma", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.button_Next.ForeColor = System.Drawing.Color.Black;
-            this.button_Next.Location = new System.Drawing.Point(647, 786);
+            this.button_Next.Location = new System.Drawing.Point(776, 943);
             this.button_Next.Margin = new System.Windows.Forms.Padding(2);
             this.button_Next.Name = "button_Next";
-            this.button_Next.Size = new System.Drawing.Size(99, 30);
+            this.button_Next.Size = new System.Drawing.Size(119, 36);
             this.button_Next.TabIndex = 107;
             this.button_Next.Text = "Next >";
             this.button_Next.UseVisualStyleBackColor = false;
@@ -631,19 +652,20 @@
             this.control_Panel.Controls.Add(this.page2_Button);
             this.control_Panel.Controls.Add(this.page1_Button);
             this.control_Panel.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.control_Panel.Location = new System.Drawing.Point(0, 61);
-            this.control_Panel.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.control_Panel.Location = new System.Drawing.Point(0, 73);
+            this.control_Panel.Margin = new System.Windows.Forms.Padding(4, 2, 4, 2);
             this.control_Panel.Name = "control_Panel";
-            this.control_Panel.Size = new System.Drawing.Size(123, 640);
+            this.control_Panel.Size = new System.Drawing.Size(148, 768);
             this.control_Panel.TabIndex = 108;
             // 
             // workflow_Label
             // 
             this.workflow_Label.AutoSize = true;
             this.workflow_Label.Font = new System.Drawing.Font("Tahoma", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.workflow_Label.Location = new System.Drawing.Point(11, 9);
+            this.workflow_Label.Location = new System.Drawing.Point(13, 11);
+            this.workflow_Label.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.workflow_Label.Name = "workflow_Label";
-            this.workflow_Label.Size = new System.Drawing.Size(82, 21);
+            this.workflow_Label.Size = new System.Drawing.Size(95, 24);
             this.workflow_Label.TabIndex = 40;
             this.workflow_Label.Text = "File Rules";
             // 
@@ -659,10 +681,10 @@
             this.page2_Button.Font = new System.Drawing.Font("Tahoma", 9.5F);
             this.page2_Button.ForeColor = System.Drawing.SystemColors.ControlDarkDark;
             this.page2_Button.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            this.page2_Button.Location = new System.Drawing.Point(12, 150);
-            this.page2_Button.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.page2_Button.Location = new System.Drawing.Point(14, 180);
+            this.page2_Button.Margin = new System.Windows.Forms.Padding(4, 2, 4, 2);
             this.page2_Button.Name = "page2_Button";
-            this.page2_Button.Size = new System.Drawing.Size(122, 60);
+            this.page2_Button.Size = new System.Drawing.Size(146, 72);
             this.page2_Button.TabIndex = 36;
             this.page2_Button.Text = "Rule Exceptions";
             this.page2_Button.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -679,10 +701,10 @@
             this.page1_Button.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.page1_Button.Font = new System.Drawing.Font("Tahoma", 9.5F);
             this.page1_Button.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            this.page1_Button.Location = new System.Drawing.Point(12, 69);
-            this.page1_Button.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.page1_Button.Location = new System.Drawing.Point(14, 83);
+            this.page1_Button.Margin = new System.Windows.Forms.Padding(4, 2, 4, 2);
             this.page1_Button.Name = "page1_Button";
-            this.page1_Button.Size = new System.Drawing.Size(120, 52);
+            this.page1_Button.Size = new System.Drawing.Size(144, 62);
             this.page1_Button.TabIndex = 35;
             this.page1_Button.Text = "Rule Conditions";
             this.page1_Button.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -691,9 +713,10 @@
             // controlHighlight_Panel
             // 
             this.controlHighlight_Panel.BackColor = System.Drawing.Color.CornflowerBlue;
-            this.controlHighlight_Panel.Location = new System.Drawing.Point(3, 140);
+            this.controlHighlight_Panel.Location = new System.Drawing.Point(4, 168);
+            this.controlHighlight_Panel.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.controlHighlight_Panel.Name = "controlHighlight_Panel";
-            this.controlHighlight_Panel.Size = new System.Drawing.Size(8, 35);
+            this.controlHighlight_Panel.Size = new System.Drawing.Size(10, 42);
             this.controlHighlight_Panel.TabIndex = 33;
             // 
             // headerLabel
@@ -701,9 +724,10 @@
             this.headerLabel.AutoSize = true;
             this.headerLabel.Font = new System.Drawing.Font("Tahoma", 11.5F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.headerLabel.ForeColor = System.Drawing.Color.Black;
-            this.headerLabel.Location = new System.Drawing.Point(17, 19);
+            this.headerLabel.Location = new System.Drawing.Point(20, 23);
+            this.headerLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.headerLabel.Name = "headerLabel";
-            this.headerLabel.Size = new System.Drawing.Size(249, 24);
+            this.headerLabel.Size = new System.Drawing.Size(290, 28);
             this.headerLabel.TabIndex = 109;
             this.headerLabel.Text = "Custom Rule Conditions";
             this.headerLabel.TextAlign = System.Drawing.ContentAlignment.TopCenter;
@@ -713,8 +737,9 @@
             this.headerPanel.BackColor = System.Drawing.Color.White;
             this.headerPanel.Controls.Add(this.headerLabel);
             this.headerPanel.Location = new System.Drawing.Point(0, 0);
+            this.headerPanel.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.headerPanel.Name = "headerPanel";
-            this.headerPanel.Size = new System.Drawing.Size(735, 62);
+            this.headerPanel.Size = new System.Drawing.Size(882, 74);
             this.headerPanel.TabIndex = 109;
             // 
             // button_AddException
@@ -725,10 +750,10 @@
             this.button_AddException.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.button_AddException.Font = new System.Drawing.Font("Tahoma", 8.5F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.button_AddException.ForeColor = System.Drawing.Color.Gray;
-            this.button_AddException.Location = new System.Drawing.Point(419, 786);
+            this.button_AddException.Location = new System.Drawing.Point(503, 943);
             this.button_AddException.Margin = new System.Windows.Forms.Padding(2);
             this.button_AddException.Name = "button_AddException";
-            this.button_AddException.Size = new System.Drawing.Size(110, 30);
+            this.button_AddException.Size = new System.Drawing.Size(132, 36);
             this.button_AddException.TabIndex = 111;
             this.button_AddException.Text = "Add Exception";
             this.button_AddException.UseVisualStyleBackColor = false;
@@ -742,10 +767,10 @@
             this.button_Back.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.button_Back.Font = new System.Drawing.Font("Tahoma", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.button_Back.ForeColor = System.Drawing.Color.Gray;
-            this.button_Back.Location = new System.Drawing.Point(316, 786);
+            this.button_Back.Location = new System.Drawing.Point(379, 943);
             this.button_Back.Margin = new System.Windows.Forms.Padding(2);
             this.button_Back.Name = "button_Back";
-            this.button_Back.Size = new System.Drawing.Size(99, 30);
+            this.button_Back.Size = new System.Drawing.Size(119, 36);
             this.button_Back.TabIndex = 110;
             this.button_Back.Text = "< Back";
             this.button_Back.UseVisualStyleBackColor = false;
@@ -757,12 +782,24 @@
             this.backgroundWorker.ProgressChanged += new System.ComponentModel.ProgressChangedEventHandler(this.backgroundWorker_ProgressChanged);
             this.backgroundWorker.RunWorkerCompleted += new System.ComponentModel.RunWorkerCompletedEventHandler(this.backgroundWorker_RunWorkerCompleted);
             // 
+            // checkBox_CustomPFN
+            // 
+            this.checkBox_CustomPFN.AutoSize = true;
+            this.checkBox_CustomPFN.Location = new System.Drawing.Point(8, 91);
+            this.checkBox_CustomPFN.Margin = new System.Windows.Forms.Padding(4);
+            this.checkBox_CustomPFN.Name = "checkBox_CustomPFN";
+            this.checkBox_CustomPFN.Size = new System.Drawing.Size(238, 24);
+            this.checkBox_CustomPFN.TabIndex = 119;
+            this.checkBox_CustomPFN.Text = "Use Custom Package Family";
+            this.checkBox_CustomPFN.UseVisualStyleBackColor = true;
+            this.checkBox_CustomPFN.CheckedChanged += new System.EventHandler(this.Checkbox_CustomPFN_Checked);
+            // 
             // CustomRuleConditionsPanel
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(120F, 120F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(144F, 144F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.Color.White;
-            this.ClientSize = new System.Drawing.Size(766, 827);
+            this.ClientSize = new System.Drawing.Size(919, 992);
             this.Controls.Add(this.button_AddException);
             this.Controls.Add(this.button_Back);
             this.Controls.Add(this.headerPanel);
@@ -773,7 +810,7 @@
             this.Controls.Add(this.panel_CustomRules);
             this.Controls.Add(this.button_CreateRule);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-            this.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.Margin = new System.Windows.Forms.Padding(4, 2, 4, 2);
             this.Name = "CustomRuleConditionsPanel";
             this.Text = "Custom Rules ";
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.CustomRulesPanel_FormClosing);
@@ -851,5 +888,6 @@
         private System.Windows.Forms.Label label_Progress;
         private System.Windows.Forms.PictureBox pictureBox_Progress;
         private System.ComponentModel.BackgroundWorker backgroundWorker;
+        private System.Windows.Forms.CheckBox checkBox_CustomPFN;
     }
 }

--- a/WDAC-Policy-Wizard/app/src/CustomRuleConditionsPanel.cs
+++ b/WDAC-Policy-Wizard/app/src/CustomRuleConditionsPanel.cs
@@ -1457,6 +1457,7 @@ namespace WDAC_Wizard
                 string arbitraryPFN = this.textBox_Packaged_App.Text; 
                 if(arbitraryPFN.Length > 3)
                 {
+                    arbitraryPFN = String.Concat(arbitraryPFN.Where(c => !Char.IsWhiteSpace(c)));
                     this.checkedListBoxPackagedApps.Items.Add(arbitraryPFN, true);
 
                     // Once added to the table, clear the textbox automatically
@@ -1552,11 +1553,33 @@ namespace WDAC_Wizard
 
             // Else, return text to 'Search' button
             // Unhide the PFN search UI
+            // If there are any checked boxes, clear the list of arbitrary/custom PFN rules after prompting user
             else
             {
-                this.buttonSearch.Text = "Search";
-                this.PolicyCustomRule.UsingCustomValues = false;
+                if(this.checkedListBoxPackagedApps.Items.Count > 0)
+                {
+                    DialogResult res = MessageBox.Show("You have active custom PFN rules that will be deleted. Are you sure you want to switch to default PFN rule creation?", "Confirmation",
+                    MessageBoxButtons.YesNo, MessageBoxIcon.Question);
+
+                    if (res == DialogResult.Yes)
+                    {
+                        this.buttonSearch.Text = "Search";
+                        this.PolicyCustomRule.UsingCustomValues = false;
+                        int n_Rules = this.checkedListBoxPackagedApps.Items.Count; 
+
+                        for(int j= 0; j < n_Rules; j++)
+                        {
+                            // Remove at the 0th index n_Rules times
+                            this.checkedListBoxPackagedApps.Items.RemoveAt(0); 
+                        }
+                    }
+                    else
+                    {
+                        this.checkBox_CustomPFN.Checked = true; 
+                    }
+                }
             }
         }
-    }   
-}
+    }
+}   
+

--- a/WDAC-Policy-Wizard/app/src/CustomRuleConditionsPanel.cs
+++ b/WDAC-Policy-Wizard/app/src/CustomRuleConditionsPanel.cs
@@ -164,8 +164,14 @@ namespace WDAC_Wizard
                     }
                 }
 
+                // Parse package family names into PolicyCustomRule.CustomValues.PackageFamilyNames
+                if (this.PolicyCustomRule.Level == PolicyCustomRules.RuleLevel.PackagedFamilyName)
+                {
+                    this.PolicyCustomRule.CustomValues.PackageFamilyNames = this.PolicyCustomRule.PackagedFamilyNames;
+                }
+
                 // Parse hashes into PolicyCustomRule.CustomValues.Hash
-                if(this.PolicyCustomRule.Type == PolicyCustomRules.RuleType.Hash)
+                if (this.PolicyCustomRule.Type == PolicyCustomRules.RuleType.Hash)
                 {
                     var hashList = this.richTextBox_CustomHashes.Text.Split(',');
                     foreach(var hash in hashList)
@@ -1429,16 +1435,40 @@ namespace WDAC_Wizard
                 return;
             }
 
-            // Prep UI
-            this.panel_Progress.Visible = true;
-            this.panel_Progress.BringToFront(); 
-            this.label_Error.Visible = false;
-
-            // Create background worker to display updates to UI
-            if (!this.backgroundWorker.IsBusy)
+            // Check whether we are creating a PFN based on arbitrary package name
+            if(!this.checkBox_CustomPFN.Checked)
             {
-                this.backgroundWorker.RunWorkerAsync();
+                // Searching for PFN on device
+                // Prep UI
+                this.panel_Progress.Visible = true;
+                this.panel_Progress.BringToFront();
+                this.label_Error.Visible = false;
+
+                // Create background worker to display updates to UI
+                if (!this.backgroundWorker.IsBusy)
+                {
+                    this.backgroundWorker.RunWorkerAsync();
+                }
             }
+            else
+            {
+                // Using arbitrary/custom PFN in rule creation
+                // Add PFN to list with checkbox checked
+                string arbitraryPFN = this.textBox_Packaged_App.Text; 
+                if(arbitraryPFN.Length > 3)
+                {
+                    this.checkedListBoxPackagedApps.Items.Add(arbitraryPFN, true);
+
+                    // Once added to the table, clear the textbox automatically
+                    this.textBox_Packaged_App.Clear(); 
+                }
+                else
+                {
+                    this.label_Error.Visible = true;
+                    this.label_Error.Text = "Package Family name must be at least 3 characters.";
+                }
+            }
+            
         }
 
         private void backgroundWorker_ProgressChanged(object sender, ProgressChangedEventArgs e)
@@ -1508,6 +1538,25 @@ namespace WDAC_Wizard
                 this.checkedListBoxPackagedApps.Items.Add(key, false);
             }
             //foreach($i in $package){$Rule += New-CIPolicyRule -Package $i} - in MainForm to resolve conflicts
+        }
+
+        private void Checkbox_CustomPFN_Checked(object sender, EventArgs e)
+        {
+            // If checked, update text on the 'Search' button
+            // Hide the PFN search UI
+            if(this.checkBox_CustomPFN.Checked)
+            {
+                this.buttonSearch.Text = "Create";
+                this.PolicyCustomRule.UsingCustomValues = true; 
+            }
+
+            // Else, return text to 'Search' button
+            // Unhide the PFN search UI
+            else
+            {
+                this.buttonSearch.Text = "Search";
+                this.PolicyCustomRule.UsingCustomValues = false;
+            }
         }
     }   
 }

--- a/WDAC-Policy-Wizard/app/src/Helper.cs
+++ b/WDAC-Policy-Wizard/app/src/Helper.cs
@@ -690,13 +690,14 @@ namespace WDAC_Wizard
         public string Description;
         public string InternalName;
         public string Path;
+        public List<string> PackageFamilyNames; 
         public List<string> Hashes; 
 
         public CustomValue()
         {
             this.Hashes = new List<string>();
+            this.PackageFamilyNames = new List<string>();
         }
-
     }
 
     public class PolicyCustomRules


### PR DESCRIPTION
You can now create PFN rules based on plain text (i.e. the package does not need to be on the device). Simply select the "Use Custom Package Family", enter the name of the package in the text field and select the Create button. The Wizard will handle the rest. 

The Wizard supports many packages in one single rule. There is no need to append each package to the table, though this is also supported, but rather a bulk add to the table. In either case, the output of the Wizard is N number of custom PFN rules. 


![image](https://user-images.githubusercontent.com/23045608/127901185-9eb58650-2001-4e37-9934-20eb4516e8e8.png)
