### PR TITLE
WDAC Wizard resets final policy ID during merging policies

### DIFF
--- a/WDAC-Policy-Wizard/app/src/BuildPage.Designer.cs
+++ b/WDAC-Policy-Wizard/app/src/BuildPage.Designer.cs
@@ -109,7 +109,7 @@ namespace WDAC_Wizard
             this.hyperlinkLabel.Size = new System.Drawing.Size(123, 19);
             this.hyperlinkLabel.TabIndex = 85;
             this.hyperlinkLabel.Text = "Unable to locate";
-            this.hyperlinkLabel.Click += new System.EventHandler(this.hyperlinkLabel_Click);
+            this.hyperlinkLabel.Click += new System.EventHandler(this.HyperlinkLabel_Click);
             // 
             // finishPanel
             // 
@@ -130,9 +130,9 @@ namespace WDAC_Wizard
             this.label4.ForeColor = System.Drawing.Color.Black;
             this.label4.Location = new System.Drawing.Point(1, 48);
             this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(131, 19);
+            this.label4.Size = new System.Drawing.Size(237, 19);
             this.label4.TabIndex = 87;
-            this.label4.Text = "Output locations:";
+            this.label4.Text = "Output locations (click to open):";
             // 
             // progressString_Label
             // 

--- a/WDAC-Policy-Wizard/app/src/BuildPage.cs
+++ b/WDAC-Policy-Wizard/app/src/BuildPage.cs
@@ -119,9 +119,8 @@ namespace WDAC_Wizard
         /// <summary>
         /// Opens the file explorer to the CI policy just built located in the folder path defined in the FilePath param . 
         /// </summary>
-        private void hyperlinkLabel_Click(object sender, EventArgs e)
+        private void HyperlinkLabel_Click(object sender, EventArgs e)
         {
-            
             // open text file in notepad (or another default text editor)
             if (File.Exists(this.FilePath))
             {

--- a/WDAC-Policy-Wizard/app/src/MainForm.cs
+++ b/WDAC-Policy-Wizard/app/src/MainForm.cs
@@ -773,9 +773,21 @@ namespace WDAC_Wizard
         /// </summary>
         private void BackgroundWorker1_RunWorkerCompleted(object sender, RunWorkerCompletedEventArgs e)
         {
+            // If error in workflow, log final exception
             if (e.Error != null)
             {
                 this.Log.AddErrorMsg("ProcessPolicy() caught the following exception ", e.Error);
+            }
+            this.Log.AddNewSeparationLine("Workflow -- DONE");
+
+            // Upload log file if customer consents
+            if (Properties.Settings.Default.allowTelemetry)
+            {
+                this.Log.UploadLog();
+            }
+
+            if (e.Error != null)
+            {
                 this._BuildPage.ShowError();
             }
             else
@@ -792,13 +804,8 @@ namespace WDAC_Wizard
                 }
             }
 
-            this.Log.AddNewSeparationLine("Workflow -- DONE"); 
-
-            // Upload log file if customer consents
-            if (Properties.Settings.Default.allowTelemetry)
-            {
-                this.Log.UploadLog();
-            }
+            // Re-initialize SiPolicy object
+            this.Policy = new WDAC_Policy();
         }
 
         /// <summary>
@@ -1476,6 +1483,7 @@ namespace WDAC_Wizard
             }
             else
             {
+                // Merge issue #87 is here - non zero custom rules
                 if (this.Policy.CustomRules.Count > 0)
                 {
                     policyPaths.Add(customRulesMergePath);
@@ -1487,7 +1495,7 @@ namespace WDAC_Wizard
                 }
             }
             
-
+            // Added in the order based on their final order in the table
             if (this.Policy.PoliciesToMerge.Count > 0)
             {
                 foreach(var path in this.Policy.PoliciesToMerge)
@@ -1522,7 +1530,6 @@ namespace WDAC_Wizard
             }
 
             // Remove last comma and add outputFilePath
-            // TODO: check if this.Policy.SchemaPath is user-writeable
             mergeScript = mergeScript.Remove(mergeScript.Length - 1);
             mergeScript += String.Format(" -OutputFilePath \"{0}\"", this.Policy.SchemaPath);
 

--- a/WDAC-Policy-Wizard/app/src/PolicyMerge_Control.Designer.cs
+++ b/WDAC-Policy-Wizard/app/src/PolicyMerge_Control.Designer.cs
@@ -136,9 +136,10 @@
             // 
             this.button_AddPolicy.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(224)))), ((int)(((byte)(224)))), ((int)(((byte)(224)))));
             this.button_AddPolicy.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.button_AddPolicy.Font = new System.Drawing.Font("Microsoft Sans Serif", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.button_AddPolicy.Location = new System.Drawing.Point(165, 307);
             this.button_AddPolicy.Name = "button_AddPolicy";
-            this.button_AddPolicy.Size = new System.Drawing.Size(120, 30);
+            this.button_AddPolicy.Size = new System.Drawing.Size(130, 30);
             this.button_AddPolicy.TabIndex = 96;
             this.button_AddPolicy.Text = "+ Add Policy";
             this.button_AddPolicy.UseVisualStyleBackColor = true;
@@ -148,9 +149,10 @@
             // 
             this.button_RemovePolicy.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(224)))), ((int)(((byte)(224)))), ((int)(((byte)(224)))));
             this.button_RemovePolicy.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.button_RemovePolicy.Location = new System.Drawing.Point(307, 307);
