### PR TITLE
Fixed issue #103 where new supplemental policies inherited all rules from the base

### DIFF
--- a/WDAC-Policy-Wizard/app/MSIX/Empty_Supplemental.xml
+++ b/WDAC-Policy-Wizard/app/MSIX/Empty_Supplemental.xml
@@ -1,22 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<SiPolicy xmlns="urn:schemas-microsoft-com:sipolicy">
+<SiPolicy xmlns="urn:schemas-microsoft-com:sipolicy" PolicyType="Supplemental Policy">
   <VersionEx>10.0.0.0</VersionEx>
   <PlatformID>{2E07F7E4-194C-4D20-B7C9-6F44A6C5A234}</PlatformID>
+  <!-- The majority of supplemental policy rules are inherited from the base. See https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-application-control/select-types-of-rules-to-create for more info -->
   <Rules>
     <Rule>
       <Option>Enabled:Unsigned System Integrity Policy</Option>
     </Rule>
     <Rule>
-      <Option>Enabled:Audit Mode</Option>
-    </Rule>
-    <Rule>
-      <Option>Enabled:Advanced Boot Options Menu</Option>
-    </Rule>
-    <Rule>
-      <Option>Required:Enforce Store Applications</Option>
-    </Rule>
-    <Rule>
-      <Option>Enabled:Allow Supplemental Policies</Option>
+      <Option>Enabled:Inherit Default Policy</Option>
     </Rule>
   </Rules>
   <!--EKUS-->
@@ -27,15 +19,28 @@
   <Signers />
   <!--Driver Signing Scenarios-->
   <SigningScenarios>
-    <SigningScenario Value="131" ID="ID_SIGNINGSCENARIO_DRIVERS_1" FriendlyName="Auto generated policy on 09-18-2020">
+    <SigningScenario Value="131" ID="ID_SIGNINGSCENARIO_DRIVERS_1" FriendlyName="Auto generated policy on 09-24-2021">
       <ProductSigners />
     </SigningScenario>
-    <SigningScenario Value="12" ID="ID_SIGNINGSCENARIO_WINDOWS" FriendlyName="Auto generated policy on 09-18-2020">
+    <SigningScenario Value="12" ID="ID_SIGNINGSCENARIO_WINDOWS" FriendlyName="Auto generated policy on 09-24-2021">
       <ProductSigners />
     </SigningScenario>
   </SigningScenarios>
   <UpdatePolicySigners />
   <CiSigners />
   <HvciOptions>0</HvciOptions>
-  <PolicyTypeID>{A244370E-44C9-4C06-B551-F6016E563076}</PolicyTypeID>
+  <BasePolicyID>{E0ABDA1F-CCF0-468E-8855-3E0F08B02D6A}</BasePolicyID>
+  <PolicyID>{B5C8D1E7-A920-4E0C-BD86-783BB59C145E}</PolicyID>
+  <Settings>
+    <Setting Provider="PolicyInfo" Key="Information" ValueName="Name">
+      <Value>
+        <String>SupplementalTemplate</String>
+      </Value>
+    </Setting>
+    <Setting Provider="PolicyInfo" Key="Information" ValueName="Id">
+      <Value>
+        <String>041922</String>
+      </Value>
+    </Setting>
+  </Settings>
 </SiPolicy>

--- a/WDAC-Policy-Wizard/app/src/ConfigTemplate_Control.cs
+++ b/WDAC-Policy-Wizard/app/src/ConfigTemplate_Control.cs
@@ -463,7 +463,12 @@ namespace WDAC_Wizard
             this._MainWindow.Policy.siPolicy = this.Policy.siPolicy;
 
             // Copy template to temp folder for reading and writing unless template already in temp folder (event log conversion)
-            if(!xmlPathToRead.Contains(this._MainWindow.TempFolderPath))
+            if(this.Policy._PolicyType == WDAC_Policy.PolicyType.SupplementalPolicy)
+            {
+                string xmlTemplateToWrite = Path.Combine(this._MainWindow.ExeFolderPath, "Empty_Supplemental.xml");
+                this._MainWindow.Policy.TemplatePath = xmlTemplateToWrite;
+            }
+            else if(!xmlPathToRead.Contains(this._MainWindow.TempFolderPath))
             {
                 string xmlTemplateToWrite = Path.Combine(this._MainWindow.TempFolderPath, Path.GetFileName(xmlPathToRead));
                 File.Copy(xmlPathToRead, xmlTemplateToWrite, true);

--- a/WDAC-Policy-Wizard/app/src/Helper.cs
+++ b/WDAC-Policy-Wizard/app/src/Helper.cs
@@ -806,6 +806,22 @@ namespace WDAC_Wizard
         }
 
         /// <summary>
+        /// Helper function to get the Windows version (e.g. 1903) to determine whether certain features are supported on this system.
+        /// </summary>
+        public static int GetWinVersion()
+        {
+            try
+            {
+                return Convert.ToInt32(Registry.GetValue(@"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion", "ReleaseId", ""));
+            }
+            catch (Exception e)
+            {
+
+            }
+            return -1;
+        }
+
+        /// <summary>
         /// Calls DateTime.UTCNow and formats to ISO 8601 (YYYY-MM-DD)
         /// </summary>
         /// <returns>DateTime string in format YYYY-MM-DD</returns>

--- a/WDAC-Policy-Wizard/app/src/MainForm.cs
+++ b/WDAC-Policy-Wizard/app/src/MainForm.cs
@@ -2220,8 +2220,6 @@ namespace WDAC_Wizard
                 Directory.CreateDirectory(tempFolderPath);
 
             return tempFolderPath; 
-
-
         }
 
         /// <summary>

--- a/WDAC-Policy-Wizard/app/src/Policy.cs
+++ b/WDAC-Policy-Wizard/app/src/Policy.cs
@@ -148,22 +148,6 @@ namespace WDAC_Wizard
         }
 
         /// <summary>
-        /// Helper function to get the Windows version (e.g. 1903) to determine whether certain features are supported on this system.
-        /// </summary>
-        public int GetWinVersion()
-        {
-            try
-            {
-                return Convert.ToInt32(Registry.GetValue(@"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion", "ReleaseId", ""));
-            } 
-            catch(Exception e)
-            {
-
-            }
-            return -1;  
-        }
-
-        /// <summary>
         /// Determines whether the policy file contains a version number and the name needs to be updated along with the policy xml version.
         /// </summary>
         public bool EditPathContainsVersionInfo()

--- a/WDAC-Policy-Wizard/app/src/PolicyType.cs
+++ b/WDAC-Policy-Wizard/app/src/PolicyType.cs
@@ -66,7 +66,7 @@ namespace WDAC_Wizard
             this.basePolicy_PictureBox.Tag = "Unselected"; 
 
             // Require >= 1903 for multiple policy formats - show UI notification 
-            if (this._Policy.GetWinVersion() < 1903)
+            if (Helper.GetWinVersion() < 1903)
                 MessageBox.Show("The multiple policy format will not work on pre-1903 systems","Multiple Policy Format Attention", 
                     MessageBoxButtons.OK, MessageBoxIcon.Information);
 


### PR DESCRIPTION
New supplemental policy workflow: 

- Supplemental policies are based off an empty supplemental instead of the base policy to supplement