### PR TITLE
User selecting Cancel during OpenFile crashes the wizard

### DIFF
--- a/WDAC-Policy-Wizard/app/src/CustomRuleConditionsPanel.cs
+++ b/WDAC-Policy-Wizard/app/src/CustomRuleConditionsPanel.cs
@@ -710,8 +710,12 @@ namespace WDAC_Wizard
                     // UI
                     this.textBox_ReferenceFile.Text = PolicyCustomRule.ReferenceFile;
                     // Show right side of the text
-                    this.textBox_ReferenceFile.SelectionStart = this.textBox_ReferenceFile.TextLength - 1;
-                    this.textBox_ReferenceFile.ScrollToCaret();
+                    if(this.textBox_ReferenceFile.TextLength > 0)
+                    {
+                        this.textBox_ReferenceFile.SelectionStart = this.textBox_ReferenceFile.TextLength - 1;
+                        this.textBox_ReferenceFile.ScrollToCaret();
+                    }
+                    
                     this.labelSlider_0.Text = "Issuing CA:";
                     this.labelSlider_1.Text = "Publisher:";
                     this.labelSlider_2.Text = "Min version:";
@@ -759,8 +763,12 @@ namespace WDAC_Wizard
                     this.textBox_ReferenceFile.Text = this.PolicyCustomRule.ReferenceFile;
 
                     // Show right side of the text
-                    this.textBox_ReferenceFile.SelectionStart = this.textBox_ReferenceFile.TextLength - 1;
-                    this.textBox_ReferenceFile.ScrollToCaret();
+                    if(this.textBox_ReferenceFile.TextLength > 0)
+                    {
+                        this.textBox_ReferenceFile.SelectionStart = this.textBox_ReferenceFile.TextLength - 1;
+                        this.textBox_ReferenceFile.ScrollToCaret();
+                    }
+                    
                     break;
 
 
@@ -772,9 +780,12 @@ namespace WDAC_Wizard
                     radioButton_File.Checked = true;
                     this.textBox_ReferenceFile.Text = PolicyCustomRule.ReferenceFile;
                     // Show right side of the text
-                    this.textBox_ReferenceFile.SelectionStart = this.textBox_ReferenceFile.TextLength - 1;
-                    this.textBox_ReferenceFile.ScrollToCaret();
-
+                    if(this.textBox_ReferenceFile.TextLength > 0)
+                    {
+                        this.textBox_ReferenceFile.SelectionStart = this.textBox_ReferenceFile.TextLength - 1;
+                        this.textBox_ReferenceFile.ScrollToCaret();
+                    }
+                    
                     panel_Publisher_Scroll.Visible = false;
                     break;
 
@@ -784,9 +795,12 @@ namespace WDAC_Wizard
                     // UI 
                     this.textBox_ReferenceFile.Text = PolicyCustomRule.ReferenceFile;
                     // Show right side of the text
-                    this.textBox_ReferenceFile.SelectionStart = this.textBox_ReferenceFile.TextLength - 1;
-                    this.textBox_ReferenceFile.ScrollToCaret();
-
+                    if(this.textBox_ReferenceFile.TextLength > 0)
+                    {
+                        this.textBox_ReferenceFile.SelectionStart = this.textBox_ReferenceFile.TextLength - 1;
+                        this.textBox_ReferenceFile.ScrollToCaret();
+                    }
+                    
                     this.labelSlider_0.Text = "Original filename:";
                     this.labelSlider_1.Text = "File description:";
                     this.labelSlider_2.Text = "Product name:";
@@ -819,8 +833,12 @@ namespace WDAC_Wizard
                     panel_Publisher_Scroll.Visible = false;
                     this.textBox_ReferenceFile.Text = PolicyCustomRule.ReferenceFile;
                     // Show right side of the text
-                    this.textBox_ReferenceFile.SelectionStart = this.textBox_ReferenceFile.TextLength - 1;
-                    this.textBox_ReferenceFile.ScrollToCaret();
+                    if(this.textBox_ReferenceFile.TextLength > 0)
+                    {
+                        this.textBox_ReferenceFile.SelectionStart = this.textBox_ReferenceFile.TextLength - 1;
+                        this.textBox_ReferenceFile.ScrollToCaret();
+                    }
+                    
                     break;
             }
 

--- a/WDAC-Policy-Wizard/app/src/Exceptions_Control.cs
+++ b/WDAC-Policy-Wizard/app/src/Exceptions_Control.cs
@@ -174,10 +174,12 @@ namespace WDAC_Wizard
                     // UI
                     this.textBox_ReferenceFile.Text = ExceptionRule.ReferenceFile;
                     // Show right side of the text
-                    this.textBox_ReferenceFile.SelectionStart = this.textBox_ReferenceFile.TextLength - 1;
-                    this.textBox_ReferenceFile.ScrollToCaret();
-                    break;
-
+                    if(this.textBox_ReferenceFile.TextLength > 0)
+                    {
+                        this.textBox_ReferenceFile.SelectionStart = this.textBox_ReferenceFile.TextLength - 1;
+                        this.textBox_ReferenceFile.ScrollToCaret();
+                    }
+                    
                     labelSlider_0.Text = "Issuing CA:";
                     labelSlider_1.Text = "Publisher:";
                     labelSlider_2.Text = "File version:";
@@ -206,8 +208,12 @@ namespace WDAC_Wizard
 
                     this.textBox_ReferenceFile.Text = ExceptionRule.ReferenceFile;
                     // Show right side of the text
-                    this.textBox_ReferenceFile.SelectionStart = this.textBox_ReferenceFile.TextLength - 1;
-                    this.textBox_ReferenceFile.ScrollToCaret();
+                    if(this.textBox_ReferenceFile.TextLength > 0)
+                    {
+                        this.textBox_ReferenceFile.SelectionStart = this.textBox_ReferenceFile.TextLength - 1;
+                        this.textBox_ReferenceFile.ScrollToCaret();
+                    }
+                    
                     //ProcessAllFiles(ExceptionRule.ReferenceFile);
                     //ExceptionRule.FolderContents = this.AllFilesinFolder; 
                     this.ExceptionRule.SetRuleLevel(PolicyCustomRules.RuleLevel.Folder);