+            this.button_RemovePolicy.Font = new System.Drawing.Font("Microsoft Sans Serif", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.button_RemovePolicy.Location = new System.Drawing.Point(317, 307);
             this.button_RemovePolicy.Name = "button_RemovePolicy";
-            this.button_RemovePolicy.Size = new System.Drawing.Size(120, 30);
+            this.button_RemovePolicy.Size = new System.Drawing.Size(130, 30);
             this.button_RemovePolicy.TabIndex = 97;
             this.button_RemovePolicy.Text = "- Remove Policy";
             this.button_RemovePolicy.UseVisualStyleBackColor = true;

--- a/WDAC-Policy-Wizard/app/src/PolicyMerge_Control.cs
+++ b/WDAC-Policy-Wizard/app/src/PolicyMerge_Control.cs
@@ -44,6 +44,11 @@ namespace WDAC_Wizard.src
             this._MainWindow.ErrorMsg = "Please choose at least 2 policies to merge and a final output location.";
         }
 
+        /// <summary>
+        /// User has selected the Browse button. Prompts user to select a file location to save their merged WDAC policy output file
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
         private void Button_Browse_Click(object sender, EventArgs e)
         {
             string dspTitle = "Choose the final merged WDAC path location";
@@ -66,13 +71,13 @@ namespace WDAC_Wizard.src
                     this._MainWindow.ErrorOnPage = false; 
                 }
             }
-            else
-            {
-                this.Log.AddInfoMsg("Final Merge Policy set to: Could Not Resolve Path");
-            }
-
         }
 
+        /// <summary>
+        /// User has selected the + Add Policy button. Prompts user to select multiple WDAC policy files to be merged
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
         private void Button_AddPolicy_Click(object sender, EventArgs e)
         {
             string dspTitle = "Choose WDAC policies to merge";
@@ -123,6 +128,11 @@ namespace WDAC_Wizard.src
             }
         }
 
+        /// <summary>
+        /// User has selected the - Remove Policy button. Prompts user to select the WDAC policy files to be removed from the table
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
         private void Button_RemovePolicy_Click(object sender, EventArgs e)
         {
             this.Log.AddInfoMsg("-- Delete Rule button clicked -- ");
@@ -191,30 +201,37 @@ namespace WDAC_Wizard.src
             }
         }
               
-
+        /// <summary>
+        /// Calls the helper function to get save file location path
+        /// </summary>
+        /// <param name="displayTitle"></param>
+        /// <returns>Path to save the merged WDAC file output. String.Empty if user cancels</returns>
         private string SavePolicy(string displayTitle)
         {
             // Open file dialog to get file or folder path
             return Helper.SaveSingleFile(Properties.Resources.SaveXMLFileDialogTitle, Helper.BrowseFileType.Policy);
         }
 
-
+        /// <summary>
+        /// Display error label. Set timer to show the error for 5 seconds
+        /// </summary>
+        /// <param name="dspStr"></param>
         private void ShowError(string dspStr)
         {
             this.label_Error.Text = dspStr; 
             this.label_Error.Visible = true;
 
             Timer settingsUpdateNotificationTimer = new Timer();
-            settingsUpdateNotificationTimer.Interval = (5000); // 1.5 secs
+            settingsUpdateNotificationTimer.Interval = (5000); // 5 secs
             settingsUpdateNotificationTimer.Tick += new EventHandler(SettingUpdateTimer_Tick);
             settingsUpdateNotificationTimer.Start();
         }
 
-
-        ///
-        /// Grid View Specific 
-        ///
-
+        /// <summary>
+        /// Method to retrieve the Cell Values
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
         private void PoliciesDataGrid_CellValueNeeded(object sender, DataGridViewCellValueEventArgs e)
         {
             // If this is the row for new records, no values are needed.
@@ -244,13 +261,18 @@ namespace WDAC_Wizard.src
             }
         }
 
+        /// <summary>
+        /// Method to hide the error label. Called when timer runs out (5s)
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
         private void SettingUpdateTimer_Tick(object sender, EventArgs e)
         {
             this.label_Error.Visible = false;
         }
     }
 
-    // Class for the datastore
+    // Class for the table datastore
     public class DisplayObject
     {
         public string Number;

--- a/WDAC-Policy-Wizard/app/src/PolicyMerge_Control.resx
+++ b/WDAC-Policy-Wizard/app/src/PolicyMerge_Control.resx
@@ -123,10 +123,4 @@
   <metadata name="Column_Path.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
-  <metadata name="Column_Number.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="Column_Path.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
 </root>


### PR DESCRIPTION
**Behavior:** The Wizard may reset the policy ID during the merge workflow. 
**Root cause:** The bug stemmed from a non-null set of custom rules after building a new policy, then going to the merge policy workflow. 

**Solution:** Reset this.Policy object at the end of build policy. 

Closing #87 