@@ -222,9 +228,12 @@ namespace WDAC_Wizard
                     radioButton_File.Checked = true;
                     this.textBox_ReferenceFile.Text = ExceptionRule.ReferenceFile;
                     // Show right side of the text
-                    this.textBox_ReferenceFile.SelectionStart = this.textBox_ReferenceFile.TextLength - 1;
-                    this.textBox_ReferenceFile.ScrollToCaret();
-
+                    if(this.textBox_ReferenceFile.TextLength > 0)
+                    {
+                        this.textBox_ReferenceFile.SelectionStart = this.textBox_ReferenceFile.TextLength - 1;
+                        this.textBox_ReferenceFile.ScrollToCaret();
+                    }
+                   
                     panel_Publisher_Scroll.Visible = false;
                     break;
 
@@ -234,8 +243,12 @@ namespace WDAC_Wizard
                     // UI 
                     this.textBox_ReferenceFile.Text = ExceptionRule.ReferenceFile;
                     // Show right side of the text
-                    this.textBox_ReferenceFile.SelectionStart = this.textBox_ReferenceFile.TextLength - 1;
-                    this.textBox_ReferenceFile.ScrollToCaret();
+                    if (this.textBox_ReferenceFile.TextLength > 0)
+                    {
+                        this.textBox_ReferenceFile.SelectionStart = this.textBox_ReferenceFile.TextLength - 1;
+                        this.textBox_ReferenceFile.ScrollToCaret();
+                    }
+
                     labelSlider_0.Text = "Original filename:";
                     labelSlider_1.Text = "File description:";
                     labelSlider_2.Text = "Product name:";
@@ -258,9 +271,12 @@ namespace WDAC_Wizard
                     panel_Publisher_Scroll.Visible = false;
                     this.textBox_ReferenceFile.Text = ExceptionRule.ReferenceFile;
                     // Show right side of the text
-                    this.textBox_ReferenceFile.SelectionStart = this.textBox_ReferenceFile.TextLength - 1;
-                    this.textBox_ReferenceFile.ScrollToCaret();
-                    
+                    if (this.textBox_ReferenceFile.TextLength > 0)
+                    {
+                        this.textBox_ReferenceFile.SelectionStart = this.textBox_ReferenceFile.TextLength - 1;
+                        this.textBox_ReferenceFile.ScrollToCaret();
+                    }
+
                     break;
             }
         }

--- a/WDAC-Policy-Wizard/app/src/PolicyMerge_Control.cs
+++ b/WDAC-Policy-Wizard/app/src/PolicyMerge_Control.cs
@@ -123,6 +123,11 @@ namespace WDAC_Wizard.src
             }
         }
 
+        /// <summary>
+        /// User selected the Remove Policy button. Remove the selected rows from the table
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
         private void Button_RemovePolicy_Click(object sender, EventArgs e)
         {
             this.Log.AddInfoMsg("-- Delete Rule button clicked -- ");

--- a/WDAC-Policy-Wizard/app/src/PolicyMerge_Control.cs
+++ b/WDAC-Policy-Wizard/app/src/PolicyMerge_Control.cs
@@ -54,11 +54,13 @@ namespace WDAC_Wizard.src
                 this.mergePolicyPath = policyPath;
                 this.finalPolicyTextBox.Text = policyPath;
                 // Show right side of the text
-                this.finalPolicyTextBox.SelectionStart = this.finalPolicyTextBox.TextLength - 1;
-                this.finalPolicyTextBox.ScrollToCaret();
+                if(this.finalPolicyTextBox.TextLength > 0)
+                {
+                    this.finalPolicyTextBox.SelectionStart = this.finalPolicyTextBox.TextLength - 1;
+                    this.finalPolicyTextBox.ScrollToCaret();
+                }
 
                 this._MainWindow.Policy.SchemaPath = this.mergePolicyPath;
-
                 this.Log.AddInfoMsg(String.Format("Final Merge Policy set to: {0}", policyPath));
 
                 if(this.nPolicies >= 2)

--- a/WDAC-Policy-Wizard/app/src/PolicyType.cs
+++ b/WDAC-Policy-Wizard/app/src/PolicyType.cs
@@ -318,9 +318,11 @@ namespace WDAC_Wizard
         {
             // Save dialog box pressed
             string policyPath = Helper.SaveSingleFile(Properties.Resources.SaveXMLFileDialogTitle, Helper.BrowseFileType.Policy);
-            if(String.IsNullOrEmpty(policyPath))
+
+            // If cancel button is selected by user, or path does not exist prevent unhandled error
+            if (String.IsNullOrEmpty(policyPath))
             {
-                return; 
+                return;
             }
 
             this._MainWindow.Policy.SchemaPath = policyPath;

--- a/WDAC-Policy-Wizard/app/src/PolicyType.cs
+++ b/WDAC-Policy-Wizard/app/src/PolicyType.cs
@@ -110,9 +110,12 @@ namespace WDAC_Wizard
             this.textBoxBasePolicyPath.Text = policyPath;
 
             // Show right side of the text
-            this.textBoxBasePolicyPath.SelectionStart = this.textBoxBasePolicyPath.TextLength - 1;
-            this.textBoxBasePolicyPath.ScrollToCaret();
-
+            if(this.textBoxBasePolicyPath.TextLength > 0)
+            {
+                this.textBoxBasePolicyPath.SelectionStart = this.textBoxBasePolicyPath.TextLength - 1;
+                this.textBoxBasePolicyPath.ScrollToCaret();
+            }
+            
             // User has modified the supplemental policy from original, force restart flow
             if (this._MainWindow.Policy.BaseToSupplementPath != this.BaseToSupplementPath)
             {
@@ -268,9 +271,12 @@ namespace WDAC_Wizard
                 // These will trigger the textChange events
                 this.textBoxSuppPath.Text = this._Policy.SchemaPath;
                 // Show right side of the text
-                this.textBoxSuppPath.SelectionStart = this.textBoxSuppPath.TextLength - 1;
-                this.textBoxSuppPath.ScrollToCaret();
-
+                if(this.textBoxSuppPath.TextLength > 0)
+                {
+                    this.textBoxSuppPath.SelectionStart = this.textBoxSuppPath.TextLength - 1;
+                    this.textBoxSuppPath.ScrollToCaret();
+                }
+                
                 this.textBox_PolicyName.Text = this._Policy.PolicyName;
                 this._MainWindow.Policy.SchemaPath = this._Policy.SchemaPath;
 
@@ -329,8 +335,11 @@ namespace WDAC_Wizard
             this.textBoxSuppPath.Text = policyPath;
 
             // Show right side of the text
-            this.textBoxSuppPath.SelectionStart = this.textBoxSuppPath.TextLength - 1;
-            this.textBoxSuppPath.ScrollToCaret();
+            if(this.textBoxSuppPath.TextLength > 0)
+            {
+                this.textBoxSuppPath.SelectionStart = this.textBoxSuppPath.TextLength - 1;
+                this.textBoxSuppPath.ScrollToCaret();
+            }
 
             // Show panel if path is set
             this.panelSuppl_Base.Visible = true; 

--- a/WDAC-Policy-Wizard/app/src/TemplatePage.Designer.cs
+++ b/WDAC-Policy-Wizard/app/src/TemplatePage.Designer.cs
@@ -63,7 +63,7 @@ namespace WDAC_Wizard
             this.label5 = new System.Windows.Forms.Label();
             this.policyInfoPanel = new System.Windows.Forms.Panel();
             this.label1 = new System.Windows.Forms.Label();
-            this.label3 = new System.Windows.Forms.Label();
+            this.label_LearnMore = new System.Windows.Forms.Label();
             this.panel2.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.allowMsft_Button)).BeginInit();
             this.panel1.SuspendLayout();
@@ -86,20 +86,20 @@ namespace WDAC_Wizard
             this.panel2.Controls.Add(this.pictureBox6);
             this.panel2.Controls.Add(this.label7);
             this.panel2.Controls.Add(this.label_PolicyFour);
-            this.panel2.Location = new System.Drawing.Point(590, 101);
-            this.panel2.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.panel2.Location = new System.Drawing.Point(492, 84);
+            this.panel2.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.panel2.Name = "panel2";
-            this.panel2.Size = new System.Drawing.Size(394, 528);
+            this.panel2.Size = new System.Drawing.Size(329, 440);
             this.panel2.TabIndex = 1;
             // 
             // allowMsft_Button
             // 
             this.allowMsft_Button.BackgroundImage = global::WDAC_Wizard.Properties.Resources.radio_off;
             this.allowMsft_Button.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
-            this.allowMsft_Button.Location = new System.Drawing.Point(175, 467);
-            this.allowMsft_Button.Margin = new System.Windows.Forms.Padding(2, 4, 2, 4);
+            this.allowMsft_Button.Location = new System.Drawing.Point(146, 389);
+            this.allowMsft_Button.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.allowMsft_Button.Name = "allowMsft_Button";
-            this.allowMsft_Button.Size = new System.Drawing.Size(36, 36);
+            this.allowMsft_Button.Size = new System.Drawing.Size(30, 30);
             this.allowMsft_Button.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
             this.allowMsft_Button.TabIndex = 99;
             this.allowMsft_Button.TabStop = false;
@@ -111,35 +111,35 @@ namespace WDAC_Wizard
             // 
             this.panel1.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.panel1.Controls.Add(this.panel4);
-            this.panel1.Location = new System.Drawing.Point(450, 0);
-            this.panel1.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.panel1.Location = new System.Drawing.Point(375, 0);
+            this.panel1.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.panel1.Name = "panel1";
-            this.panel1.Size = new System.Drawing.Size(448, 814);
+            this.panel1.Size = new System.Drawing.Size(374, 679);
             this.panel1.TabIndex = 3;
             // 
             // panel4
             // 
-            this.panel4.Location = new System.Drawing.Point(458, 5);
-            this.panel4.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.panel4.Location = new System.Drawing.Point(382, 4);
+            this.panel4.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.panel4.Name = "panel4";
-            this.panel4.Size = new System.Drawing.Size(450, 815);
+            this.panel4.Size = new System.Drawing.Size(375, 679);
             this.panel4.TabIndex = 2;
             // 
             // panel3
             // 
-            this.panel3.Location = new System.Drawing.Point(458, 5);
-            this.panel3.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.panel3.Location = new System.Drawing.Point(382, 4);
+            this.panel3.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.panel3.Name = "panel3";
-            this.panel3.Size = new System.Drawing.Size(450, 815);
+            this.panel3.Size = new System.Drawing.Size(375, 679);
             this.panel3.TabIndex = 2;
             // 
             // pictureBox6
             // 
             this.pictureBox6.Image = global::WDAC_Wizard.Properties.Resources.windows_logo;
-            this.pictureBox6.Location = new System.Drawing.Point(132, 125);
-            this.pictureBox6.Margin = new System.Windows.Forms.Padding(2, 4, 2, 4);
+            this.pictureBox6.Location = new System.Drawing.Point(110, 104);
+            this.pictureBox6.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.pictureBox6.Name = "pictureBox6";
-            this.pictureBox6.Size = new System.Drawing.Size(122, 88);
+            this.pictureBox6.Size = new System.Drawing.Size(102, 73);
             this.pictureBox6.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
             this.pictureBox6.TabIndex = 14;
             this.pictureBox6.TabStop = false;
@@ -149,10 +149,9 @@ namespace WDAC_Wizard
             this.label7.AutoSize = true;
             this.label7.Font = new System.Drawing.Font("Tahoma", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label7.ForeColor = System.Drawing.Color.Black;
-            this.label7.Location = new System.Drawing.Point(22, 240);
-            this.label7.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label7.Location = new System.Drawing.Point(18, 200);
             this.label7.Name = "label7";
-            this.label7.Size = new System.Drawing.Size(347, 175);
+            this.label7.Size = new System.Drawing.Size(274, 147);
             this.label7.TabIndex = 17;
             this.label7.Text = resources.GetString("label7.Text");
             // 
@@ -161,10 +160,9 @@ namespace WDAC_Wizard
             this.label_PolicyFour.AutoSize = true;
             this.label_PolicyFour.Font = new System.Drawing.Font("Tahoma", 11.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label_PolicyFour.ForeColor = System.Drawing.Color.Black;
-            this.label_PolicyFour.Location = new System.Drawing.Point(62, 67);
-            this.label_PolicyFour.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label_PolicyFour.Location = new System.Drawing.Point(52, 56);
             this.label_PolicyFour.Name = "label_PolicyFour";
-            this.label_PolicyFour.Size = new System.Drawing.Size(262, 28);
+            this.label_PolicyFour.Size = new System.Drawing.Size(218, 23);
             this.label_PolicyFour.TabIndex = 8;
             this.label_PolicyFour.Text = "Allow Microsoft Mode";
             // 
@@ -172,10 +170,10 @@ namespace WDAC_Wizard
             // 
             this.windowsWorks_Button.BackgroundImage = global::WDAC_Wizard.Properties.Resources.radio_off;
             this.windowsWorks_Button.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
-            this.windowsWorks_Button.Location = new System.Drawing.Point(179, 467);
-            this.windowsWorks_Button.Margin = new System.Windows.Forms.Padding(2, 4, 2, 4);
+            this.windowsWorks_Button.Location = new System.Drawing.Point(149, 389);
+            this.windowsWorks_Button.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.windowsWorks_Button.Name = "windowsWorks_Button";
-            this.windowsWorks_Button.Size = new System.Drawing.Size(36, 36);
+            this.windowsWorks_Button.Size = new System.Drawing.Size(30, 30);
             this.windowsWorks_Button.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
             this.windowsWorks_Button.TabIndex = 98;
             this.windowsWorks_Button.TabStop = false;
@@ -186,10 +184,10 @@ namespace WDAC_Wizard
             // pictureBox5
             // 
             this.pictureBox5.Image = global::WDAC_Wizard.Properties.Resources.office;
-            this.pictureBox5.Location = new System.Drawing.Point(136, 125);
-            this.pictureBox5.Margin = new System.Windows.Forms.Padding(2, 4, 2, 4);
+            this.pictureBox5.Location = new System.Drawing.Point(113, 104);
+            this.pictureBox5.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.pictureBox5.Name = "pictureBox5";
-            this.pictureBox5.Size = new System.Drawing.Size(122, 88);
+            this.pictureBox5.Size = new System.Drawing.Size(102, 73);
             this.pictureBox5.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
             this.pictureBox5.TabIndex = 14;
             this.pictureBox5.TabStop = false;
@@ -199,10 +197,9 @@ namespace WDAC_Wizard
             this.label2.AutoSize = true;
             this.label2.Font = new System.Drawing.Font("Tahoma", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label2.ForeColor = System.Drawing.Color.Black;
-            this.label2.Location = new System.Drawing.Point(28, 240);
-            this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label2.Location = new System.Drawing.Point(23, 200);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(336, 150);
+            this.label2.Size = new System.Drawing.Size(269, 126);
             this.label2.TabIndex = 8;
             this.label2.Text = "Default Windows Mode authorizes:\r\n\r\n   - Windows OS components\r\n   - Microsoft St" +
     "ore applications\r\n   - Office 365, OneDrive, Teams\r\n   - WHQL signed kernel driv" +
@@ -213,10 +210,9 @@ namespace WDAC_Wizard
             this.label_PolicyOne.AutoSize = true;
             this.label_PolicyOne.Font = new System.Drawing.Font("Tahoma", 11.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label_PolicyOne.ForeColor = System.Drawing.Color.Black;
-            this.label_PolicyOne.Location = new System.Drawing.Point(58, 67);
-            this.label_PolicyOne.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label_PolicyOne.Location = new System.Drawing.Point(48, 56);
             this.label_PolicyOne.Name = "label_PolicyOne";
-            this.label_PolicyOne.Size = new System.Drawing.Size(281, 28);
+            this.label_PolicyOne.Size = new System.Drawing.Size(232, 23);
             this.label_PolicyOne.TabIndex = 5;
             this.label_PolicyOne.Text = "Default Windows Mode";
             // 
@@ -229,18 +225,18 @@ namespace WDAC_Wizard
             this.panel5.Controls.Add(this.label2);
             this.panel5.Controls.Add(this.label_PolicyOne);
             this.panel5.Font = new System.Drawing.Font("Tahoma", 7.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.panel5.Location = new System.Drawing.Point(197, 101);
-            this.panel5.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.panel5.Location = new System.Drawing.Point(164, 84);
+            this.panel5.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.panel5.Name = "panel5";
-            this.panel5.Size = new System.Drawing.Size(394, 528);
+            this.panel5.Size = new System.Drawing.Size(329, 440);
             this.panel5.TabIndex = 4;
             // 
             // panel6
             // 
-            this.panel6.Location = new System.Drawing.Point(458, 5);
-            this.panel6.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.panel6.Location = new System.Drawing.Point(382, 4);
+            this.panel6.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.panel6.Name = "panel6";
-            this.panel6.Size = new System.Drawing.Size(450, 815);
+            this.panel6.Size = new System.Drawing.Size(375, 679);
             this.panel6.TabIndex = 2;
             // 
             // panel9
@@ -253,10 +249,10 @@ namespace WDAC_Wizard
             this.panel9.Controls.Add(this.label4);
             this.panel9.Controls.Add(this.label_PolicyThree);
             this.panel9.Controls.Add(this.panel10);
-            this.panel9.Location = new System.Drawing.Point(984, 101);
-            this.panel9.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.panel9.Location = new System.Drawing.Point(820, 84);
+            this.panel9.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.panel9.Name = "panel9";
-            this.panel9.Size = new System.Drawing.Size(417, 528);
+            this.panel9.Size = new System.Drawing.Size(348, 440);
             this.panel9.TabIndex = 5;
             // 
             // signedReputable_Button
@@ -264,14 +260,14 @@ namespace WDAC_Wizard
             this.signedReputable_Button.BackColor = System.Drawing.Color.White;
             this.signedReputable_Button.BackgroundImage = global::WDAC_Wizard.Properties.Resources.radio_off;
             this.signedReputable_Button.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
-            this.signedReputable_Button.Location = new System.Drawing.Point(186, 467);
-            this.signedReputable_Button.Margin = new System.Windows.Forms.Padding(2, 4, 2, 4);
+            this.signedReputable_Button.Location = new System.Drawing.Point(155, 389);
+            this.signedReputable_Button.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.signedReputable_Button.Name = "signedReputable_Button";
-            this.signedReputable_Button.Size = new System.Drawing.Size(36, 36);
+            this.signedReputable_Button.Size = new System.Drawing.Size(30, 30);
             this.signedReputable_Button.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
             this.signedReputable_Button.TabIndex = 96;
             this.signedReputable_Button.TabStop = false;
-            this.signedReputable_Button.Click += new System.EventHandler(this.signedReputable_Button_Click);
+            this.signedReputable_Button.Click += new System.EventHandler(this.SignedReputable_Button_Click);
             this.signedReputable_Button.MouseLeave += new System.EventHandler(this.MouseLeave_Button);
             this.signedReputable_Button.MouseHover += new System.EventHandler(this.MouseHover_Button);
             // 
@@ -282,10 +278,10 @@ namespace WDAC_Wizard
             this.ISGLabel.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(16)))), ((int)(((byte)(110)))), ((int)(((byte)(190)))));
             this.ISGLabel.Image = global::WDAC_Wizard.Properties.Resources.external_link_symbol_highlight;
             this.ISGLabel.ImageAlign = System.Drawing.ContentAlignment.MiddleRight;
-            this.ISGLabel.Location = new System.Drawing.Point(32, 415);
+            this.ISGLabel.Location = new System.Drawing.Point(27, 346);
             this.ISGLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.ISGLabel.Name = "ISGLabel";
-            this.ISGLabel.Size = new System.Drawing.Size(375, 24);
+            this.ISGLabel.Size = new System.Drawing.Size(314, 21);
             this.ISGLabel.TabIndex = 5;
             this.ISGLabel.Text = "- Files with good reputation using ISG     ";
             this.ISGLabel.Click += new System.EventHandler(this.ISGLabel_Click);
@@ -295,20 +291,19 @@ namespace WDAC_Wizard
             this.label6.AutoSize = true;
             this.label6.Font = new System.Drawing.Font("Tahoma", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label6.ForeColor = System.Drawing.Color.Black;
-            this.label6.Location = new System.Drawing.Point(14, 240);
-            this.label6.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label6.Location = new System.Drawing.Point(12, 200);
             this.label6.Name = "label6";
-            this.label6.Size = new System.Drawing.Size(385, 175);
+            this.label6.Size = new System.Drawing.Size(304, 147);
             this.label6.TabIndex = 16;
             this.label6.Text = resources.GetString("label6.Text");
             // 
             // pictureBox8
             // 
             this.pictureBox8.Image = global::WDAC_Wizard.Properties.Resources.shield;
-            this.pictureBox8.Location = new System.Drawing.Point(138, 125);
-            this.pictureBox8.Margin = new System.Windows.Forms.Padding(2, 4, 2, 4);
+            this.pictureBox8.Location = new System.Drawing.Point(115, 104);
+            this.pictureBox8.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.pictureBox8.Name = "pictureBox8";
-            this.pictureBox8.Size = new System.Drawing.Size(133, 88);
+            this.pictureBox8.Size = new System.Drawing.Size(111, 73);
             this.pictureBox8.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
             this.pictureBox8.TabIndex = 16;
             this.pictureBox8.TabStop = false;
@@ -318,10 +313,9 @@ namespace WDAC_Wizard
             this.label4.AutoSize = true;
             this.label4.Font = new System.Drawing.Font("Tahoma", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label4.ForeColor = System.Drawing.Color.White;
-            this.label4.Location = new System.Drawing.Point(43, 275);
-            this.label4.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label4.Location = new System.Drawing.Point(36, 229);
             this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(0, 25);
+            this.label4.Size = new System.Drawing.Size(0, 21);
             this.label4.TabIndex = 10;
             // 
             // label_PolicyThree
@@ -329,19 +323,18 @@ namespace WDAC_Wizard
             this.label_PolicyThree.AutoSize = true;
             this.label_PolicyThree.Font = new System.Drawing.Font("Tahoma", 11.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label_PolicyThree.ForeColor = System.Drawing.Color.Black;
-            this.label_PolicyThree.Location = new System.Drawing.Point(38, 67);
-            this.label_PolicyThree.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label_PolicyThree.Location = new System.Drawing.Point(32, 56);
             this.label_PolicyThree.Name = "label_PolicyThree";
-            this.label_PolicyThree.Size = new System.Drawing.Size(338, 28);
+            this.label_PolicyThree.Size = new System.Drawing.Size(277, 23);
             this.label_PolicyThree.TabIndex = 7;
             this.label_PolicyThree.Text = "Signed and Reputable Mode";
             // 
             // panel10
             // 
-            this.panel10.Location = new System.Drawing.Point(458, 5);
-            this.panel10.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.panel10.Location = new System.Drawing.Point(382, 4);
+            this.panel10.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.panel10.Name = "panel10";
-            this.panel10.Size = new System.Drawing.Size(450, 815);
+            this.panel10.Size = new System.Drawing.Size(375, 679);
             this.panel10.TabIndex = 2;
             // 
             // label_fileLocation
@@ -349,10 +342,9 @@ namespace WDAC_Wizard
             this.label_fileLocation.AutoSize = true;
             this.label_fileLocation.Font = new System.Drawing.Font("Tahoma", 9.5F);
             this.label_fileLocation.ForeColor = System.Drawing.Color.Black;
-            this.label_fileLocation.Location = new System.Drawing.Point(11, 109);
-            this.label_fileLocation.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label_fileLocation.Location = new System.Drawing.Point(9, 91);
             this.label_fileLocation.Name = "label_fileLocation";
-            this.label_fileLocation.Size = new System.Drawing.Size(172, 23);
+            this.label_fileLocation.Size = new System.Drawing.Size(149, 19);
             this.label_fileLocation.TabIndex = 6;
             this.label_fileLocation.Text = "Policy File Location:";
             // 
@@ -360,22 +352,21 @@ namespace WDAC_Wizard
             // 
             this.textBoxPolicyPath.Font = new System.Drawing.Font("Tahoma", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.textBoxPolicyPath.ForeColor = System.Drawing.Color.Black;
-            this.textBoxPolicyPath.Location = new System.Drawing.Point(222, 104);
-            this.textBoxPolicyPath.Margin = new System.Windows.Forms.Padding(2, 4, 2, 4);
+            this.textBoxPolicyPath.Location = new System.Drawing.Point(185, 87);
+            this.textBoxPolicyPath.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.textBoxPolicyPath.Name = "textBoxPolicyPath";
-            this.textBoxPolicyPath.Size = new System.Drawing.Size(482, 29);
+            this.textBoxPolicyPath.Size = new System.Drawing.Size(402, 26);
             this.textBoxPolicyPath.TabIndex = 2;
-            this.textBoxPolicyPath.Click += new System.EventHandler(this.textBoxPolicyPath_TextChanged);
+            this.textBoxPolicyPath.Click += new System.EventHandler(this.TextBoxPolicyPath_TextChanged);
             // 
             // label_policyName
             // 
             this.label_policyName.AutoSize = true;
             this.label_policyName.Font = new System.Drawing.Font("Tahoma", 9.5F);
             this.label_policyName.ForeColor = System.Drawing.Color.Black;
-            this.label_policyName.Location = new System.Drawing.Point(11, 60);
-            this.label_policyName.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label_policyName.Location = new System.Drawing.Point(9, 50);
             this.label_policyName.Name = "label_policyName";
-            this.label_policyName.Size = new System.Drawing.Size(118, 23);
+            this.label_policyName.Size = new System.Drawing.Size(102, 19);
             this.label_policyName.TabIndex = 8;
             this.label_policyName.Text = "Policy Name:";
             // 
@@ -383,12 +374,12 @@ namespace WDAC_Wizard
             // 
             this.textBox_PolicyName.Font = new System.Drawing.Font("Tahoma", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.textBox_PolicyName.ForeColor = System.Drawing.Color.Black;
-            this.textBox_PolicyName.Location = new System.Drawing.Point(222, 55);
-            this.textBox_PolicyName.Margin = new System.Windows.Forms.Padding(2, 4, 2, 4);
+            this.textBox_PolicyName.Location = new System.Drawing.Point(185, 46);
+            this.textBox_PolicyName.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.textBox_PolicyName.Name = "textBox_PolicyName";
-            this.textBox_PolicyName.Size = new System.Drawing.Size(482, 29);
+            this.textBox_PolicyName.Size = new System.Drawing.Size(402, 26);
             this.textBox_PolicyName.TabIndex = 1;
-            this.textBox_PolicyName.TextChanged += new System.EventHandler(this.textBoxPolicyName_TextChanged);
+            this.textBox_PolicyName.TextChanged += new System.EventHandler(this.TextBoxPolicyName_TextChanged);
             // 
             // button_Browse
             // 
@@ -396,24 +387,23 @@ namespace WDAC_Wizard
             this.button_Browse.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.button_Browse.Font = new System.Drawing.Font("Tahoma", 9F);
             this.button_Browse.ForeColor = System.Drawing.Color.DodgerBlue;
-            this.button_Browse.Location = new System.Drawing.Point(722, 103);
-            this.button_Browse.Margin = new System.Windows.Forms.Padding(2, 4, 2, 4);
+            this.button_Browse.Location = new System.Drawing.Point(602, 86);
+            this.button_Browse.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.button_Browse.Name = "button_Browse";
-            this.button_Browse.Size = new System.Drawing.Size(128, 34);
+            this.button_Browse.Size = new System.Drawing.Size(107, 28);
             this.button_Browse.TabIndex = 3;
             this.button_Browse.Text = "Browse";
             this.button_Browse.UseVisualStyleBackColor = true;
-            this.button_Browse.Click += new System.EventHandler(this.textBoxPolicyPath_TextChanged);
+            this.button_Browse.Click += new System.EventHandler(this.TextBoxPolicyPath_TextChanged);
             // 
             // label5
             // 
             this.label5.AutoSize = true;
             this.label5.Font = new System.Drawing.Font("Tahoma", 10F);
             this.label5.ForeColor = System.Drawing.Color.Black;
-            this.label5.Location = new System.Drawing.Point(4, 14);
-            this.label5.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label5.Location = new System.Drawing.Point(3, 12);
             this.label5.Name = "label5";
-            this.label5.Size = new System.Drawing.Size(598, 24);
+            this.label5.Size = new System.Drawing.Size(495, 21);
             this.label5.TabIndex = 11;
             this.label5.Text = "You can modify the policy name and location, or keep the default.";
             // 
@@ -425,10 +415,10 @@ namespace WDAC_Wizard
             this.policyInfoPanel.Controls.Add(this.label_policyName);
             this.policyInfoPanel.Controls.Add(this.textBoxPolicyPath);
             this.policyInfoPanel.Controls.Add(this.label_fileLocation);
-            this.policyInfoPanel.Location = new System.Drawing.Point(198, 634);
-            this.policyInfoPanel.Margin = new System.Windows.Forms.Padding(2, 4, 2, 4);
+            this.policyInfoPanel.Location = new System.Drawing.Point(165, 528);
+            this.policyInfoPanel.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.policyInfoPanel.Name = "policyInfoPanel";
-            this.policyInfoPanel.Size = new System.Drawing.Size(1098, 161);
+            this.policyInfoPanel.Size = new System.Drawing.Size(915, 134);
             this.policyInfoPanel.TabIndex = 95;
             this.policyInfoPanel.Visible = false;
             // 
@@ -437,43 +427,42 @@ namespace WDAC_Wizard
             this.label1.AutoSize = true;
             this.label1.Font = new System.Drawing.Font("Tahoma", 14F);
             this.label1.ForeColor = System.Drawing.Color.Black;
-            this.label1.Location = new System.Drawing.Point(192, 40);
-            this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label1.Location = new System.Drawing.Point(160, 33);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(476, 34);
+            this.label1.Size = new System.Drawing.Size(410, 29);
             this.label1.TabIndex = 95;
             this.label1.Text = "Select a Base Template for the policy";
             // 
-            // label3
+            // label_LearnMore
             // 
-            this.label3.AutoSize = true;
-            this.label3.Font = new System.Drawing.Font("Tahoma", 9F);
-            this.label3.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(16)))), ((int)(((byte)(110)))), ((int)(((byte)(190)))));
-            this.label3.Image = global::WDAC_Wizard.Properties.Resources.external_link_symbol_highlight;
-            this.label3.ImageAlign = System.Drawing.ContentAlignment.MiddleRight;
-            this.label3.Location = new System.Drawing.Point(1084, 74);
-            this.label3.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
-            this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(317, 22);
-            this.label3.TabIndex = 4;
-            this.label3.Text = "Learn more about template policies     ";
-            this.label3.Click += new System.EventHandler(this.label3_Click);
+            this.label_LearnMore.AutoSize = true;
+            this.label_LearnMore.Font = new System.Drawing.Font("Tahoma", 9F);
+            this.label_LearnMore.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(16)))), ((int)(((byte)(110)))), ((int)(((byte)(190)))));
+            this.label_LearnMore.Image = global::WDAC_Wizard.Properties.Resources.external_link_symbol_highlight;
+            this.label_LearnMore.ImageAlign = System.Drawing.ContentAlignment.MiddleRight;
+            this.label_LearnMore.Location = new System.Drawing.Point(903, 62);
+            this.label_LearnMore.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.label_LearnMore.Name = "label_LearnMore";
+            this.label_LearnMore.Size = new System.Drawing.Size(261, 18);
+            this.label_LearnMore.TabIndex = 4;
+            this.label_LearnMore.Text = "Learn more about template policies     ";
+            this.label_LearnMore.Click += new System.EventHandler(this.Label_LearnMore_Click);
             // 
             // TemplatePage
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(144F, 144F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(120F, 120F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.Color.White;
             this.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Center;
-            this.Controls.Add(this.label3);
+            this.Controls.Add(this.label_LearnMore);
             this.Controls.Add(this.label1);
             this.Controls.Add(this.policyInfoPanel);
             this.Controls.Add(this.panel9);
             this.Controls.Add(this.panel2);
             this.Controls.Add(this.panel5);
-            this.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.Name = "TemplatePage";
-            this.Size = new System.Drawing.Size(1406, 938);
+            this.Size = new System.Drawing.Size(1172, 782);
             this.panel2.ResumeLayout(false);
             this.panel2.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.allowMsft_Button)).EndInit();
@@ -525,6 +514,6 @@ namespace WDAC_Wizard
         private System.Windows.Forms.PictureBox signedReputable_Button;
         private System.Windows.Forms.PictureBox windowsWorks_Button;
         private System.Windows.Forms.PictureBox allowMsft_Button;
-        private System.Windows.Forms.Label label3;
+        private System.Windows.Forms.Label label_LearnMore;
     }
 }

--- a/WDAC-Policy-Wizard/app/src/TemplatePage.cs
+++ b/WDAC-Policy-Wizard/app/src/TemplatePage.cs
@@ -50,7 +50,7 @@ namespace WDAC_Wizard
                 
             this._Policy._PolicyTemplate = WDAC_Policy.NewPolicyTemplate.AllowMicrosoft;
             // Update UI
-            uncheck_all();
+            Uncheck_all();
             SetDefaultTextValues("AllowMicrosoft"); 
             allowMsft_Button.Tag = "toggle";
             allowMsft_Button.BackgroundImage = Properties.Resources.radio_on;
@@ -72,7 +72,7 @@ namespace WDAC_Wizard
                 
             this._Policy._PolicyTemplate = WDAC_Policy.NewPolicyTemplate.WindowsWorks;
             // Update UI
-            uncheck_all();
+            Uncheck_all();
             SetDefaultTextValues("WindowsWorks");
             windowsWorks_Button.Tag = "toggle";
             windowsWorks_Button.BackgroundImage = Properties.Resources.radio_on;
@@ -83,7 +83,7 @@ namespace WDAC_Wizard
         /// Signed and Reputable template policy selected. Least restrictive and lowest level of security.  
         /// </summary>
         /// 
-        private void signedReputable_Button_Click(object sender, EventArgs e)
+        private void SignedReputable_Button_Click(object sender, EventArgs e)
         {
             //Policy Signed and Reputable (certificate & reputation signing)
             // User coming back to this page and changing template -- redo flow
@@ -96,7 +96,7 @@ namespace WDAC_Wizard
             this._Policy._PolicyTemplate = WDAC_Policy.NewPolicyTemplate.SignedReputable;
             
             // Update UI
-            uncheck_all();
+            Uncheck_all();
             SetDefaultTextValues("SignedReputable");
             signedReputable_Button.Tag = "toggle";
             signedReputable_Button.BackgroundImage = Properties.Resources.radio_on;
@@ -107,8 +107,7 @@ namespace WDAC_Wizard
         /// Uncheck all of the tempalte policy options. Required since the buttons do not automatically 
         /// untoggle each other. Called each time a user toggles a template.  
         /// </summary>
-        /// 
-        private void uncheck_all()
+        private void Uncheck_all()
         {
             // Show the text fields now that user has selected base policy template:
             this.policyInfoPanel.Visible = true;
@@ -129,12 +128,19 @@ namespace WDAC_Wizard
         /// <summary>
         /// Sets the policy schema path string. Triggered when user wants to modify the save path for their policy: browse button press or PolicyPath TextBox text changed.  
         /// </summary>
-        /// 
-        private void textBoxPolicyPath_TextChanged(object sender, EventArgs e)
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void TextBoxPolicyPath_TextChanged(object sender, EventArgs e)
         {
             // Save dialog box pressed
 
-            string policyPath = Helper.SaveSingleFile(Properties.Resources.SaveXMLFileDialogTitle, Helper.BrowseFileType.Policy); 
+            string policyPath = Helper.SaveSingleFile(Properties.Resources.SaveXMLFileDialogTitle, Helper.BrowseFileType.Policy);
+
+            // If cancel button is selected by user, or path does not exist prevent unhandled error
+            if(String.IsNullOrEmpty(policyPath))
+            {
+                return; 
+            }
 
             textBoxPolicyPath.Text = policyPath;
             this._Policy.SchemaPath = policyPath;
@@ -149,10 +155,11 @@ namespace WDAC_Wizard
         }
 
         /// <summary>
-        /// Sets the policy friendly name string. Triggered when user wants to modify the policy name: PolicyName TextBox text changed.  
+        /// Sets the policy friendly name string. Triggered when user wants to modify the policy name: PolicyName TextBox text changed. 
         /// </summary>
-        /// 
-        private void textBoxPolicyName_TextChanged(object sender, EventArgs e)
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void TextBoxPolicyName_TextChanged(object sender, EventArgs e)
         {
             // Policy Friend Name
             this._Policy.PolicyName = textBox_PolicyName.Text;
@@ -191,6 +198,12 @@ namespace WDAC_Wizard
             this.textBoxPolicyPath.ScrollToCaret();
         }
 
+        /// <summary>
+        /// Find a default path for the policy to be saved. 
+        /// </summary>
+        /// <param name="policyTemplate"></param>
+        /// <param name="nAttempts"></param>
+        /// <returns></returns>
         private string GetDefaultPath(string policyTemplate, int nAttempts)
         {
             string dateString = this._MainWindow.FormatDate(false);
@@ -208,7 +221,12 @@ namespace WDAC_Wizard
             else
                 return proposedPath;
         }
-                
+
+        /// <summary>
+        /// User has clicked the ISG label to learn more. Launch webpage
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
         private void ISGLabel_Click(object sender, EventArgs e)
         {
             // ISG label clicked. Launch ISG webpage
@@ -247,8 +265,12 @@ namespace WDAC_Wizard
             checkBox.BackColor = Color.White;
         }
 
-        // Learn more about the template policies
-        private void label3_Click(object sender, EventArgs e)
+        /// <summary>
+        /// Learn more about the template policies
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void Label_LearnMore_Click(object sender, EventArgs e)
         {
             try
             {

--- a/WDAC-Policy-Wizard/app/src/TemplatePage.cs
+++ b/WDAC-Policy-Wizard/app/src/TemplatePage.cs
@@ -145,9 +145,14 @@ namespace WDAC_Wizard
             textBoxPolicyPath.Text = policyPath;
             this._Policy.SchemaPath = policyPath;
             this._MainWindow.Policy.SchemaPath = this._Policy.SchemaPath;
-            this.textBoxPolicyPath.SelectionStart = this.textBoxPolicyPath.TextLength - 1; 
-            this.textBoxPolicyPath.ScrollToCaret(); 
-            
+
+            // Scroll to the right-most side of the textbox
+            if(this.textBoxPolicyPath.TextLength > 0)
+            {
+                this.textBoxPolicyPath.SelectionStart = this.textBoxPolicyPath.TextLength - 1;
+                this.textBoxPolicyPath.ScrollToCaret();
+            }
+                        
             if(this._Policy.PolicyName != null)
             {
                 this._MainWindow.ErrorOnPage = false;
@@ -194,8 +199,12 @@ namespace WDAC_Wizard
             this._MainWindow.Policy._PolicyTemplate = this._Policy._PolicyTemplate;
 
             // Show right side of the text
-            this.textBoxPolicyPath.SelectionStart = this.textBoxPolicyPath.TextLength - 1;
-            this.textBoxPolicyPath.ScrollToCaret();
+            if(this.textBoxPolicyPath.TextLength > 0)
+            {
+                this.textBoxPolicyPath.SelectionStart = this.textBoxPolicyPath.TextLength - 1;
+                this.textBoxPolicyPath.ScrollToCaret();
+            }
+            
         }
 
         /// <summary>


### PR DESCRIPTION
…dle exception. Drive by renaming of functions

**Behavior:** Clicking 'Cancel' on the templates page when selecting a location to save the policy results in an unhandled exception. 

**Solution:**Added exception handling for OpenFileDialog and SaveFileDialog when a user may select **Cancel** which returns an empty string by the helper function. Quick refactoring of method names

Fixed issue #79 
