### PR TITLE
New event log experience

### DIFF
--- a/WDAC-Policy-Wizard/app/Properties/Resources.Designer.cs
+++ b/WDAC-Policy-Wizard/app/Properties/Resources.Designer.cs
@@ -261,7 +261,7 @@ namespace WDAC_Wizard.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Conversion of the event log to a WDAC Policy XML file was successful. .
+        ///   Looks up a localized string similar to The WDAC Wizard successfully parsed all of the WDAC Event Logs.
         /// </summary>
         internal static string EventLogConversionSuccess {
             get {

--- a/WDAC-Policy-Wizard/app/Properties/Resources.Designer.cs
+++ b/WDAC-Policy-Wizard/app/Properties/Resources.Designer.cs
@@ -100,6 +100,15 @@ namespace WDAC_Wizard.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Unknown.
+        /// </summary>
+        internal static string BadEventPubValue {
+            get {
+                return ResourceManager.GetString("BadEventPubValue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>
         internal static System.Drawing.Bitmap blank_check_box {
@@ -257,6 +266,30 @@ namespace WDAC_Wizard.Properties {
         internal static string DynamicSecurity_Info {
             get {
                 return ResourceManager.GetString("DynamicSecurity_Info", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;
+        ///&lt;SiPolicy xmlns=&quot;urn:schemas-microsoft-com:sipolicy&quot; PolicyType=&quot;Base Policy&quot;&gt;
+        ///  &lt;VersionEx&gt;10.0.0.0&lt;/VersionEx&gt;
+        ///  &lt;PlatformID&gt;{2E07F7E4-194C-4D20-B7C9-6F44A6C5A234}&lt;/PlatformID&gt;
+        ///  &lt;Rules&gt;
+        ///    &lt;Rule&gt;
+        ///      &lt;Option&gt;Enabled:Unsigned System Integrity Policy&lt;/Option&gt;
+        ///    &lt;/Rule&gt;
+        ///    &lt;Rule&gt;
+        ///      &lt;Option&gt;Enabled:Audit Mode&lt;/Option&gt;
+        ///    &lt;/Rule&gt;
+        ///    &lt;Rule&gt;
+        ///      &lt;Option&gt;Enabled:Advanced Boot Options Menu&lt;/Option&gt;
+        ///    &lt;/Rule&gt;
+        ///    &lt;Rule&gt;
+        ///      &lt;Option&gt;Required:En [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string EmptyWDAC {
+            get {
+                return ResourceManager.GetString("EmptyWDAC", resourceCulture);
             }
         }
         

--- a/WDAC-Policy-Wizard/app/Properties/Resources.resx
+++ b/WDAC-Policy-Wizard/app/Properties/Resources.resx
@@ -438,4 +438,10 @@ EKU is 1.3.6.1.4.1.311.76.3.1</value>
     <value>Unable to proceed to Exceptions Panel. WDAC does not support path rule exceptions. 
 Please select the  'Create Rule' button.</value>
   </data>
+  <data name="BadEventPubValue" xml:space="preserve">
+    <value>Unknown</value>
+  </data>
+  <data name="EmptyWDAC" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\EmptyWDAC.xml;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+  </data>
 </root>

--- a/WDAC-Policy-Wizard/app/Properties/Resources.resx
+++ b/WDAC-Policy-Wizard/app/Properties/Resources.resx
@@ -149,7 +149,7 @@
     <value>When enabled, future WDAC policy updates are applied without requiring a system reboot.</value>
   </data>
   <data name="EventLogConversionSuccess" xml:space="preserve">
-    <value>Conversion of the event log to a WDAC Policy XML file was successful. </value>
+    <value>The WDAC Wizard successfully parsed all of the WDAC Event Logs</value>
   </data>
   <data name="DynamicSecurity_Info" xml:space="preserve">
     <value>Enables policy enforcement for .NET applications and DLLs.</value>

--- a/WDAC-Policy-Wizard/app/Resources/EmptyWDAC.xml
+++ b/WDAC-Policy-Wizard/app/Resources/EmptyWDAC.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<SiPolicy xmlns="urn:schemas-microsoft-com:sipolicy" PolicyType="Base Policy">
+  <VersionEx>10.0.0.0</VersionEx>
+  <PlatformID>{2E07F7E4-194C-4D20-B7C9-6F44A6C5A234}</PlatformID>
+  <Rules>
+    <Rule>
+      <Option>Enabled:Unsigned System Integrity Policy</Option>
+    </Rule>
+    <Rule>
+      <Option>Enabled:Audit Mode</Option>
+    </Rule>
+    <Rule>
+      <Option>Enabled:Advanced Boot Options Menu</Option>
+    </Rule>
+    <Rule>
+      <Option>Required:Enforce Store Applications</Option>
+    </Rule>
+  </Rules>
+  <!--EKUS-->
+  <EKUs />
+  <!--File Rules-->
+  <FileRules />
+  <!--Signers-->
+  <Signers />
+  <!--Driver Signing Scenarios-->
+  <SigningScenarios>
+    <SigningScenario Value="131" ID="ID_SIGNINGSCENARIO_DRIVERS_1" FriendlyName="Auto generated policy on 05-12-2022">
+      <ProductSigners />
+    </SigningScenario>
+    <SigningScenario Value="12" ID="ID_SIGNINGSCENARIO_WINDOWS" FriendlyName="Auto generated policy on 05-12-2022">
+      <ProductSigners />
+    </SigningScenario>
+  </SigningScenarios>
+  <UpdatePolicySigners />
+  <CiSigners />
+  <HvciOptions>0</HvciOptions>
+  <BasePolicyID>{784C4414-79F4-4C32-A6A5-F0FB42A51D0D}</BasePolicyID>
+  <PolicyID>{784C4414-79F4-4C32-A6A5-F0FB42A51D0D}</PolicyID>
+</SiPolicy>

--- a/WDAC-Policy-Wizard/app/WDAC Wizard.csproj
+++ b/WDAC-Policy-Wizard/app/WDAC Wizard.csproj
@@ -407,6 +407,7 @@
     <None Include="Resources\gear.png" />
     <None Include="Resources\imgs\add-button.png" />
     <None Include="Resources\eventlog_progress.bmp" />
+    <None Include="Resources\EmptyWDAC.xml" />
     <Content Include="Resources\imgs\back.png" />
     <Content Include="Resources\imgs\blank-check-box.png" />
     <None Include="Resources\untoggle.png" />

--- a/WDAC-Policy-Wizard/app/WDAC Wizard.csproj
+++ b/WDAC-Policy-Wizard/app/WDAC Wizard.csproj
@@ -183,6 +183,7 @@
     <Compile Include="src\CustomRuleConditionsPanel.Designer.cs">
       <DependentUpon>CustomRuleConditionsPanel.cs</DependentUpon>
     </Compile>
+    <Compile Include="src\EventLog.cs" />
     <Compile Include="src\Exceptions_Control.cs">
       <SubType>UserControl</SubType>
     </Compile>

--- a/WDAC-Policy-Wizard/app/WDAC Wizard.csproj
+++ b/WDAC-Policy-Wizard/app/WDAC Wizard.csproj
@@ -184,6 +184,12 @@
       <DependentUpon>CustomRuleConditionsPanel.cs</DependentUpon>
     </Compile>
     <Compile Include="src\EventLog.cs" />
+    <Compile Include="src\EventLogRuleConfiguration.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="src\EventLogRuleConfiguration.Designer.cs">
+      <DependentUpon>EventLogRuleConfiguration.cs</DependentUpon>
+    </Compile>
     <Compile Include="src\Exceptions_Control.cs">
       <SubType>UserControl</SubType>
     </Compile>
@@ -267,6 +273,9 @@
     </EmbeddedResource>
     <EmbeddedResource Include="src\EditWorkflow.resx">
       <DependentUpon>EditWorkflow.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="src\EventLogRuleConfiguration.resx">
+      <DependentUpon>EventLogRuleConfiguration.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="src\Exceptions_Control.resx">
       <DependentUpon>Exceptions_Control.cs</DependentUpon>

--- a/WDAC-Policy-Wizard/app/src/EditWorkflow.Designer.cs
+++ b/WDAC-Policy-Wizard/app/src/EditWorkflow.Designer.cs
@@ -34,7 +34,7 @@ namespace WDAC_Wizard
         {
             this.label1 = new System.Windows.Forms.Label();
             this.label2 = new System.Windows.Forms.Label();
-            this.button_Create = new System.Windows.Forms.Button();
+            this.browseButton = new System.Windows.Forms.Button();
             this.textBoxPolicyPath = new System.Windows.Forms.TextBox();
             this.policyInfoPanel = new System.Windows.Forms.Panel();
             this.label5 = new System.Windows.Forms.Label();
@@ -58,9 +58,6 @@ namespace WDAC_Wizard
             this.eventLogParsing_Result_Panel = new System.Windows.Forms.Panel();
             this.parseresult_PictureBox = new System.Windows.Forms.PictureBox();
             this.parseResults_Label = new System.Windows.Forms.Label();
-            this.label8 = new System.Windows.Forms.Label();
-            this.label7 = new System.Windows.Forms.Label();
-            this.comboBox_Level = new System.Windows.Forms.ComboBox();
             this.textBox_EventLogFilePath = new System.Windows.Forms.TextBox();
             this.label4 = new System.Windows.Forms.Label();
             this.label6 = new System.Windows.Forms.Label();
@@ -99,20 +96,20 @@ namespace WDAC_Wizard
             this.label2.TabIndex = 108;
             this.label2.Text = "Browse for your policy on disk or create one from a code integrity event log.";
             // 
-            // button_Create
+            // browseButton
             // 
-            this.button_Create.FlatAppearance.BorderColor = System.Drawing.SystemColors.MenuHighlight;
-            this.button_Create.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.button_Create.Font = new System.Drawing.Font("Tahoma", 9F);
-            this.button_Create.ForeColor = System.Drawing.Color.DodgerBlue;
-            this.button_Create.Location = new System.Drawing.Point(499, 21);
-            this.button_Create.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
-            this.button_Create.Name = "button_Create";
-            this.button_Create.Size = new System.Drawing.Size(110, 28);
-            this.button_Create.TabIndex = 109;
-            this.button_Create.Text = "Browse";
-            this.button_Create.UseVisualStyleBackColor = true;
-            this.button_Create.Click += new System.EventHandler(this.button_Create_Click);
+            this.browseButton.FlatAppearance.BorderColor = System.Drawing.SystemColors.MenuHighlight;
+            this.browseButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.browseButton.Font = new System.Drawing.Font("Tahoma", 9F);
+            this.browseButton.ForeColor = System.Drawing.Color.DodgerBlue;
+            this.browseButton.Location = new System.Drawing.Point(499, 21);
+            this.browseButton.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
+            this.browseButton.Name = "browseButton";
+            this.browseButton.Size = new System.Drawing.Size(110, 28);
+            this.browseButton.TabIndex = 109;
+            this.browseButton.Text = "Browse";
+            this.browseButton.UseVisualStyleBackColor = true;
+            this.browseButton.Click += new System.EventHandler(this.BrowseButton_Click);
             // 
             // textBoxPolicyPath
             // 
@@ -178,7 +175,7 @@ namespace WDAC_Wizard
             this.textBox_PolicyID.Name = "textBox_PolicyID";
             this.textBox_PolicyID.Size = new System.Drawing.Size(351, 26);
             this.textBox_PolicyID.TabIndex = 3;
-            this.textBox_PolicyID.TextChanged += new System.EventHandler(this.textBox_PolicyID_TextChanged);
+            this.textBox_PolicyID.TextChanged += new System.EventHandler(this.TextBox_PolicyID_TextChanged);
             // 
             // label_fileLocation
             // 
@@ -195,13 +192,13 @@ namespace WDAC_Wizard
             // 
             this.button_ParseEventLog.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.button_ParseEventLog.ForeColor = System.Drawing.Color.DodgerBlue;
-            this.button_ParseEventLog.Location = new System.Drawing.Point(343, 163);
+            this.button_ParseEventLog.Location = new System.Drawing.Point(343, 76);
             this.button_ParseEventLog.Name = "button_ParseEventLog";
             this.button_ParseEventLog.Size = new System.Drawing.Size(133, 27);
             this.button_ParseEventLog.TabIndex = 112;
             this.button_ParseEventLog.Text = "Parse Event Log";
             this.button_ParseEventLog.UseVisualStyleBackColor = true;
-            this.button_ParseEventLog.Click += new System.EventHandler(this.button_ParseEventLog_Click);
+            this.button_ParseEventLog.Click += new System.EventHandler(this.ParseSystemLog_ButtonClick);
             // 
             // button_Parse_LogFile
             // 
@@ -209,13 +206,13 @@ namespace WDAC_Wizard
             this.button_Parse_LogFile.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.button_Parse_LogFile.Font = new System.Drawing.Font("Microsoft Sans Serif", 8F);
             this.button_Parse_LogFile.ForeColor = System.Drawing.Color.DodgerBlue;
-            this.button_Parse_LogFile.Location = new System.Drawing.Point(343, 269);
+            this.button_Parse_LogFile.Location = new System.Drawing.Point(343, 182);
             this.button_Parse_LogFile.Name = "button_Parse_LogFile";
             this.button_Parse_LogFile.Size = new System.Drawing.Size(133, 27);
             this.button_Parse_LogFile.TabIndex = 113;
             this.button_Parse_LogFile.Text = "Parse Log File";
             this.button_Parse_LogFile.UseVisualStyleBackColor = true;
-            this.button_Parse_LogFile.Click += new System.EventHandler(this.button_Parse_LogFile_Click);
+            this.button_Parse_LogFile.Click += new System.EventHandler(this.ParseLog_ButtonClick);
             // 
             // backgroundWorker
             // 
@@ -228,9 +225,9 @@ namespace WDAC_Wizard
             // 
             this.panel_Progress.Controls.Add(this.label_Progress);
             this.panel_Progress.Controls.Add(this.pictureBox_Progress);
-            this.panel_Progress.Location = new System.Drawing.Point(537, 112);
+            this.panel_Progress.Location = new System.Drawing.Point(533, 30);
             this.panel_Progress.Name = "panel_Progress";
-            this.panel_Progress.Size = new System.Drawing.Size(280, 179);
+            this.panel_Progress.Size = new System.Drawing.Size(280, 193);
             this.panel_Progress.TabIndex = 114;
             this.panel_Progress.Visible = false;
             // 
@@ -239,7 +236,7 @@ namespace WDAC_Wizard
             this.label_Progress.AutoSize = true;
             this.label_Progress.Location = new System.Drawing.Point(15, 18);
             this.label_Progress.Name = "label_Progress";
-            this.label_Progress.Size = new System.Drawing.Size(300, 20);
+            this.label_Progress.Size = new System.Drawing.Size(254, 17);
             this.label_Progress.TabIndex = 1;
             this.label_Progress.Text = "23 / 137 Rules from Event Log Created";
             this.label_Progress.TextAlign = System.Drawing.ContentAlignment.TopCenter;
@@ -323,9 +320,6 @@ namespace WDAC_Wizard
             this.panel_EventLog_Conversion.Controls.Add(this.textBox_EventLog);
             this.panel_EventLog_Conversion.Controls.Add(this.eventLogParsing_Result_Panel);
             this.panel_EventLog_Conversion.Controls.Add(this.button_Parse_LogFile);
-            this.panel_EventLog_Conversion.Controls.Add(this.label8);
-            this.panel_EventLog_Conversion.Controls.Add(this.label7);
-            this.panel_EventLog_Conversion.Controls.Add(this.comboBox_Level);
             this.panel_EventLog_Conversion.Controls.Add(this.textBox_EventLogFilePath);
             this.panel_EventLog_Conversion.Controls.Add(this.label4);
             this.panel_EventLog_Conversion.Controls.Add(this.label6);
@@ -340,7 +334,7 @@ namespace WDAC_Wizard
             // textBox_EventLog
             // 
             this.textBox_EventLog.Font = new System.Drawing.Font("Tahoma", 9F);
-            this.textBox_EventLog.Location = new System.Drawing.Point(23, 133);
+            this.textBox_EventLog.Location = new System.Drawing.Point(23, 46);
             this.textBox_EventLog.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.textBox_EventLog.Name = "textBox_EventLog";
             this.textBox_EventLog.ReadOnly = true;
@@ -351,10 +345,10 @@ namespace WDAC_Wizard
             // 
             this.eventLogParsing_Result_Panel.Controls.Add(this.parseresult_PictureBox);
             this.eventLogParsing_Result_Panel.Controls.Add(this.parseResults_Label);
-            this.eventLogParsing_Result_Panel.Location = new System.Drawing.Point(20, 311);
+            this.eventLogParsing_Result_Panel.Location = new System.Drawing.Point(22, 240);
             this.eventLogParsing_Result_Panel.Margin = new System.Windows.Forms.Padding(2);
             this.eventLogParsing_Result_Panel.Name = "eventLogParsing_Result_Panel";
-            this.eventLogParsing_Result_Panel.Size = new System.Drawing.Size(526, 63);
+            this.eventLogParsing_Result_Panel.Size = new System.Drawing.Size(526, 47);
             this.eventLogParsing_Result_Panel.TabIndex = 122;
             this.eventLogParsing_Result_Panel.Visible = false;
             // 
@@ -381,85 +375,44 @@ namespace WDAC_Wizard
             this.parseResults_Label.TabIndex = 16;
             this.parseResults_Label.Text = "Policy conversion was successful.";
             // 
-            // label8
-            // 
-            this.label8.AutoSize = true;
-            this.label8.Font = new System.Drawing.Font("Tahoma", 8F);
-            this.label8.ForeColor = System.Drawing.Color.Black;
-            this.label8.Location = new System.Drawing.Point(19, 44);
-            this.label8.Name = "label8";
-            this.label8.Size = new System.Drawing.Size(470, 17);
-            this.label8.TabIndex = 121;
-            this.label8.Text = "The Wizard will try to create file rules with this level and fallback to hash rul" +
-    "es";
-            // 
-            // label7
-            // 
-            this.label7.AutoSize = true;
-            this.label7.Font = new System.Drawing.Font("Tahoma", 9.5F);
-            this.label7.ForeColor = System.Drawing.Color.Black;
-            this.label7.Location = new System.Drawing.Point(19, 16);
-            this.label7.Name = "label7";
-            this.label7.Size = new System.Drawing.Size(116, 19);
-            this.label7.TabIndex = 120;
-            this.label7.Text = "File Rule Level:";
-            // 
-            // comboBox_Level
-            // 
-            this.comboBox_Level.FormattingEnabled = true;
-            this.comboBox_Level.Items.AddRange(new object[] {
-            "Root CA Certificate",
-            "PCA Certificate",
-            "Publisher",
-            "Signed Version",
-            "File Publisher",
-            "File Name",
-            "Hash"});
-            this.comboBox_Level.Location = new System.Drawing.Point(140, 13);
-            this.comboBox_Level.Name = "comboBox_Level";
-            this.comboBox_Level.Size = new System.Drawing.Size(135, 28);
-            this.comboBox_Level.TabIndex = 119;
-            this.comboBox_Level.Text = "Select Level";
-            this.comboBox_Level.SelectedIndexChanged += new System.EventHandler(this.comboBox_Level_SelectedIndexChanged);
-            // 
             // textBox_EventLogFilePath
             // 
             this.textBox_EventLogFilePath.Font = new System.Drawing.Font("Tahoma", 9F);
-            this.textBox_EventLogFilePath.Location = new System.Drawing.Point(23, 239);
+            this.textBox_EventLogFilePath.Location = new System.Drawing.Point(23, 152);
             this.textBox_EventLogFilePath.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.textBox_EventLogFilePath.Name = "textBox_EventLogFilePath";
             this.textBox_EventLogFilePath.ReadOnly = true;
             this.textBox_EventLogFilePath.Size = new System.Drawing.Size(453, 26);
             this.textBox_EventLogFilePath.TabIndex = 118;
-            this.textBox_EventLogFilePath.Text = "Select Event Log File";
+            this.textBox_EventLogFilePath.Text = "Select Event Log Files";
             // 
             // label4
             // 
             this.label4.AutoSize = true;
             this.label4.Font = new System.Drawing.Font("Tahoma", 9.5F);
             this.label4.ForeColor = System.Drawing.Color.Black;
-            this.label4.Location = new System.Drawing.Point(16, 217);
+            this.label4.Location = new System.Drawing.Point(16, 130);
             this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(238, 19);
+            this.label4.Size = new System.Drawing.Size(270, 19);
             this.label4.TabIndex = 117;
-            this.label4.Text = "Parse an Event Log File to Policy";
+            this.label4.Text = "Parse a Event Log evtx Files to Policy";
             // 
             // label6
             // 
             this.label6.AutoSize = true;
             this.label6.Font = new System.Drawing.Font("Tahoma", 9F, System.Drawing.FontStyle.Bold);
             this.label6.ForeColor = System.Drawing.Color.Black;
-            this.label6.Location = new System.Drawing.Point(17, 112);
+            this.label6.Location = new System.Drawing.Point(17, 25);
             this.label6.Name = "label6";
-            this.label6.Size = new System.Drawing.Size(493, 18);
+            this.label6.Size = new System.Drawing.Size(432, 18);
             this.label6.TabIndex = 116;
-            this.label6.Text = "Parse Event Log from the Event Viewer to Policy (Recommended)";
+            this.label6.Text = "Parse Event Logs from the system Event Viewer to Policy";
             // 
             // panel_Edit_XML
             // 
             this.panel_Edit_XML.Controls.Add(this.label3);
             this.panel_Edit_XML.Controls.Add(this.policyInfoPanel);
-            this.panel_Edit_XML.Controls.Add(this.button_Create);
+            this.panel_Edit_XML.Controls.Add(this.browseButton);
             this.panel_Edit_XML.Controls.Add(this.textBoxPolicyPath);
             this.panel_Edit_XML.Location = new System.Drawing.Point(3, 3);
             this.panel_Edit_XML.Name = "panel_Edit_XML";
@@ -529,7 +482,7 @@ namespace WDAC_Wizard
 
         private System.Windows.Forms.Label label1;
         private System.Windows.Forms.Label label2;
-        private System.Windows.Forms.Button button_Create;
+        private System.Windows.Forms.Button browseButton;
         private System.Windows.Forms.TextBox textBoxPolicyPath;
         private System.Windows.Forms.Panel policyInfoPanel;
         private System.Windows.Forms.Label label5;
@@ -551,9 +504,6 @@ namespace WDAC_Wizard
         private System.Windows.Forms.Panel panel_EventLog_Conversion;
         private System.Windows.Forms.Panel panel_Edit_XML;
         private System.Windows.Forms.Label label3;
-        private System.Windows.Forms.Label label8;
-        private System.Windows.Forms.Label label7;
-        private System.Windows.Forms.ComboBox comboBox_Level;
         private System.Windows.Forms.TextBox textBox_EventLogFilePath;
         private System.Windows.Forms.Label label4;
         private System.Windows.Forms.Label label6;

--- a/WDAC-Policy-Wizard/app/src/EditWorkflow.cs
+++ b/WDAC-Policy-Wizard/app/src/EditWorkflow.cs
@@ -26,15 +26,15 @@ namespace WDAC_Wizard
         private MainWindow _MainWindow;
         private WDAC_Policy Policy;
         private Runspace runspace;
-        private List<DriverFile> DriverFiles;
         private WorkflowType Workflow;
-        private RuleLevel SelectedLevel; 
+        private RuleLevel SelectedLevel;
+        private List<string> EventLogPaths; 
         const int PAD_X = 3;
         const int PAD_Y = 3;
 
         const string EVENT_LOG_POLICY_PATH = "EventLog_ConvertedTo_WDAC.xml"; 
 
-        private enum WorkflowType
+        public enum WorkflowType
         {
             Edit = 0, 
             DeviceEventLog = 1, 
@@ -65,14 +65,15 @@ namespace WDAC_Wizard
             this.Log = this._MainWindow.Log;
             this.Log.AddInfoMsg("==== Edit Workflow Page Initialized ====");
             this.Workflow = WorkflowType.Edit; // Edit xml is default in the UI
-            this.SelectedLevel = RuleLevel.None; 
+            this.SelectedLevel = RuleLevel.None;
+            this.EventLogPaths = new List<string>();
         }
 
         /// <summary>
         /// Sets the Edit Policy Path parameter of the policy object. Launches the OpenFileDialog so the user can 
         /// select the Policy they would like to edit. 
         /// </summary>
-        private void button_Create_Click(object sender, EventArgs e)
+        private void BrowseButton_Click(object sender, EventArgs e)
         {
             // If user is changing the policy schema being edited, show message
             if(this._MainWindow.PageList.Count > 1)
@@ -196,15 +197,18 @@ namespace WDAC_Wizard
         /// <summary>
         /// Sets the new Policy ID setting. 
         /// </summary>
-        private void textBox_PolicyID_TextChanged(object sender, EventArgs e)
+        private void TextBox_PolicyID_TextChanged(object sender, EventArgs e)
         {
             this._MainWindow.Policy.PolicyID = textBox_PolicyID.Text;
         }
 
-
-        private void button_Parse_LogFile_Click(object sender, EventArgs e)
+        /// <summary>
+        /// Parses the event logs on file provided by the user
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void ParseLog_ButtonClick(object sender, EventArgs e)
         {
-
             if (this.SelectedLevel == RuleLevel.None)
             {
                 this.Log.AddWarningMsg("Selected Level is null. Level must be selected before Parse_LogEvent_Click");
@@ -228,20 +232,14 @@ namespace WDAC_Wizard
                 return; 
             }
 
+            this.EventLogPaths = eventLogPaths; 
+
             // Prep UI
             this.textBox_EventLogFilePath.Text = eventLogPaths[0]; 
             this.panel_Progress.Visible = true;
             this.label_Error.Visible = false;
             this.eventLogParsing_Result_Panel.Visible = false;
             this.Workflow = WorkflowType.ArbitraryEventLog;
-
-
-            List<CiEvent> ciEvents = EventLog.ReadArbitraryEventLogs(eventLogPaths);
-                     
-            // TODO: handle 0 case
-            //this.NumberRules = this.DriverFiles.Count;
-            //this.label_Progress.Text = String.Format("0 / {0} Rules from Event Log Created", this.NumberRules); 
-
 
             // Create background worker to display updates to UI
             if (!this.backgroundWorker.IsBusy)
@@ -250,7 +248,12 @@ namespace WDAC_Wizard
             }  
         }
 
-        private void button_ParseEventLog_Click(object sender, EventArgs e)
+        /// <summary>
+        /// Parses the system event logs
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void ParseSystemLog_ButtonClick(object sender, EventArgs e)
         {
             // Serialize the siPolicy to xml and display the name and ID to user. 
             // Afterwards, set the editPath to the temp location of the xml
@@ -275,34 +278,24 @@ namespace WDAC_Wizard
             {
                 this.backgroundWorker.RunWorkerAsync();
             }
-
         }
 
+        /// <summary>
+        /// Parses the event logs provided by the user
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
         private void BackgroundWorker_DoWork(object sender, DoWorkEventArgs e)
         {
             this.backgroundWorker = sender as BackgroundWorker;
-            string xmlPath = String.Empty; 
             if(this.Workflow == WorkflowType.ArbitraryEventLog)
             {
-                List<string> policyPaths = ConvertDriverFilestoXml(this.DriverFiles);
-                xmlPath = MergeAllPolicies(policyPaths); 
-            }
-            
-            else if(this.Workflow == WorkflowType.DeviceEventLog)
-            {
-                //SiPolicy siPolicy = Helper.ReadMachineEventLogs(this._MainWindow.TempFolderPath, this.SelectedLevel.ToString());
-
-                xmlPath = Path.Combine(this._MainWindow.TempFolderPath, EVENT_LOG_POLICY_PATH);
-                // Helper.SerializePolicytoXML(siPolicy, xmlPath);
+                this._MainWindow.CiEvents = EventLog.ReadArbitraryEventLogs(this.EventLogPaths);
             }
             else
             {
-
+                // this._MainWindow.CiEvents = EventLog.ReadSystemEventLogs();
             }
-
-            // Set paths correctly so policy rules page can parse the policy
-            this.EditPath = xmlPath;
-            this._MainWindow.Policy.EditPolicyPath = this.EditPath;
         }
 
         private void backgroundWorker_ProgressChanged(object sender, ProgressChangedEventArgs e)
@@ -314,6 +307,11 @@ namespace WDAC_Wizard
             label_Progress.Text = progress; 
         }
 
+        /// <summary>
+        /// Sets the UI after parsing the event logs finishes successfully or unsuccessfully
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
         private void BackgroundWorker_RunWorkerCompleted(object sender, RunWorkerCompletedEventArgs e)
         {
             // Remove GIF // Update UI 
@@ -337,190 +335,16 @@ namespace WDAC_Wizard
             }
 
             this.Log.AddNewSeparationLine("Event Parsing Workflow -- DONE");
-
         }
 
-
-        public string CreateCustomRuleScript(PolicyCustomRules customRule)
-        {
-            string customRuleScript = string.Empty;
-
-            // Create new CI Rule: https://docs.microsoft.com/powershell/module/configci/new-cipolicyrule
-            switch (customRule.GetRuleType())
-            {
-                case PolicyCustomRules.RuleType.Publisher:
-                    {
-                        customRuleScript = String.Format("$Rule_{0} = New-CIPolicyRule -Level {1} -DriverFilePath \'{2}\'" +
-                            " -Fallback Hash", customRule.PSVariable, customRule.GetRuleLevel(), customRule.ReferenceFile);
-                    }
-                    break;
-
-                case PolicyCustomRules.RuleType.FilePath:
-                    {
-                        customRuleScript = String.Format("$Rule_{0} = New-CIPolicyRule -Level FilePath -DriverFilePath \"{1}\"" +
-                            " -Fallback Hash -UserWriteablePaths", customRule.PSVariable, customRule.ReferenceFile); // -UserWriteablePaths allows all paths (userWriteable and non) to be added as filepath rules
-                    }
-                    break;
-
-                case PolicyCustomRules.RuleType.Folder:
-                    {
-                        // Check if part of the folder path can be replaced with an env variable eg. %OSDRIVE% == "C:\"
-                        if (customRule.GetRuleType() == PolicyCustomRules.RuleType.FilePath && Properties.Settings.Default.useEnvVars )
-                            customRuleScript = String.Format("$Rule_{0} = New-CIPolicyRule -FilePathRule \"{1}\"", customRule.PSVariable, Helper.GetEnvPath(customRule.ReferenceFile));
-                        else
-                            customRuleScript = String.Format("$Rule_{0} = New-CIPolicyRule -FilePathRule \"{1}\"", customRule.PSVariable, customRule.ReferenceFile);
-                    }
-                    break;
-
-                case PolicyCustomRules.RuleType.FileAttributes:
-                    {
-                        customRuleScript = String.Format("$Rule_{0} = New-CIPolicyRule -Level FileName -SpecificFileNameLevel {1} -DriverFilePath \"{2}\" " +
-                            "-Fallback Hash", customRule.PSVariable, customRule.GetRuleLevel(), customRule.ReferenceFile);
-                    }
-                    break;
-
-                case PolicyCustomRules.RuleType.Hash:
-                    {
-                        customRuleScript = String.Format("$Rule_{0} = New-CIPolicyRule -Level {1} -DriverFilePath \"{2}\" ", customRule.PSVariable, customRule.GetRuleLevel(), customRule.ReferenceFile);
-                    }
-                    break;
-            }
-
-            // If this is a deny rule, append the Deny switch
-            if (customRule.GetRulePermission() == PolicyCustomRules.RulePermission.Deny)
-            {
-                customRuleScript += " -Deny";
-            }
-                
-            return customRuleScript;
-        }
 
         /// <summary>
-        /// Creates a unique CI Policy file per custom rule defined in the SigningRules_Control. Writes to a unique filepath.
+        /// Opens the 'Create a policy from Event Logs' MS Docs page
         /// </summary>
-        public string CreatePolicyScript(PolicyCustomRules customRule, string tempPolicyPath)
-        {
-            string policyScript;
-
-            if (this.Policy._Format == WDAC_Policy.Format.MultiPolicy)
-            {
-                policyScript = String.Format("New-CIPolicy -MultiplePolicyFormat -FilePath \"{0}\" -Rules $Rule_{1}", tempPolicyPath, customRule.PSVariable);
-            }
-                
-            else
-            {
-                policyScript = String.Format("New-CIPolicy -FilePath \"{0}\" -Rules $Rule_{1}", tempPolicyPath, customRule.PSVariable);
-            }
-                
-            return policyScript;
-        }
-
-        private List<string> ConvertDriverFilestoXml(List<DriverFile> driverFiles)
-        {
-            List<string> policyPaths = new List<string>();
-
-            for (int i = 0; i < driverFiles.Count(); i++)
-            {
-                var file = driverFiles[i];
-                string tmpPolicyPath = Helper.GetUniquePolicyPath(this._MainWindow.TempFolderPath);
-                PolicyCustomRules customRule = new PolicyCustomRules();
-                customRule.ReferenceFile = file.Path;
-
-                switch ((int)this.SelectedLevel)
-                {
-                    case 0:
-                        customRule.Type = PolicyCustomRules.RuleType.Publisher;
-                        customRule.Level = PolicyCustomRules.RuleLevel.RootCertificate;
-                        break;
-
-                    case 1:
-                        customRule.Type = PolicyCustomRules.RuleType.Publisher;
-                        customRule.Level = PolicyCustomRules.RuleLevel.PcaCertificate;
-                        break;
-
-                    case 2:
-                        customRule.Type = PolicyCustomRules.RuleType.Publisher;
-                        customRule.Level = PolicyCustomRules.RuleLevel.Publisher;
-                        break;
-
-                    case 3:
-                        customRule.Type = PolicyCustomRules.RuleType.Publisher;
-                        customRule.Level = PolicyCustomRules.RuleLevel.SignedVersion;
-                        break;
-
-                    case 4:
-                        customRule.Type = PolicyCustomRules.RuleType.Publisher;
-                        customRule.Level = PolicyCustomRules.RuleLevel.FilePublisher;
-                        break;
-
-                    case 5:
-                        customRule.Type = PolicyCustomRules.RuleType.FilePath;
-                        customRule.Level = PolicyCustomRules.RuleLevel.FilePath;
-                        break;
-
-                    case 6:
-                        customRule.Type = PolicyCustomRules.RuleType.Hash;
-                        customRule.Level = PolicyCustomRules.RuleLevel.Hash;
-                        break;
-                }
-                
-                
-                customRule.Permission = PolicyCustomRules.RulePermission.Allow;
-                customRule.PSVariable = i.ToString();
-                string ruleScript = CreateCustomRuleScript(customRule);
-                string policyScript = CreatePolicyScript(customRule, tmpPolicyPath);
-
-                // Add script to pipeline and run PS command
-                Pipeline pipeline = this.runspace.CreatePipeline();
-                pipeline.Commands.AddScript(ruleScript);
-                pipeline.Commands.AddScript(policyScript);
-
-                // Update progress bar per completion of custom rule created
-                double prog = Math.Ceiling((double)i / (double)driverFiles.Count * (double)100);
-                this.backgroundWorker.ReportProgress((int) prog);
-
-                try
-                {
-                    Collection<PSObject> results = pipeline.Invoke();
-                    policyPaths.Add(tmpPolicyPath);
-                }
-                catch (Exception exp)
-                {
-                    this.Log.AddErrorMsg("CreatePolicyFileRuleOptions() caught the following exception ", exp);
-                }
-
-                pipeline.Dispose(); 
-            }
-
-            return policyPaths; 
-        }
-
-        private string MergeAllPolicies(List<string> policyPaths)
-        {
-            string mergeScript = "Merge-CIPolicy -PolicyPaths ";
-            string xmlPath = Path.Combine(this._MainWindow.TempFolderPath, EVENT_LOG_POLICY_PATH);
-
-            foreach (var path in policyPaths)
-            {
-                mergeScript += String.Format("\"{0}\",", path);
-            }
-
-            // Remove last comma and add outputFilePath
-            mergeScript = mergeScript.Remove(mergeScript.Length - 1);
-            mergeScript += String.Format(" -OutputFilePath \"{0}\"", xmlPath);
-            Pipeline mergePipeline = this.runspace.CreatePipeline();
-
-            mergePipeline.Commands.AddScript(mergeScript);
-            mergePipeline.Commands.Add("Out-String");
-            mergePipeline.Invoke();
-            mergePipeline.Dispose();
-
-            return xmlPath;
-        }
-
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
         private void Label_LearnMore_Click(object sender, EventArgs e)
         {
-            // multi-policy info label clicked. Launch multi-policy info webpage
             try
             {
                 string webpage = "https://docs.microsoft.com/windows/security/threat-protection/windows-defender-application-control"
@@ -533,17 +357,29 @@ namespace WDAC_Wizard
             }
         }
 
+        /// <summary>
+        /// Sets the UI state for Edit XML workflow
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
         private void EditXML_RadioButton_Click(object sender, EventArgs e)
         {
             // User wants to edit xml file of an existing policy. Prepare the UI accordingly
             this.panel_Edit_XML.Visible = true;
             this.panel_EventLog_Conversion.Visible = false;
 
+            this._MainWindow.EditWorkflow = MainWindow.EditWorkflowType.Edit;
+
             // Bring edit xml panel to upper-right corner of page panel
             Point urPoint = new Point(PAD_X, PAD_Y);
             this.panel_Edit_XML.Location = urPoint; 
         }
 
+        /// <summary>
+        /// Sets the UI state for event conversion workflow
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
         private void EventConversion_RadioButton_Click(object sender, EventArgs e)
         {
             // User wants to convert an event log to a WDAC policy. Prepare the UI accordingly
@@ -551,45 +387,11 @@ namespace WDAC_Wizard
             this.panel_EventLog_Conversion.Visible = true;
             this.textBox_EventLog.Text = Properties.Resources.CILogEvtPath;
 
+            this._MainWindow.EditWorkflow = MainWindow.EditWorkflowType.DeviceEventLog;
 
             // Bring edit xml panel to upper-right corner of page panel
             Point urPoint = new Point(PAD_X, PAD_Y);
             this.panel_EventLog_Conversion.Location = urPoint;
-        }
-
-        private void comboBox_Level_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            // Convert selected index to this.SelectedLevel
-            switch(this.comboBox_Level.SelectedIndex)
-            {
-                case 0:
-                    this.SelectedLevel = RuleLevel.RootCertificate;
-                    break;
-
-                case 1:
-                    this.SelectedLevel = RuleLevel.PCACertificate;
-                    break;
-
-                case 2:
-                    this.SelectedLevel = RuleLevel.Publisher;
-                    break;
-
-                case 3:
-                    this.SelectedLevel = RuleLevel.SignedVersion;
-                    break;
-
-                case 4:
-                    this.SelectedLevel = RuleLevel.FilePublisher;
-                    break;
-
-                case 5:
-                    this.SelectedLevel = RuleLevel.FileName;
-                    break;
-
-                case 6:
-                    this.SelectedLevel = RuleLevel.Hash;
-                    break;
-            }
         }
     }
 }

--- a/WDAC-Policy-Wizard/app/src/EditWorkflow.cs
+++ b/WDAC-Policy-Wizard/app/src/EditWorkflow.cs
@@ -218,7 +218,7 @@ namespace WDAC_Wizard
             this.EventLogPaths = eventLogPaths; 
 
             // Prep UI
-            this.textBox_EventLogFilePath.Text = eventLogPaths[0]; 
+            this.textBox_EventLogFilePath.Text = string.Join(", ", eventLogPaths.ToArray()); 
             this.panel_Progress.Visible = true;
             this.label_Error.Visible = false;
             this.eventLogParsing_Result_Panel.Visible = false;
@@ -267,7 +267,7 @@ namespace WDAC_Wizard
             }
             else
             {
-                // this._MainWindow.CiEvents = EventLog.ReadSystemEventLogs();
+                this._MainWindow.CiEvents = EventLog.ReadSystemEventLogs();
             }
         }
 

--- a/WDAC-Policy-Wizard/app/src/EditWorkflow.cs
+++ b/WDAC-Policy-Wizard/app/src/EditWorkflow.cs
@@ -236,11 +236,11 @@ namespace WDAC_Wizard
             this.Workflow = WorkflowType.ArbitraryEventLog;
 
 
-            this.DriverFiles = Helper.ReadArbitraryEventLogs(eventLogPaths);
+            List<CiEvent> ciEvents = EventLog.ReadArbitraryEventLogs(eventLogPaths);
                      
             // TODO: handle 0 case
-            this.NumberRules = this.DriverFiles.Count;
-            this.label_Progress.Text = String.Format("0 / {0} Rules from Event Log Created", this.NumberRules); 
+            //this.NumberRules = this.DriverFiles.Count;
+            //this.label_Progress.Text = String.Format("0 / {0} Rules from Event Log Created", this.NumberRules); 
 
 
             // Create background worker to display updates to UI
@@ -290,10 +290,10 @@ namespace WDAC_Wizard
             
             else if(this.Workflow == WorkflowType.DeviceEventLog)
             {
-                SiPolicy siPolicy = Helper.ReadMachineEventLogs(this._MainWindow.TempFolderPath, this.SelectedLevel.ToString());
+                //SiPolicy siPolicy = Helper.ReadMachineEventLogs(this._MainWindow.TempFolderPath, this.SelectedLevel.ToString());
 
                 xmlPath = Path.Combine(this._MainWindow.TempFolderPath, EVENT_LOG_POLICY_PATH);
-                Helper.SerializePolicytoXML(siPolicy, xmlPath);
+                // Helper.SerializePolicytoXML(siPolicy, xmlPath);
             }
             else
             {

--- a/WDAC-Policy-Wizard/app/src/EditWorkflow.cs
+++ b/WDAC-Policy-Wizard/app/src/EditWorkflow.cs
@@ -27,7 +27,6 @@ namespace WDAC_Wizard
         private WDAC_Policy Policy;
         private Runspace runspace;
         private WorkflowType Workflow;
-        private RuleLevel SelectedLevel;
         private List<string> EventLogPaths; 
         const int PAD_X = 3;
         const int PAD_Y = 3;
@@ -65,7 +64,6 @@ namespace WDAC_Wizard
             this.Log = this._MainWindow.Log;
             this.Log.AddInfoMsg("==== Edit Workflow Page Initialized ====");
             this.Workflow = WorkflowType.Edit; // Edit xml is default in the UI
-            this.SelectedLevel = RuleLevel.None;
             this.EventLogPaths = new List<string>();
         }
 
@@ -209,21 +207,6 @@ namespace WDAC_Wizard
         /// <param name="e"></param>
         private void ParseLog_ButtonClick(object sender, EventArgs e)
         {
-            if (this.SelectedLevel == RuleLevel.None)
-            {
-                this.Log.AddWarningMsg("Selected Level is null. Level must be selected before Parse_LogEvent_Click");
-                this.label_Error.Text = "Rule level must be selected before event log file parsing can begin";
-                this.label_Error.Visible = true;
-                this.label_Error.BringToFront();
-                return; 
-            }
-
-            if (this.runspace == null)
-            {
-                this.runspace = RunspaceFactory.CreateRunspace();
-                this.runspace.Open();
-            }
-
             string dspTitle = "Choose event logs to convert to policy";
             List<string> eventLogPaths = Helper.BrowseForMultiFiles(dspTitle, Helper.BrowseFileType.EventLog);
 
@@ -257,20 +240,10 @@ namespace WDAC_Wizard
         {
             // Serialize the siPolicy to xml and display the name and ID to user. 
             // Afterwards, set the editPath to the temp location of the xml
-
-            if(this.SelectedLevel == RuleLevel.None)
-            {
-                this.Log.AddWarningMsg("Selected Level is null. Level must be selected before ParseEventLog_Click");
-                this.label_Error.Text = "Rule level must be selected before event log parsing can begin";
-                this.label_Error.Visible = true;
-                this.label_Error.BringToFront(); 
-                return; 
-            }
-
             this.panel_Progress.Visible = true;
             this.label_Error.Visible = false;
             this.eventLogParsing_Result_Panel.Visible = false; 
-            this.label_Progress.Text = "Event Viewer Log Conversion in Progress";
+            this.label_Progress.Text = "Event Viewer Log Parsing in Progress";
             this.Workflow = WorkflowType.DeviceEventLog; 
 
             // Create background worker to display updates to UI
@@ -302,7 +275,7 @@ namespace WDAC_Wizard
         {
             int progressPercent = e.ProgressPercentage;
             double completedRules = Math.Ceiling((double)progressPercent / (double)100 * (double)this.NumberRules); 
-            string progress = String.Format("{0} / {1} Rules from Event Log Created", (int) completedRules, this.NumberRules); 
+            string progress = String.Format("{0} / {1} Event Log events parsed", (int) completedRules, this.NumberRules); 
 
             label_Progress.Text = progress; 
         }
@@ -330,7 +303,7 @@ namespace WDAC_Wizard
             {
                 this.parseResults_Label.Text = Properties.Resources.EventLogConversionSuccess;
                 this.parseresult_PictureBox.Image = Properties.Resources.verified;
-                DialogResult res = MessageBox.Show(Properties.Resources.EventLogConversionSuccess, "WDAC Wizard Event Log to WDAC Policy Conversion Success", 
+                DialogResult res = MessageBox.Show(Properties.Resources.EventLogConversionSuccess, "WDAC Wizard Event Log Parsing Success", 
                     MessageBoxButtons.OK, MessageBoxIcon.Information);
             }
 

--- a/WDAC-Policy-Wizard/app/src/EventLog.cs
+++ b/WDAC-Policy-Wizard/app/src/EventLog.cs
@@ -1,0 +1,316 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.IO;
+using System.Diagnostics.Eventing.Reader;
+
+
+namespace WDAC_Wizard
+{
+    internal static class EventLog
+    {
+        // Audit Events
+        const int AUDIT_KERNEL_ID = 3067;
+        const int AUDIT_PE_ID = 3076;
+        const int AUDIT_SCRIPT_ID = 8028;
+
+        // Block Events
+        const int BLOCK_PE_ID = 3077;
+        const int BLOCK_KERNEL_ID = 3068;
+        const int BLOCK_SCRIPT_ID = 8029;
+
+        const int BLOCK_SIG_LEVEL_ID = 3033;
+
+        // Signature Event
+        const int SIG_INFO_ID = 3089;
+
+        public static List<CiEvent> ReadArbitraryEventLogs(List<string> auditLogPaths)
+        {
+            List<CiEvent> ciEvents = new List<CiEvent>();
+            List<SignerEvent> signerEvents = new List<SignerEvent>(); 
+
+            foreach (var auditLogPath in auditLogPaths)
+            {
+                // Check that path provided is an evtx log
+                if (Path.GetExtension(auditLogPath) != ".evtx")
+                {
+                    continue; // do something here? Log?
+                }
+
+                EventLogReader log = new EventLogReader(auditLogPath, PathType.FilePath);
+
+                // Read Signature Events first to prepopulate for correlation with audit/block events
+                for (EventRecord entry = log.ReadEvent(); entry != null; entry = log.ReadEvent())
+                {
+                    if (entry.Id == SIG_INFO_ID)
+                    {
+                        SignerEvent signerEvent = ReadSignatureEvent(entry);
+                        if(signerEvent != null)
+                        {
+                            signerEvents.Add(signerEvent);
+                        }
+                    }
+                }
+
+                log = new EventLogReader(auditLogPath, PathType.FilePath);
+                // Read all other audit/block events
+                for (EventRecord entry = log.ReadEvent(); entry != null; entry = log.ReadEvent())
+                {
+                    // Audit 3076's
+                    if (entry.Id == AUDIT_PE_ID)
+                    {
+                        CiEvent auditEvent = ReadPEAuditEvent(entry, signerEvents);
+                        if (auditEvent != null)
+                        {
+                            ciEvents.Add(auditEvent);
+                        }
+                    }
+                    // Block 3077's
+                    else if(entry.Id == BLOCK_PE_ID)
+                    {
+                        CiEvent blockEvent = ReadPEAuditEvent(entry, signerEvents);
+                        if (blockEvent != null)
+                        {
+                            ciEvents.Add(blockEvent);
+                        }
+                    }
+                    // Block 3033's
+                    else if(entry.Id == BLOCK_SIG_LEVEL_ID)
+                    {
+                        CiEvent blockSLEvent = ReadSLBlockEvent(entry, signerEvents);
+                        if (blockSLEvent != null)
+                        {
+                            ciEvents.Add(blockSLEvent);
+                        }
+                    }
+                }
+            }
+
+            return ciEvents;
+        }
+
+        /// <summary>
+        /// Parses the EventRecord for a 3078 audit event into a CiEvent object
+        /// </summary>
+        /// <param name="entry"></param>
+        /// <returns></returns>
+        public static CiEvent ReadPEAuditEvent(EventRecord entry, List<SignerEvent> signerEvents)
+        {
+            CiEvent ciEvent = new CiEvent();
+
+            // Event Info
+            // Version 4
+            try
+            {
+                ciEvent.EventId = 3076;
+                ciEvent.CorrelationId = entry.ActivityId.ToString();
+
+                // File related info
+                string ntfilePath = entry.Properties[1].Value.ToString(); // e.g. "\\Device\\HarddiskVolume3\\Windows\\CCM\\StateMessage
+                ciEvent.FileName = Helper.GetDOSPath(ntfilePath);
+                ciEvent.SHA1 = (byte[])entry.Properties[12].Value;
+                ciEvent.SHA1Page = (byte[])entry.Properties[8].Value;
+                ciEvent.SHA2 = (byte[])entry.Properties[14].Value;
+                ciEvent.SHA2Page = (byte[])entry.Properties[10].Value;
+                ciEvent.OriginalFilename = entry.Properties[24].Value.ToString();
+                ciEvent.InternalFilename = entry.Properties[26].Value.ToString();
+                ciEvent.FileDescription = entry.Properties[28].Value.ToString();
+                ciEvent.ProductName = entry.Properties[30].Value.ToString();
+                ciEvent.FileVersion = entry.Properties[31].Value.ToString();
+
+                // Policy related info
+                // ciEvent.PolicyGUID = entry.Properties[32].Value.ToString();
+                ciEvent.PolicyName = entry.Properties[18].Value.ToString();
+                ciEvent.PolicyId = entry.Properties[20].Value.ToString();
+
+                // Try to match with pre-populated signer events
+                foreach (SignerEvent signer in signerEvents)
+                {
+                    if (signer.CorrelationId == ciEvent.CorrelationId)
+                    {
+                        ciEvent.SignerEvents.Add(signer);
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                return null;
+            }
+
+            return ciEvent;
+        }
+
+        /// <summary>
+        /// Parses the EventRecord for a 3077 block event into a CiEvent object
+        /// </summary>
+        /// <param name="entry"></param>
+        /// <returns></returns>
+        public static CiEvent ReadPEBlockEvent(EventRecord entry, List<SignerEvent> signerEvents)
+        {
+            CiEvent ciEvent = new CiEvent(); 
+
+            // Version 5
+            // Event Info
+            try
+            {
+                ciEvent.EventId = 3077;
+                ciEvent.CorrelationId = entry.ActivityId.ToString();
+
+                // File related info
+                string ntfilePath = entry.Properties[1].Value.ToString(); // e.g. "\\Device\\HarddiskVolume3\\Windows\\CCM\\StateMessage
+                ciEvent.FileName = Helper.GetDOSPath(ntfilePath);
+                ciEvent.SHA1 = (byte[])entry.Properties[12].Value;
+                ciEvent.SHA1Page = (byte[])entry.Properties[8].Value;
+                ciEvent.SHA2 = (byte[])entry.Properties[14].Value;
+                ciEvent.SHA2Page = (byte[])entry.Properties[10].Value;
+                ciEvent.OriginalFilename = entry.Properties[24].Value.ToString();
+                ciEvent.InternalFilename = entry.Properties[26].Value.ToString();
+                ciEvent.FileDescription = entry.Properties[28].Value.ToString();
+                ciEvent.ProductName = entry.Properties[30].Value.ToString();
+                ciEvent.FileVersion = entry.Properties[31].Value.ToString();
+
+                // Policy related info
+                ciEvent.PolicyGUID = entry.Properties[32].Value.ToString();
+                ciEvent.PolicyName = entry.Properties[18].Value.ToString();
+                ciEvent.PolicyId = entry.Properties[20].Value.ToString();
+
+                // Try to match with pre-populated signer events
+                foreach(SignerEvent signer in signerEvents)
+                {
+                    if(signer.CorrelationId == ciEvent.CorrelationId)
+                    {
+                        ciEvent.SignerEvents.Add(signer);
+                    }
+                }
+
+            }
+            catch(Exception e)
+            {
+                return null; 
+            }
+
+            return ciEvent; 
+        }
+
+        /// <summary>
+        /// Parses the EventRecord for a 3033 signing level block event into a CiEvent object
+        /// </summary>
+        /// <param name="entry"></param>
+        /// <returns></returns>
+        public static CiEvent ReadSLBlockEvent(EventRecord entry, List<SignerEvent> signerEvents)
+        {
+            CiEvent ciEvent = new CiEvent();
+
+            // Version 0
+            // Event Info
+            try
+            {
+                ciEvent.EventId = 3033;
+                ciEvent.CorrelationId = entry.ActivityId.ToString();
+
+                // File related info
+                string ntfilePath = entry.Properties[1].Value.ToString(); // e.g. "\\Device\\HarddiskVolume3\\Windows\\CCM\\StateMessage
+                ciEvent.FileName = Helper.GetDOSPath(ntfilePath);
+
+                // Try to match with pre-populated signer events
+                // This will be the only thing to allow on to by pass this block event
+                foreach (SignerEvent signer in signerEvents)
+                {
+                    if (signer.CorrelationId == ciEvent.CorrelationId)
+                    {
+                        ciEvent.SignerEvents.Add(signer);
+                    }
+                }
+
+            }
+            catch (Exception e)
+            {
+                return null;
+            }
+
+            return ciEvent;
+        }
+
+        /// <summary>
+        /// Parses the EventRecord for a 3089 signature event into a signer event object
+        /// </summary>
+        /// <param name="entry"></param>
+        /// <returns></returns>
+        public static SignerEvent ReadSignatureEvent(EventRecord entry)
+        {
+            // Version 4 
+
+            SignerEvent signerEvent = new SignerEvent();
+
+            // Event Info
+            try
+            {
+                signerEvent.EventId = 3089;
+                signerEvent.CorrelationId = entry.ActivityId.ToString();
+
+                // File related info
+                signerEvent.PublisherName = entry.Properties[14].Value.ToString();
+                signerEvent.IssuerName = entry.Properties[16].Value.ToString();
+                signerEvent.IssuerTBSHash = (byte[]) entry.Properties[18].Value;
+
+            }
+            catch (Exception e)
+            {
+                return null;
+            }
+
+            return signerEvent; 
+        }
+    }
+
+    public class CiEvent
+    {
+        /// <summary>
+        /// Event related inffo
+        /// </summary>
+        public int EventId { get; set; }
+        public string CorrelationId { get; set; }
+
+        // File related info
+        public string FileName { get; set; }
+        public byte[] SHA1 { get; set; }
+        public byte[] SHA1Page { get; set; }
+        public byte[] SHA2 { get; set; }
+        public byte[] SHA2Page { get; set; }
+
+        public string OriginalFilename { get; set; }
+        public string InternalFilename { get; set; }
+        public string FileDescription { get; set; }
+        public string ProductName { get; set; }
+        public string FileVersion { get; set; }
+        public string PackageFamilyName { get; set; }
+
+        public List<SignerEvent> SignerEvents {get;set;}
+
+        // Policy related info
+        public string PolicyName { get; set; }
+        public string PolicyGUID { get; set; }
+        public string PolicyId { get; set; }
+
+        public CiEvent()
+        {
+            this.SignerEvents = new List<SignerEvent>(); 
+        }
+    }
+
+    /// <summary>
+    /// Class for the 3089 signature events
+    /// </summary>
+    public class SignerEvent
+    {
+        public int EventId { get; set; }
+        public string CorrelationId { get; set; }
+
+        // Signers related info
+        public string IssuerName { get; set; }
+        public byte[] IssuerTBSHash { get; set; }
+        public string PublisherName { get; set; }
+    }
+}

--- a/WDAC-Policy-Wizard/app/src/EventLogRuleConfiguration.Designer.cs
+++ b/WDAC-Policy-Wizard/app/src/EventLogRuleConfiguration.Designer.cs
@@ -29,8 +29,7 @@ namespace WDAC_Wizard
         /// </summary>
         private void InitializeComponent()
         {
-            this.button1 = new System.Windows.Forms.Button();
-            this.customRulePanel = new System.Windows.Forms.Panel();
+            this.addButton = new System.Windows.Forms.Button();
             this.publisherRulePanel = new System.Windows.Forms.Panel();
             this.productTextBox = new System.Windows.Forms.TextBox();
             this.versionTextBox = new System.Windows.Forms.TextBox();
@@ -44,6 +43,17 @@ namespace WDAC_Wizard
             this.issuerCheckBox = new System.Windows.Forms.CheckBox();
             this.label3 = new System.Windows.Forms.Label();
             this.ruleTypeComboBox = new System.Windows.Forms.ComboBox();
+            this.fileAttributeRulePanel = new System.Windows.Forms.Panel();
+            this.pfnTextBox = new System.Windows.Forms.TextBox();
+            this.intFileNameTextBox = new System.Windows.Forms.TextBox();
+            this.prodNameTextBox = new System.Windows.Forms.TextBox();
+            this.fileDescTextBox = new System.Windows.Forms.TextBox();
+            this.origFileNameTextBox = new System.Windows.Forms.TextBox();
+            this.pfnCheckBox = new System.Windows.Forms.CheckBox();
+            this.intFileNameCheckBox = new System.Windows.Forms.CheckBox();
+            this.prodNameCheckBox = new System.Windows.Forms.CheckBox();
+            this.fileDescCheckBox = new System.Windows.Forms.CheckBox();
+            this.origFileNameCheckBox = new System.Windows.Forms.CheckBox();
             this.eventsDataGridView = new System.Windows.Forms.DataGridView();
             this.addedColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.eventIdColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
@@ -53,30 +63,36 @@ namespace WDAC_Wizard
             this.publisherColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.label1 = new System.Windows.Forms.Label();
             this.label2 = new System.Windows.Forms.Label();
-            this.customRulePanel.SuspendLayout();
+            this.hashRulePanel = new System.Windows.Forms.Panel();
+            this.label7 = new System.Windows.Forms.Label();
+            this.label6 = new System.Windows.Forms.Label();
+            this.label5 = new System.Windows.Forms.Label();
+            this.label4 = new System.Windows.Forms.Label();
+            this.sha2PageTextBox = new System.Windows.Forms.TextBox();
+            this.sha2TextBox = new System.Windows.Forms.TextBox();
+            this.sha1PageTextBox = new System.Windows.Forms.TextBox();
+            this.sha1TextBox = new System.Windows.Forms.TextBox();
+            this.filePathRulePanel = new System.Windows.Forms.Panel();
+            this.filePathTextBox = new System.Windows.Forms.TextBox();
+            this.folderPathTextBox = new System.Windows.Forms.TextBox();
+            this.folderPathCheckBox = new System.Windows.Forms.CheckBox();
+            this.filePathCheckBox = new System.Windows.Forms.CheckBox();
             this.publisherRulePanel.SuspendLayout();
+            this.fileAttributeRulePanel.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.eventsDataGridView)).BeginInit();
+            this.hashRulePanel.SuspendLayout();
+            this.filePathRulePanel.SuspendLayout();
             this.SuspendLayout();
             // 
-            // button1
+            // addButton
             // 
-            this.button1.Location = new System.Drawing.Point(177, 677);
-            this.button1.Name = "button1";
-            this.button1.Size = new System.Drawing.Size(113, 30);
-            this.button1.TabIndex = 0;
-            this.button1.Text = "Add -->";
-            this.button1.UseVisualStyleBackColor = true;
-            this.button1.Click += new System.EventHandler(this.AddButton_Click);
-            // 
-            // customRulePanel
-            // 
-            this.customRulePanel.Controls.Add(this.publisherRulePanel);
-            this.customRulePanel.Controls.Add(this.label3);
-            this.customRulePanel.Controls.Add(this.ruleTypeComboBox);
-            this.customRulePanel.Location = new System.Drawing.Point(167, 429);
-            this.customRulePanel.Name = "customRulePanel";
-            this.customRulePanel.Size = new System.Drawing.Size(669, 242);
-            this.customRulePanel.TabIndex = 1;
+            this.addButton.Location = new System.Drawing.Point(167, 653);
+            this.addButton.Name = "addButton";
+            this.addButton.Size = new System.Drawing.Size(113, 30);
+            this.addButton.TabIndex = 0;
+            this.addButton.Text = "Add Allow Rule";
+            this.addButton.UseVisualStyleBackColor = true;
+            this.addButton.Click += new System.EventHandler(this.AddButton_Click);
             // 
             // publisherRulePanel
             // 
@@ -90,9 +106,9 @@ namespace WDAC_Wizard
             this.publisherRulePanel.Controls.Add(this.filenameCheckBox);
             this.publisherRulePanel.Controls.Add(this.publisherCheckBox);
             this.publisherRulePanel.Controls.Add(this.issuerCheckBox);
-            this.publisherRulePanel.Location = new System.Drawing.Point(6, 49);
+            this.publisherRulePanel.Location = new System.Drawing.Point(167, 447);
             this.publisherRulePanel.Name = "publisherRulePanel";
-            this.publisherRulePanel.Size = new System.Drawing.Size(493, 190);
+            this.publisherRulePanel.Size = new System.Drawing.Size(716, 190);
             this.publisherRulePanel.TabIndex = 9;
             // 
             // productTextBox
@@ -100,7 +116,8 @@ namespace WDAC_Wizard
             this.productTextBox.Font = new System.Drawing.Font("Tahoma", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.productTextBox.Location = new System.Drawing.Point(102, 159);
             this.productTextBox.Name = "productTextBox";
-            this.productTextBox.Size = new System.Drawing.Size(351, 28);
+            this.productTextBox.ReadOnly = true;
+            this.productTextBox.Size = new System.Drawing.Size(420, 28);
             this.productTextBox.TabIndex = 20;
             // 
             // versionTextBox
@@ -108,7 +125,8 @@ namespace WDAC_Wizard
             this.versionTextBox.Font = new System.Drawing.Font("Tahoma", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.versionTextBox.Location = new System.Drawing.Point(102, 120);
             this.versionTextBox.Name = "versionTextBox";
-            this.versionTextBox.Size = new System.Drawing.Size(351, 28);
+            this.versionTextBox.ReadOnly = true;
+            this.versionTextBox.Size = new System.Drawing.Size(420, 28);
             this.versionTextBox.TabIndex = 19;
             // 
             // filenameTextBox
@@ -116,7 +134,8 @@ namespace WDAC_Wizard
             this.filenameTextBox.Font = new System.Drawing.Font("Tahoma", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.filenameTextBox.Location = new System.Drawing.Point(101, 81);
             this.filenameTextBox.Name = "filenameTextBox";
-            this.filenameTextBox.Size = new System.Drawing.Size(352, 28);
+            this.filenameTextBox.ReadOnly = true;
+            this.filenameTextBox.Size = new System.Drawing.Size(421, 28);
             this.filenameTextBox.TabIndex = 18;
             // 
             // publisherTextBox
@@ -124,7 +143,8 @@ namespace WDAC_Wizard
             this.publisherTextBox.Font = new System.Drawing.Font("Tahoma", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.publisherTextBox.Location = new System.Drawing.Point(103, 42);
             this.publisherTextBox.Name = "publisherTextBox";
-            this.publisherTextBox.Size = new System.Drawing.Size(351, 28);
+            this.publisherTextBox.ReadOnly = true;
+            this.publisherTextBox.Size = new System.Drawing.Size(420, 28);
             this.publisherTextBox.TabIndex = 17;
             // 
             // issuerTextBox
@@ -132,7 +152,8 @@ namespace WDAC_Wizard
             this.issuerTextBox.Font = new System.Drawing.Font("Tahoma", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.issuerTextBox.Location = new System.Drawing.Point(103, 3);
             this.issuerTextBox.Name = "issuerTextBox";
-            this.issuerTextBox.Size = new System.Drawing.Size(351, 28);
+            this.issuerTextBox.ReadOnly = true;
+            this.issuerTextBox.Size = new System.Drawing.Size(420, 28);
             this.issuerTextBox.TabIndex = 16;
             // 
             // productCheckBox
@@ -201,7 +222,7 @@ namespace WDAC_Wizard
             // 
             this.label3.AutoSize = true;
             this.label3.Font = new System.Drawing.Font("Tahoma", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label3.Location = new System.Drawing.Point(3, 17);
+            this.label3.Location = new System.Drawing.Point(163, 415);
             this.label3.Name = "label3";
             this.label3.Size = new System.Drawing.Size(90, 21);
             this.label3.TabIndex = 8;
@@ -217,10 +238,134 @@ namespace WDAC_Wizard
             "File Attributes",
             "Packaged App",
             "File Hash"});
-            this.ruleTypeComboBox.Location = new System.Drawing.Point(99, 14);
+            this.ruleTypeComboBox.Location = new System.Drawing.Point(259, 412);
             this.ruleTypeComboBox.Name = "ruleTypeComboBox";
             this.ruleTypeComboBox.Size = new System.Drawing.Size(163, 29);
             this.ruleTypeComboBox.TabIndex = 3;
+            this.ruleTypeComboBox.SelectedIndexChanged += new System.EventHandler(this.RuleTypeChanged);
+            // 
+            // fileAttributeRulePanel
+            // 
+            this.fileAttributeRulePanel.Controls.Add(this.pfnTextBox);
+            this.fileAttributeRulePanel.Controls.Add(this.intFileNameTextBox);
+            this.fileAttributeRulePanel.Controls.Add(this.prodNameTextBox);
+            this.fileAttributeRulePanel.Controls.Add(this.fileDescTextBox);
+            this.fileAttributeRulePanel.Controls.Add(this.origFileNameTextBox);
+            this.fileAttributeRulePanel.Controls.Add(this.pfnCheckBox);
+            this.fileAttributeRulePanel.Controls.Add(this.intFileNameCheckBox);
+            this.fileAttributeRulePanel.Controls.Add(this.prodNameCheckBox);
+            this.fileAttributeRulePanel.Controls.Add(this.fileDescCheckBox);
+            this.fileAttributeRulePanel.Controls.Add(this.origFileNameCheckBox);
+            this.fileAttributeRulePanel.Location = new System.Drawing.Point(1021, 99);
+            this.fileAttributeRulePanel.Name = "fileAttributeRulePanel";
+            this.fileAttributeRulePanel.Size = new System.Drawing.Size(551, 190);
+            this.fileAttributeRulePanel.TabIndex = 21;
+            this.fileAttributeRulePanel.Visible = false;
+            // 
+            // pfnTextBox
+            // 
+            this.pfnTextBox.Font = new System.Drawing.Font("Tahoma", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.pfnTextBox.Location = new System.Drawing.Point(172, 159);
+            this.pfnTextBox.Name = "pfnTextBox";
+            this.pfnTextBox.ReadOnly = true;
+            this.pfnTextBox.Size = new System.Drawing.Size(351, 28);
+            this.pfnTextBox.TabIndex = 20;
+            // 
+            // intFileNameTextBox
+            // 
+            this.intFileNameTextBox.Font = new System.Drawing.Font("Tahoma", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.intFileNameTextBox.Location = new System.Drawing.Point(172, 120);
+            this.intFileNameTextBox.Name = "intFileNameTextBox";
+            this.intFileNameTextBox.ReadOnly = true;
+            this.intFileNameTextBox.Size = new System.Drawing.Size(351, 28);
+            this.intFileNameTextBox.TabIndex = 19;
+            // 
+            // prodNameTextBox
+            // 
+            this.prodNameTextBox.Font = new System.Drawing.Font("Tahoma", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.prodNameTextBox.Location = new System.Drawing.Point(171, 81);
+            this.prodNameTextBox.Name = "prodNameTextBox";
+            this.prodNameTextBox.ReadOnly = true;
+            this.prodNameTextBox.Size = new System.Drawing.Size(352, 28);
+            this.prodNameTextBox.TabIndex = 18;
+            // 
+            // fileDescTextBox
+            // 
+            this.fileDescTextBox.Font = new System.Drawing.Font("Tahoma", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.fileDescTextBox.Location = new System.Drawing.Point(173, 42);
+            this.fileDescTextBox.Name = "fileDescTextBox";
+            this.fileDescTextBox.ReadOnly = true;
+            this.fileDescTextBox.Size = new System.Drawing.Size(351, 28);
+            this.fileDescTextBox.TabIndex = 17;
+            // 
+            // origFileNameTextBox
+            // 
+            this.origFileNameTextBox.Font = new System.Drawing.Font("Tahoma", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.origFileNameTextBox.Location = new System.Drawing.Point(173, 3);
+            this.origFileNameTextBox.Name = "origFileNameTextBox";
+            this.origFileNameTextBox.ReadOnly = true;
+            this.origFileNameTextBox.Size = new System.Drawing.Size(351, 28);
+            this.origFileNameTextBox.TabIndex = 16;
+            // 
+            // pfnCheckBox
+            // 
+            this.pfnCheckBox.AutoSize = true;
+            this.pfnCheckBox.Enabled = false;
+            this.pfnCheckBox.Font = new System.Drawing.Font("Tahoma", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.pfnCheckBox.Location = new System.Drawing.Point(3, 159);
+            this.pfnCheckBox.Name = "pfnCheckBox";
+            this.pfnCheckBox.Size = new System.Drawing.Size(147, 25);
+            this.pfnCheckBox.TabIndex = 15;
+            this.pfnCheckBox.Text = "Package Name:";
+            this.pfnCheckBox.UseVisualStyleBackColor = true;
+            // 
+            // intFileNameCheckBox
+            // 
+            this.intFileNameCheckBox.AutoSize = true;
+            this.intFileNameCheckBox.Enabled = false;
+            this.intFileNameCheckBox.Font = new System.Drawing.Font("Tahoma", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.intFileNameCheckBox.Location = new System.Drawing.Point(2, 120);
+            this.intFileNameCheckBox.Name = "intFileNameCheckBox";
+            this.intFileNameCheckBox.Size = new System.Drawing.Size(168, 25);
+            this.intFileNameCheckBox.TabIndex = 14;
+            this.intFileNameCheckBox.Text = "Internal Filename:";
+            this.intFileNameCheckBox.UseVisualStyleBackColor = true;
+            // 
+            // prodNameCheckBox
+            // 
+            this.prodNameCheckBox.AutoSize = true;
+            this.prodNameCheckBox.Enabled = false;
+            this.prodNameCheckBox.Font = new System.Drawing.Font("Tahoma", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.prodNameCheckBox.Location = new System.Drawing.Point(3, 81);
+            this.prodNameCheckBox.Name = "prodNameCheckBox";
+            this.prodNameCheckBox.Size = new System.Drawing.Size(142, 25);
+            this.prodNameCheckBox.TabIndex = 13;
+            this.prodNameCheckBox.Text = "Product Name:";
+            this.prodNameCheckBox.UseVisualStyleBackColor = true;
+            // 
+            // fileDescCheckBox
+            // 
+            this.fileDescCheckBox.AutoSize = true;
+            this.fileDescCheckBox.Enabled = false;
+            this.fileDescCheckBox.Font = new System.Drawing.Font("Tahoma", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.fileDescCheckBox.Location = new System.Drawing.Point(3, 42);
+            this.fileDescCheckBox.Name = "fileDescCheckBox";
+            this.fileDescCheckBox.Size = new System.Drawing.Size(153, 25);
+            this.fileDescCheckBox.TabIndex = 12;
+            this.fileDescCheckBox.Text = "File Description:";
+            this.fileDescCheckBox.UseVisualStyleBackColor = true;
+            // 
+            // origFileNameCheckBox
+            // 
+            this.origFileNameCheckBox.AutoSize = true;
+            this.origFileNameCheckBox.Enabled = false;
+            this.origFileNameCheckBox.Font = new System.Drawing.Font("Tahoma", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.origFileNameCheckBox.Location = new System.Drawing.Point(4, 3);
+            this.origFileNameCheckBox.Name = "origFileNameCheckBox";
+            this.origFileNameCheckBox.Size = new System.Drawing.Size(167, 25);
+            this.origFileNameCheckBox.TabIndex = 10;
+            this.origFileNameCheckBox.Text = "Original Filename:";
+            this.origFileNameCheckBox.UseVisualStyleBackColor = true;
             // 
             // eventsDataGridView
             // 
@@ -235,7 +380,7 @@ namespace WDAC_Wizard
             this.productColumn,
             this.policyColumn,
             this.publisherColumn});
-            this.eventsDataGridView.Location = new System.Drawing.Point(167, 123);
+            this.eventsDataGridView.Location = new System.Drawing.Point(167, 101);
             this.eventsDataGridView.Margin = new System.Windows.Forms.Padding(2);
             this.eventsDataGridView.MultiSelect = false;
             this.eventsDataGridView.Name = "eventsDataGridView";
@@ -323,25 +468,182 @@ namespace WDAC_Wizard
             this.label2.TabIndex = 7;
             this.label2.Text = "Create custom rules based on the WDAC event log events";
             // 
+            // hashRulePanel
+            // 
+            this.hashRulePanel.Controls.Add(this.label7);
+            this.hashRulePanel.Controls.Add(this.label6);
+            this.hashRulePanel.Controls.Add(this.label5);
+            this.hashRulePanel.Controls.Add(this.label4);
+            this.hashRulePanel.Controls.Add(this.sha2PageTextBox);
+            this.hashRulePanel.Controls.Add(this.sha2TextBox);
+            this.hashRulePanel.Controls.Add(this.sha1PageTextBox);
+            this.hashRulePanel.Controls.Add(this.sha1TextBox);
+            this.hashRulePanel.Location = new System.Drawing.Point(1021, 464);
+            this.hashRulePanel.Name = "hashRulePanel";
+            this.hashRulePanel.Size = new System.Drawing.Size(603, 164);
+            this.hashRulePanel.TabIndex = 22;
+            this.hashRulePanel.Visible = false;
+            // 
+            // label7
+            // 
+            this.label7.AutoSize = true;
+            this.label7.Font = new System.Drawing.Font("Tahoma", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label7.Location = new System.Drawing.Point(12, 124);
+            this.label7.Name = "label7";
+            this.label7.Size = new System.Drawing.Size(157, 21);
+            this.label7.TabIndex = 26;
+            this.label7.Text = "SHA256 Page Hash:";
+            // 
+            // label6
+            // 
+            this.label6.AutoSize = true;
+            this.label6.Font = new System.Drawing.Font("Tahoma", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label6.Location = new System.Drawing.Point(12, 46);
+            this.label6.Name = "label6";
+            this.label6.Size = new System.Drawing.Size(139, 21);
+            this.label6.TabIndex = 25;
+            this.label6.Text = "SHA1 Page Hash:";
+            // 
+            // label5
+            // 
+            this.label5.AutoSize = true;
+            this.label5.Font = new System.Drawing.Font("Tahoma", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label5.Location = new System.Drawing.Point(12, 85);
+            this.label5.Name = "label5";
+            this.label5.Size = new System.Drawing.Size(140, 21);
+            this.label5.TabIndex = 24;
+            this.label5.Text = "SHA256 PE Hash:";
+            // 
+            // label4
+            // 
+            this.label4.AutoSize = true;
+            this.label4.Font = new System.Drawing.Font("Tahoma", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label4.Location = new System.Drawing.Point(12, 7);
+            this.label4.Name = "label4";
+            this.label4.Size = new System.Drawing.Size(122, 21);
+            this.label4.TabIndex = 23;
+            this.label4.Text = "SHA1 PE Hash:";
+            // 
+            // sha2PageTextBox
+            // 
+            this.sha2PageTextBox.Font = new System.Drawing.Font("Tahoma", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.sha2PageTextBox.Location = new System.Drawing.Point(172, 120);
+            this.sha2PageTextBox.Name = "sha2PageTextBox";
+            this.sha2PageTextBox.ReadOnly = true;
+            this.sha2PageTextBox.Size = new System.Drawing.Size(351, 26);
+            this.sha2PageTextBox.TabIndex = 19;
+            // 
+            // sha2TextBox
+            // 
+            this.sha2TextBox.Font = new System.Drawing.Font("Tahoma", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.sha2TextBox.Location = new System.Drawing.Point(171, 81);
+            this.sha2TextBox.Name = "sha2TextBox";
+            this.sha2TextBox.ReadOnly = true;
+            this.sha2TextBox.Size = new System.Drawing.Size(352, 26);
+            this.sha2TextBox.TabIndex = 18;
+            // 
+            // sha1PageTextBox
+            // 
+            this.sha1PageTextBox.Font = new System.Drawing.Font("Tahoma", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.sha1PageTextBox.Location = new System.Drawing.Point(173, 42);
+            this.sha1PageTextBox.Name = "sha1PageTextBox";
+            this.sha1PageTextBox.ReadOnly = true;
+            this.sha1PageTextBox.Size = new System.Drawing.Size(351, 26);
+            this.sha1PageTextBox.TabIndex = 17;
+            // 
+            // sha1TextBox
+            // 
+            this.sha1TextBox.Font = new System.Drawing.Font("Tahoma", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.sha1TextBox.Location = new System.Drawing.Point(173, 3);
+            this.sha1TextBox.Name = "sha1TextBox";
+            this.sha1TextBox.ReadOnly = true;
+            this.sha1TextBox.Size = new System.Drawing.Size(351, 26);
+            this.sha1TextBox.TabIndex = 16;
+            // 
+            // filePathRulePanel
+            // 
+            this.filePathRulePanel.Controls.Add(this.filePathTextBox);
+            this.filePathRulePanel.Controls.Add(this.folderPathTextBox);
+            this.filePathRulePanel.Controls.Add(this.folderPathCheckBox);
+            this.filePathRulePanel.Controls.Add(this.filePathCheckBox);
+            this.filePathRulePanel.Location = new System.Drawing.Point(1021, 333);
+            this.filePathRulePanel.Name = "filePathRulePanel";
+            this.filePathRulePanel.Size = new System.Drawing.Size(743, 93);
+            this.filePathRulePanel.TabIndex = 22;
+            this.filePathRulePanel.Visible = false;
+            // 
+            // filePathTextBox
+            // 
+            this.filePathTextBox.Font = new System.Drawing.Font("Tahoma", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.filePathTextBox.Location = new System.Drawing.Point(173, 5);
+            this.filePathTextBox.Name = "filePathTextBox";
+            this.filePathTextBox.ReadOnly = true;
+            this.filePathTextBox.Size = new System.Drawing.Size(516, 28);
+            this.filePathTextBox.TabIndex = 18;
+            // 
+            // folderPathTextBox
+            // 
+            this.folderPathTextBox.Font = new System.Drawing.Font("Tahoma", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.folderPathTextBox.Location = new System.Drawing.Point(173, 42);
+            this.folderPathTextBox.Name = "folderPathTextBox";
+            this.folderPathTextBox.ReadOnly = true;
+            this.folderPathTextBox.Size = new System.Drawing.Size(516, 28);
+            this.folderPathTextBox.TabIndex = 17;
+            // 
+            // folderPathCheckBox
+            // 
+            this.folderPathCheckBox.AutoSize = true;
+            this.folderPathCheckBox.Checked = true;
+            this.folderPathCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.folderPathCheckBox.Font = new System.Drawing.Font("Tahoma", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.folderPathCheckBox.Location = new System.Drawing.Point(3, 44);
+            this.folderPathCheckBox.Name = "folderPathCheckBox";
+            this.folderPathCheckBox.Size = new System.Drawing.Size(122, 25);
+            this.folderPathCheckBox.TabIndex = 12;
+            this.folderPathCheckBox.Text = "Folder Path:";
+            this.folderPathCheckBox.UseVisualStyleBackColor = true;
+            // 
+            // filePathCheckBox
+            // 
+            this.filePathCheckBox.AutoSize = true;
+            this.filePathCheckBox.Checked = true;
+            this.filePathCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.filePathCheckBox.Font = new System.Drawing.Font("Tahoma", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.filePathCheckBox.Location = new System.Drawing.Point(4, 7);
+            this.filePathCheckBox.Name = "filePathCheckBox";
+            this.filePathCheckBox.Size = new System.Drawing.Size(102, 25);
+            this.filePathCheckBox.TabIndex = 10;
+            this.filePathCheckBox.Text = "File Path:";
+            this.filePathCheckBox.UseVisualStyleBackColor = true;
+            // 
             // EventLogRuleConfiguration
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(120F, 120F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.Color.White;
+            this.Controls.Add(this.publisherRulePanel);
+            this.Controls.Add(this.label3);
+            this.Controls.Add(this.filePathRulePanel);
+            this.Controls.Add(this.ruleTypeComboBox);
+            this.Controls.Add(this.hashRulePanel);
+            this.Controls.Add(this.fileAttributeRulePanel);
             this.Controls.Add(this.label2);
             this.Controls.Add(this.label1);
             this.Controls.Add(this.eventsDataGridView);
-            this.Controls.Add(this.customRulePanel);
-            this.Controls.Add(this.button1);
+            this.Controls.Add(this.addButton);
             this.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.Name = "EventLogRuleConfiguration";
             this.Size = new System.Drawing.Size(1208, 782);
             this.Load += new System.EventHandler(this.EventLogRuleConfiguration_Load);
-            this.customRulePanel.ResumeLayout(false);
-            this.customRulePanel.PerformLayout();
             this.publisherRulePanel.ResumeLayout(false);
             this.publisherRulePanel.PerformLayout();
+            this.fileAttributeRulePanel.ResumeLayout(false);
+            this.fileAttributeRulePanel.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.eventsDataGridView)).EndInit();
+            this.hashRulePanel.ResumeLayout(false);
+            this.hashRulePanel.PerformLayout();
+            this.filePathRulePanel.ResumeLayout(false);
+            this.filePathRulePanel.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -349,8 +651,7 @@ namespace WDAC_Wizard
 
         #endregion
 
-        private System.Windows.Forms.Button button1;
-        private System.Windows.Forms.Panel customRulePanel;
+        private System.Windows.Forms.Button addButton;
         private System.Windows.Forms.ComboBox ruleTypeComboBox;
         private System.Windows.Forms.DataGridView eventsDataGridView;
         private System.Windows.Forms.Label label1;
@@ -373,5 +674,30 @@ namespace WDAC_Wizard
         private System.Windows.Forms.DataGridViewTextBoxColumn productColumn;
         private System.Windows.Forms.DataGridViewTextBoxColumn policyColumn;
         private System.Windows.Forms.DataGridViewTextBoxColumn publisherColumn;
+        private System.Windows.Forms.Panel fileAttributeRulePanel;
+        private System.Windows.Forms.TextBox pfnTextBox;
+        private System.Windows.Forms.TextBox intFileNameTextBox;
+        private System.Windows.Forms.TextBox prodNameTextBox;
+        private System.Windows.Forms.TextBox fileDescTextBox;
+        private System.Windows.Forms.TextBox origFileNameTextBox;
+        private System.Windows.Forms.CheckBox pfnCheckBox;
+        private System.Windows.Forms.CheckBox intFileNameCheckBox;
+        private System.Windows.Forms.CheckBox prodNameCheckBox;
+        private System.Windows.Forms.CheckBox fileDescCheckBox;
+        private System.Windows.Forms.CheckBox origFileNameCheckBox;
+        private System.Windows.Forms.Panel hashRulePanel;
+        private System.Windows.Forms.Label label7;
+        private System.Windows.Forms.Label label6;
+        private System.Windows.Forms.Label label5;
+        private System.Windows.Forms.Label label4;
+        private System.Windows.Forms.TextBox sha2PageTextBox;
+        private System.Windows.Forms.TextBox sha2TextBox;
+        private System.Windows.Forms.TextBox sha1PageTextBox;
+        private System.Windows.Forms.TextBox sha1TextBox;
+        private System.Windows.Forms.Panel filePathRulePanel;
+        private System.Windows.Forms.TextBox folderPathTextBox;
+        private System.Windows.Forms.CheckBox folderPathCheckBox;
+        private System.Windows.Forms.CheckBox filePathCheckBox;
+        private System.Windows.Forms.TextBox filePathTextBox;
     }
 }

--- a/WDAC-Policy-Wizard/app/src/EventLogRuleConfiguration.Designer.cs
+++ b/WDAC-Policy-Wizard/app/src/EventLogRuleConfiguration.Designer.cs
@@ -86,9 +86,9 @@ namespace WDAC_Wizard
             // 
             // addButton
             // 
-            this.addButton.Location = new System.Drawing.Point(167, 653);
+            this.addButton.Location = new System.Drawing.Point(442, 412);
             this.addButton.Name = "addButton";
-            this.addButton.Size = new System.Drawing.Size(113, 30);
+            this.addButton.Size = new System.Drawing.Size(130, 30);
             this.addButton.TabIndex = 0;
             this.addButton.Text = "Add Allow Rule";
             this.addButton.UseVisualStyleBackColor = true;
@@ -478,7 +478,7 @@ namespace WDAC_Wizard
             this.hashRulePanel.Controls.Add(this.sha2TextBox);
             this.hashRulePanel.Controls.Add(this.sha1PageTextBox);
             this.hashRulePanel.Controls.Add(this.sha1TextBox);
-            this.hashRulePanel.Location = new System.Drawing.Point(1021, 464);
+            this.hashRulePanel.Location = new System.Drawing.Point(1021, 489);
             this.hashRulePanel.Name = "hashRulePanel";
             this.hashRulePanel.Size = new System.Drawing.Size(603, 164);
             this.hashRulePanel.TabIndex = 22;
@@ -530,7 +530,7 @@ namespace WDAC_Wizard
             this.sha2PageTextBox.Location = new System.Drawing.Point(172, 120);
             this.sha2PageTextBox.Name = "sha2PageTextBox";
             this.sha2PageTextBox.ReadOnly = true;
-            this.sha2PageTextBox.Size = new System.Drawing.Size(351, 26);
+            this.sha2PageTextBox.Size = new System.Drawing.Size(398, 26);
             this.sha2PageTextBox.TabIndex = 19;
             // 
             // sha2TextBox
@@ -539,7 +539,7 @@ namespace WDAC_Wizard
             this.sha2TextBox.Location = new System.Drawing.Point(171, 81);
             this.sha2TextBox.Name = "sha2TextBox";
             this.sha2TextBox.ReadOnly = true;
-            this.sha2TextBox.Size = new System.Drawing.Size(352, 26);
+            this.sha2TextBox.Size = new System.Drawing.Size(399, 26);
             this.sha2TextBox.TabIndex = 18;
             // 
             // sha1PageTextBox
@@ -548,7 +548,7 @@ namespace WDAC_Wizard
             this.sha1PageTextBox.Location = new System.Drawing.Point(173, 42);
             this.sha1PageTextBox.Name = "sha1PageTextBox";
             this.sha1PageTextBox.ReadOnly = true;
-            this.sha1PageTextBox.Size = new System.Drawing.Size(351, 26);
+            this.sha1PageTextBox.Size = new System.Drawing.Size(397, 26);
             this.sha1PageTextBox.TabIndex = 17;
             // 
             // sha1TextBox
@@ -557,7 +557,7 @@ namespace WDAC_Wizard
             this.sha1TextBox.Location = new System.Drawing.Point(173, 3);
             this.sha1TextBox.Name = "sha1TextBox";
             this.sha1TextBox.ReadOnly = true;
-            this.sha1TextBox.Size = new System.Drawing.Size(351, 26);
+            this.sha1TextBox.Size = new System.Drawing.Size(397, 26);
             this.sha1TextBox.TabIndex = 16;
             // 
             // filePathRulePanel

--- a/WDAC-Policy-Wizard/app/src/EventLogRuleConfiguration.Designer.cs
+++ b/WDAC-Policy-Wizard/app/src/EventLogRuleConfiguration.Designer.cs
@@ -224,8 +224,8 @@ namespace WDAC_Wizard
             // 
             // eventsDataGridView
             // 
-            this.eventsDataGridView.AllowUserToAddRows = false;
             this.eventsDataGridView.AllowUserToDeleteRows = false;
+            this.eventsDataGridView.AutoSizeColumnsMode = System.Windows.Forms.DataGridViewAutoSizeColumnsMode.AllCells;
             this.eventsDataGridView.BackgroundColor = System.Drawing.Color.WhiteSmoke;
             this.eventsDataGridView.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
             this.eventsDataGridView.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
@@ -236,15 +236,19 @@ namespace WDAC_Wizard
             this.policyColumn,
             this.publisherColumn});
             this.eventsDataGridView.Location = new System.Drawing.Point(167, 123);
+            this.eventsDataGridView.Margin = new System.Windows.Forms.Padding(2);
             this.eventsDataGridView.MultiSelect = false;
             this.eventsDataGridView.Name = "eventsDataGridView";
             this.eventsDataGridView.ReadOnly = true;
-            this.eventsDataGridView.RowHeadersWidth = 51;
+            this.eventsDataGridView.RowHeadersVisible = false;
+            this.eventsDataGridView.RowHeadersWidth = 70;
             this.eventsDataGridView.RowTemplate.Height = 24;
+            this.eventsDataGridView.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
             this.eventsDataGridView.Size = new System.Drawing.Size(799, 287);
             this.eventsDataGridView.TabIndex = 4;
             this.eventsDataGridView.VirtualMode = true;
             this.eventsDataGridView.CellClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.EventRowClick);
+            this.eventsDataGridView.CellValueNeeded += new System.Windows.Forms.DataGridViewCellValueEventHandler(this.EventsDataGrid_CellValueNeeded);
             // 
             // addedColumn
             // 

--- a/WDAC-Policy-Wizard/app/src/EventLogRuleConfiguration.Designer.cs
+++ b/WDAC-Policy-Wizard/app/src/EventLogRuleConfiguration.Designer.cs
@@ -1,0 +1,373 @@
+﻿
+namespace WDAC_Wizard
+{
+    partial class EventLogRuleConfiguration
+    {
+        /// <summary> 
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary> 
+        /// Required method for Designer support - do not modify 
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.button1 = new System.Windows.Forms.Button();
+            this.customRulePanel = new System.Windows.Forms.Panel();
+            this.publisherRulePanel = new System.Windows.Forms.Panel();
+            this.productTextBox = new System.Windows.Forms.TextBox();
+            this.versionTextBox = new System.Windows.Forms.TextBox();
+            this.filenameTextBox = new System.Windows.Forms.TextBox();
+            this.publisherTextBox = new System.Windows.Forms.TextBox();
+            this.issuerTextBox = new System.Windows.Forms.TextBox();
+            this.productCheckBox = new System.Windows.Forms.CheckBox();
+            this.versionCheckBox = new System.Windows.Forms.CheckBox();
+            this.filenameCheckBox = new System.Windows.Forms.CheckBox();
+            this.publisherCheckBox = new System.Windows.Forms.CheckBox();
+            this.issuerCheckBox = new System.Windows.Forms.CheckBox();
+            this.label3 = new System.Windows.Forms.Label();
+            this.ruleTypeComboBox = new System.Windows.Forms.ComboBox();
+            this.eventsDataGridView = new System.Windows.Forms.DataGridView();
+            this.addedColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.eventIdColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.filenameColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.productColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.policyColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.publisherColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.label1 = new System.Windows.Forms.Label();
+            this.label2 = new System.Windows.Forms.Label();
+            this.customRulePanel.SuspendLayout();
+            this.publisherRulePanel.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.eventsDataGridView)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // button1
+            // 
+            this.button1.Location = new System.Drawing.Point(177, 677);
+            this.button1.Name = "button1";
+            this.button1.Size = new System.Drawing.Size(113, 30);
+            this.button1.TabIndex = 0;
+            this.button1.Text = "Add -->";
+            this.button1.UseVisualStyleBackColor = true;
+            this.button1.Click += new System.EventHandler(this.AddButton_Click);
+            // 
+            // customRulePanel
+            // 
+            this.customRulePanel.Controls.Add(this.publisherRulePanel);
+            this.customRulePanel.Controls.Add(this.label3);
+            this.customRulePanel.Controls.Add(this.ruleTypeComboBox);
+            this.customRulePanel.Location = new System.Drawing.Point(167, 429);
+            this.customRulePanel.Name = "customRulePanel";
+            this.customRulePanel.Size = new System.Drawing.Size(669, 242);
+            this.customRulePanel.TabIndex = 1;
+            // 
+            // publisherRulePanel
+            // 
+            this.publisherRulePanel.Controls.Add(this.productTextBox);
+            this.publisherRulePanel.Controls.Add(this.versionTextBox);
+            this.publisherRulePanel.Controls.Add(this.filenameTextBox);
+            this.publisherRulePanel.Controls.Add(this.publisherTextBox);
+            this.publisherRulePanel.Controls.Add(this.issuerTextBox);
+            this.publisherRulePanel.Controls.Add(this.productCheckBox);
+            this.publisherRulePanel.Controls.Add(this.versionCheckBox);
+            this.publisherRulePanel.Controls.Add(this.filenameCheckBox);
+            this.publisherRulePanel.Controls.Add(this.publisherCheckBox);
+            this.publisherRulePanel.Controls.Add(this.issuerCheckBox);
+            this.publisherRulePanel.Location = new System.Drawing.Point(6, 49);
+            this.publisherRulePanel.Name = "publisherRulePanel";
+            this.publisherRulePanel.Size = new System.Drawing.Size(493, 190);
+            this.publisherRulePanel.TabIndex = 9;
+            // 
+            // productTextBox
+            // 
+            this.productTextBox.Font = new System.Drawing.Font("Tahoma", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.productTextBox.Location = new System.Drawing.Point(102, 159);
+            this.productTextBox.Name = "productTextBox";
+            this.productTextBox.Size = new System.Drawing.Size(351, 28);
+            this.productTextBox.TabIndex = 20;
+            // 
+            // versionTextBox
+            // 
+            this.versionTextBox.Font = new System.Drawing.Font("Tahoma", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.versionTextBox.Location = new System.Drawing.Point(102, 120);
+            this.versionTextBox.Name = "versionTextBox";
+            this.versionTextBox.Size = new System.Drawing.Size(351, 28);
+            this.versionTextBox.TabIndex = 19;
+            // 
+            // filenameTextBox
+            // 
+            this.filenameTextBox.Font = new System.Drawing.Font("Tahoma", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.filenameTextBox.Location = new System.Drawing.Point(101, 81);
+            this.filenameTextBox.Name = "filenameTextBox";
+            this.filenameTextBox.Size = new System.Drawing.Size(352, 28);
+            this.filenameTextBox.TabIndex = 18;
+            // 
+            // publisherTextBox
+            // 
+            this.publisherTextBox.Font = new System.Drawing.Font("Tahoma", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.publisherTextBox.Location = new System.Drawing.Point(103, 42);
+            this.publisherTextBox.Name = "publisherTextBox";
+            this.publisherTextBox.Size = new System.Drawing.Size(351, 28);
+            this.publisherTextBox.TabIndex = 17;
+            // 
+            // issuerTextBox
+            // 
+            this.issuerTextBox.Font = new System.Drawing.Font("Tahoma", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.issuerTextBox.Location = new System.Drawing.Point(103, 3);
+            this.issuerTextBox.Name = "issuerTextBox";
+            this.issuerTextBox.Size = new System.Drawing.Size(351, 28);
+            this.issuerTextBox.TabIndex = 16;
+            // 
+            // productCheckBox
+            // 
+            this.productCheckBox.AutoSize = true;
+            this.productCheckBox.Enabled = false;
+            this.productCheckBox.Font = new System.Drawing.Font("Tahoma", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.productCheckBox.Location = new System.Drawing.Point(3, 159);
+            this.productCheckBox.Name = "productCheckBox";
+            this.productCheckBox.Size = new System.Drawing.Size(94, 25);
+            this.productCheckBox.TabIndex = 15;
+            this.productCheckBox.Text = "Product:";
+            this.productCheckBox.UseVisualStyleBackColor = true;
+            // 
+            // versionCheckBox
+            // 
+            this.versionCheckBox.AutoSize = true;
+            this.versionCheckBox.Enabled = false;
+            this.versionCheckBox.Font = new System.Drawing.Font("Tahoma", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.versionCheckBox.Location = new System.Drawing.Point(2, 120);
+            this.versionCheckBox.Name = "versionCheckBox";
+            this.versionCheckBox.Size = new System.Drawing.Size(93, 25);
+            this.versionCheckBox.TabIndex = 14;
+            this.versionCheckBox.Text = "Version:";
+            this.versionCheckBox.UseVisualStyleBackColor = true;
+            // 
+            // filenameCheckBox
+            // 
+            this.filenameCheckBox.AutoSize = true;
+            this.filenameCheckBox.Enabled = false;
+            this.filenameCheckBox.Font = new System.Drawing.Font("Tahoma", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.filenameCheckBox.Location = new System.Drawing.Point(3, 81);
+            this.filenameCheckBox.Name = "filenameCheckBox";
+            this.filenameCheckBox.Size = new System.Drawing.Size(105, 25);
+            this.filenameCheckBox.TabIndex = 13;
+            this.filenameCheckBox.Text = "Filename:";
+            this.filenameCheckBox.UseVisualStyleBackColor = true;
+            // 
+            // publisherCheckBox
+            // 
+            this.publisherCheckBox.AutoSize = true;
+            this.publisherCheckBox.Enabled = false;
+            this.publisherCheckBox.Font = new System.Drawing.Font("Tahoma", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.publisherCheckBox.Location = new System.Drawing.Point(3, 42);
+            this.publisherCheckBox.Name = "publisherCheckBox";
+            this.publisherCheckBox.Size = new System.Drawing.Size(105, 25);
+            this.publisherCheckBox.TabIndex = 12;
+            this.publisherCheckBox.Text = "Publisher:";
+            this.publisherCheckBox.UseVisualStyleBackColor = true;
+            // 
+            // issuerCheckBox
+            // 
+            this.issuerCheckBox.AutoSize = true;
+            this.issuerCheckBox.Checked = true;
+            this.issuerCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.issuerCheckBox.Enabled = false;
+            this.issuerCheckBox.Font = new System.Drawing.Font("Tahoma", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.issuerCheckBox.Location = new System.Drawing.Point(4, 3);
+            this.issuerCheckBox.Name = "issuerCheckBox";
+            this.issuerCheckBox.Size = new System.Drawing.Size(84, 25);
+            this.issuerCheckBox.TabIndex = 10;
+            this.issuerCheckBox.Text = "Issuer:";
+            this.issuerCheckBox.UseVisualStyleBackColor = true;
+            // 
+            // label3
+            // 
+            this.label3.AutoSize = true;
+            this.label3.Font = new System.Drawing.Font("Tahoma", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label3.Location = new System.Drawing.Point(3, 17);
+            this.label3.Name = "label3";
+            this.label3.Size = new System.Drawing.Size(90, 21);
+            this.label3.TabIndex = 8;
+            this.label3.Text = "Rule Type:";
+            // 
+            // ruleTypeComboBox
+            // 
+            this.ruleTypeComboBox.Font = new System.Drawing.Font("Tahoma", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.ruleTypeComboBox.FormattingEnabled = true;
+            this.ruleTypeComboBox.Items.AddRange(new object[] {
+            "Publisher",
+            "Path",
+            "File Attributes",
+            "Packaged App",
+            "File Hash"});
+            this.ruleTypeComboBox.Location = new System.Drawing.Point(99, 14);
+            this.ruleTypeComboBox.Name = "ruleTypeComboBox";
+            this.ruleTypeComboBox.Size = new System.Drawing.Size(163, 29);
+            this.ruleTypeComboBox.TabIndex = 3;
+            // 
+            // eventsDataGridView
+            // 
+            this.eventsDataGridView.AllowUserToAddRows = false;
+            this.eventsDataGridView.AllowUserToDeleteRows = false;
+            this.eventsDataGridView.BackgroundColor = System.Drawing.Color.WhiteSmoke;
+            this.eventsDataGridView.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            this.eventsDataGridView.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
+            this.addedColumn,
+            this.eventIdColumn,
+            this.filenameColumn,
+            this.productColumn,
+            this.policyColumn,
+            this.publisherColumn});
+            this.eventsDataGridView.Location = new System.Drawing.Point(167, 123);
+            this.eventsDataGridView.MultiSelect = false;
+            this.eventsDataGridView.Name = "eventsDataGridView";
+            this.eventsDataGridView.ReadOnly = true;
+            this.eventsDataGridView.RowHeadersWidth = 51;
+            this.eventsDataGridView.RowTemplate.Height = 24;
+            this.eventsDataGridView.Size = new System.Drawing.Size(799, 287);
+            this.eventsDataGridView.TabIndex = 4;
+            this.eventsDataGridView.VirtualMode = true;
+            this.eventsDataGridView.CellClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.EventRowClick);
+            // 
+            // addedColumn
+            // 
+            this.addedColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
+            this.addedColumn.HeaderText = "Added To Policy";
+            this.addedColumn.MinimumWidth = 100;
+            this.addedColumn.Name = "addedColumn";
+            this.addedColumn.ReadOnly = true;
+            // 
+            // eventIdColumn
+            // 
+            this.eventIdColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
+            this.eventIdColumn.HeaderText = "Event Id";
+            this.eventIdColumn.MinimumWidth = 6;
+            this.eventIdColumn.Name = "eventIdColumn";
+            this.eventIdColumn.ReadOnly = true;
+            this.eventIdColumn.Width = 82;
+            // 
+            // filenameColumn
+            // 
+            this.filenameColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
+            this.filenameColumn.HeaderText = "Filename";
+            this.filenameColumn.MinimumWidth = 6;
+            this.filenameColumn.Name = "filenameColumn";
+            this.filenameColumn.ReadOnly = true;
+            this.filenameColumn.Width = 94;
+            // 
+            // productColumn
+            // 
+            this.productColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
+            this.productColumn.HeaderText = "Product";
+            this.productColumn.MinimumWidth = 6;
+            this.productColumn.Name = "productColumn";
+            this.productColumn.ReadOnly = true;
+            this.productColumn.Width = 86;
+            // 
+            // policyColumn
+            // 
+            this.policyColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
+            this.policyColumn.HeaderText = "Policy Name";
+            this.policyColumn.MinimumWidth = 6;
+            this.policyColumn.Name = "policyColumn";
+            this.policyColumn.ReadOnly = true;
+            this.policyColumn.Width = 106;
+            // 
+            // publisherColumn
+            // 
+            this.publisherColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
+            this.publisherColumn.HeaderText = "Publisher";
+            this.publisherColumn.MinimumWidth = 6;
+            this.publisherColumn.Name = "publisherColumn";
+            this.publisherColumn.ReadOnly = true;
+            this.publisherColumn.Width = 96;
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Font = new System.Drawing.Font("Tahoma", 14F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label1.Location = new System.Drawing.Point(162, 29);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(292, 29);
+            this.label1.TabIndex = 6;
+            this.label1.Text = "Configure Event Log Rules";
+            // 
+            // label2
+            // 
+            this.label2.AutoSize = true;
+            this.label2.Font = new System.Drawing.Font("Tahoma", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label2.Location = new System.Drawing.Point(164, 71);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(391, 18);
+            this.label2.TabIndex = 7;
+            this.label2.Text = "Create custom rules based on the WDAC event log events";
+            // 
+            // EventLogRuleConfiguration
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(120F, 120F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
+            this.BackColor = System.Drawing.Color.White;
+            this.Controls.Add(this.label2);
+            this.Controls.Add(this.label1);
+            this.Controls.Add(this.eventsDataGridView);
+            this.Controls.Add(this.customRulePanel);
+            this.Controls.Add(this.button1);
+            this.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            this.Name = "EventLogRuleConfiguration";
+            this.Size = new System.Drawing.Size(1208, 782);
+            this.Load += new System.EventHandler(this.EventLogRuleConfiguration_Load);
+            this.customRulePanel.ResumeLayout(false);
+            this.customRulePanel.PerformLayout();
+            this.publisherRulePanel.ResumeLayout(false);
+            this.publisherRulePanel.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.eventsDataGridView)).EndInit();
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Button button1;
+        private System.Windows.Forms.Panel customRulePanel;
+        private System.Windows.Forms.ComboBox ruleTypeComboBox;
+        private System.Windows.Forms.DataGridView eventsDataGridView;
+        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.Label label3;
+        private System.Windows.Forms.Panel publisherRulePanel;
+        private System.Windows.Forms.TextBox productTextBox;
+        private System.Windows.Forms.TextBox versionTextBox;
+        private System.Windows.Forms.TextBox filenameTextBox;
+        private System.Windows.Forms.TextBox publisherTextBox;
+        private System.Windows.Forms.TextBox issuerTextBox;
+        private System.Windows.Forms.CheckBox productCheckBox;
+        private System.Windows.Forms.CheckBox versionCheckBox;
+        private System.Windows.Forms.CheckBox filenameCheckBox;
+        private System.Windows.Forms.CheckBox publisherCheckBox;
+        private System.Windows.Forms.CheckBox issuerCheckBox;
+        private System.Windows.Forms.DataGridViewTextBoxColumn addedColumn;
+        private System.Windows.Forms.DataGridViewTextBoxColumn eventIdColumn;
+        private System.Windows.Forms.DataGridViewTextBoxColumn filenameColumn;
+        private System.Windows.Forms.DataGridViewTextBoxColumn productColumn;
+        private System.Windows.Forms.DataGridViewTextBoxColumn policyColumn;
+        private System.Windows.Forms.DataGridViewTextBoxColumn publisherColumn;
+    }
+}

--- a/WDAC-Policy-Wizard/app/src/EventLogRuleConfiguration.cs
+++ b/WDAC-Policy-Wizard/app/src/EventLogRuleConfiguration.cs
@@ -18,7 +18,10 @@ namespace WDAC_Wizard
             new System.Collections.ArrayList();
 
         private Logger Log;
-        private SiPolicy siPolicy; 
+        private SiPolicy siPolicy;
+
+        private EventDisplayObject displayObjectInEdit;
+        private int rowInEdit = -1;
 
         public EventLogRuleConfiguration(MainWindow pMainWindow)
         {
@@ -58,15 +61,15 @@ namespace WDAC_Wizard
             {
                 // Create one row per ciEvent per signer Event
                 // File signed by 3 signers will create 3 rows/rules
-                foreach (SignerEvent signerEvent in ciEvent.SignerEvents)
-                {
-                    EventDisplayObject dpObject = new EventDisplayObject(
+                EventDisplayObject dpObject = new EventDisplayObject(
                         ciEvent.EventId.ToString(),
                         ciEvent.FileName,
                         ciEvent.ProductName,
                         ciEvent.PolicyName,
-                        signerEvent.PublisherName);
-                }
+                        ciEvent.SignerInfo.PublisherName);
+
+                this.DisplayObjects.Add(dpObject);
+                this.eventsDataGridView.RowCount += 1;
             }
         }
 
@@ -92,9 +95,9 @@ namespace WDAC_Wizard
 
             int selectedRow = e.RowIndex;
             SetCustomRulesPanel(
-                this.CiEvents[selectedRow].SignerEvents[0].IssuerName,
-                this.CiEvents[selectedRow].SignerEvents[0].PublisherName,
-                this.CiEvents[selectedRow].FileName,
+                this.CiEvents[selectedRow].SignerInfo.IssuerName,
+                this.CiEvents[selectedRow].SignerInfo.PublisherName,
+                this.CiEvents[selectedRow].OriginalFilename,
                 this.CiEvents[selectedRow].FileVersion,
                 this.CiEvents[selectedRow].ProductName);
         }
@@ -168,7 +171,51 @@ namespace WDAC_Wizard
             }
         }
 
+        private void EventsDataGrid_CellValueNeeded(object sender, DataGridViewCellValueEventArgs e)
+        {
+            // If this is the row for new records, no values are needed.
+            if (e.RowIndex == this.eventsDataGridView.RowCount - 1) return;
 
+            EventDisplayObject displayObject = null;
+
+            // Store a reference to the Customer object for the row being painted.
+            if (e.RowIndex == rowInEdit)
+            {
+                displayObject = this.displayObjectInEdit;
+            }
+            else
+            {
+                displayObject = (EventDisplayObject)this.DisplayObjects[e.RowIndex];
+            }
+
+            // Set the cell value to paint using the Customer object retrieved.
+            switch (this.eventsDataGridView.Columns[e.ColumnIndex].Name)
+            {
+                case "addedColumn":
+                    e.Value = displayObject.Action;
+                    break;
+
+                case "eventIdColumn":
+                    e.Value = displayObject.EventId;
+                    break;
+
+                case "filenameColumn":
+                    e.Value = displayObject.Filename;
+                    break;
+
+                case "productColumn":
+                    e.Value = displayObject.Product;
+                    break;
+
+                case "policyColumn":
+                    e.Value = displayObject.PolicyName;
+                    break;
+
+                case "publisherColumn":
+                    e.Value = displayObject.Publisher;
+                    break;
+            }
+        }
     }
 
     // Class for the datastore

--- a/WDAC-Policy-Wizard/app/src/EventLogRuleConfiguration.cs
+++ b/WDAC-Policy-Wizard/app/src/EventLogRuleConfiguration.cs
@@ -1,0 +1,205 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace WDAC_Wizard
+{
+    public partial class EventLogRuleConfiguration : UserControl
+    {
+        private List<CiEvent> CiEvents;
+        // Declare an ArrayList to serve as the data store. 
+        private System.Collections.ArrayList DisplayObjects =
+            new System.Collections.ArrayList();
+
+        private Logger Log;
+        private SiPolicy siPolicy; 
+
+        public EventLogRuleConfiguration(MainWindow pMainWindow)
+        {
+            InitializeComponent();
+
+            this.CiEvents = pMainWindow.CiEvents; 
+            this.Log = pMainWindow.Log;
+            this.siPolicy = new SiPolicy(); 
+        }
+
+        /// <summary>
+        /// On page load, set the UI and populate the event table
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void EventLogRuleConfiguration_Load(object sender, EventArgs e)
+        {
+            // UI Elements
+            // Set publisher rule by default
+            this.ruleTypeComboBox.SelectedIndex = 0;
+            this.publisherRulePanel.Visible = true;
+            this.customRulePanel.Visible = true;
+
+            // Highlight/select the first row in the table
+
+
+            // Set the table, let's eat
+            DisplayEvents();
+        }
+
+        /// <summary>
+        /// Creates a new display object for the DataGridView for each CiEvent object
+        /// </summary>
+        private void DisplayEvents()
+        {
+            foreach(CiEvent ciEvent in this.CiEvents)
+            {
+                // Create one row per ciEvent per signer Event
+                // File signed by 3 signers will create 3 rows/rules
+                foreach (SignerEvent signerEvent in ciEvent.SignerEvents)
+                {
+                    EventDisplayObject dpObject = new EventDisplayObject(
+                        ciEvent.EventId.ToString(),
+                        ciEvent.FileName,
+                        ciEvent.ProductName,
+                        ciEvent.PolicyName,
+                        signerEvent.PublisherName);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Adds rule to the SiPolicy object
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void AddButton_Click(object sender, EventArgs e)
+        {
+
+        }
+
+        /// <summary>
+        /// Populates the custom rules panel UI with the contents from the CiEvent list
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void EventRowClick(object sender, DataGridViewCellEventArgs e)
+        {
+            // Set the UI
+            ResetCustomRulesPanel();
+
+            int selectedRow = e.RowIndex;
+            SetCustomRulesPanel(
+                this.CiEvents[selectedRow].SignerEvents[0].IssuerName,
+                this.CiEvents[selectedRow].SignerEvents[0].PublisherName,
+                this.CiEvents[selectedRow].FileName,
+                this.CiEvents[selectedRow].FileVersion,
+                this.CiEvents[selectedRow].ProductName);
+        }
+
+        /// <summary>
+        /// Resets the custom rules panel 
+        /// </summary>
+        private void ResetCustomRulesPanel()
+        {
+            // Uncheck boxes
+            this.publisherCheckBox.Checked = false;
+            this.filenameCheckBox.Checked = false;
+            this.versionCheckBox.Checked = false;
+            this.productCheckBox.Checked = false;
+
+            this.publisherCheckBox.Enabled = false;
+            this.filenameCheckBox.Enabled = false;
+            this.versionCheckBox.Enabled = false;
+            this.productCheckBox.Enabled = false;
+
+            // Clear all textboxes
+            this.issuerTextBox.Clear();
+            this.publisherTextBox.Clear();
+            this.filenameTextBox.Clear();
+            this.versionTextBox.Clear();
+            this.productTextBox.Clear();
+
+            // Dropdown
+            this.ruleTypeComboBox.SelectedIndex = 0; 
+        }
+
+        /// <summary>
+        /// Sets the text in the publisher textboxes and the default checkbox states
+        /// </summary>
+        /// <param name="issuer"></param>
+        /// <param name="publisher"></param>
+        /// <param name="filename"></param>
+        /// <param name="version"></param>
+        /// <param name="product"></param>
+        private void SetCustomRulesPanel(string issuer, string publisher, string filename, string version, string product)
+        {
+            this.issuerTextBox.Text = issuer; 
+            this.publisherTextBox.Text = publisher;
+            this.filenameTextBox.Text = filename;
+            this.versionTextBox.Text = version;
+            this.productTextBox.Text = product;
+
+            // Default checkbox checked and enabled states
+            if(!String.IsNullOrEmpty(publisher))
+            {
+                this.publisherCheckBox.Checked = true;
+                this.publisherCheckBox.Enabled = true;
+            }
+
+            if (!String.IsNullOrEmpty(filename))
+            {
+                this.filenameCheckBox.Checked = true;
+                this.filenameCheckBox.Enabled = true;
+            }
+
+            if (!String.IsNullOrEmpty(version))
+            {
+                this.versionCheckBox.Checked = true;
+                this.versionCheckBox.Enabled = true;
+            }
+
+            if (!String.IsNullOrEmpty(product))
+            {
+                this.productCheckBox.Checked = true;
+                this.productCheckBox.Enabled = true;
+            }
+        }
+
+
+    }
+
+    // Class for the datastore
+    public class EventDisplayObject
+    {
+        public string Action;
+        public string EventId;
+        public string Filename;
+        public string Product;
+        public string PolicyName;
+        public string Publisher;
+
+        public EventDisplayObject()
+        {
+            this.Action = string.Empty;
+            this.EventId = string.Empty;
+            this.Filename = string.Empty;
+            this.Product = string.Empty;
+            this.PolicyName = string.Empty;
+            this.Publisher = string.Empty;
+        }
+
+        public EventDisplayObject(string eventId, string filename, string product, string policyName, string publisher)
+        {
+            this.Action = "-";
+            this.EventId = eventId;
+            this.Filename = filename;
+            this.Product = product;
+            this.PolicyName = policyName;
+            this.Publisher = publisher;
+        }
+
+    }
+}

--- a/WDAC-Policy-Wizard/app/src/EventLogRuleConfiguration.cs
+++ b/WDAC-Policy-Wizard/app/src/EventLogRuleConfiguration.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
+using System.IO;
 
 namespace WDAC_Wizard
 {
@@ -14,8 +15,7 @@ namespace WDAC_Wizard
     {
         private List<CiEvent> CiEvents;
         // Declare an ArrayList to serve as the data store. 
-        private System.Collections.ArrayList DisplayObjects =
-            new System.Collections.ArrayList();
+        private List<EventDisplayObject> DisplayObjects;
 
         private Logger Log;
         private SiPolicy siPolicy;
@@ -23,13 +23,26 @@ namespace WDAC_Wizard
         private EventDisplayObject displayObjectInEdit;
         private int rowInEdit = -1;
 
+        private int SelectedRow;
+        private List<int> RuleIdsToAdd;
+
+        // UI States
+        private int[] PublisherUIState = { 1, 0, 0, 0, 0};
+        private int[] FileAttributesUIState = { 0, 0, 0, 0, 0 };
+        private int[] FilePathUIState = { 0, 0 };
+
         public EventLogRuleConfiguration(MainWindow pMainWindow)
         {
             InitializeComponent();
 
             this.CiEvents = pMainWindow.CiEvents; 
             this.Log = pMainWindow.Log;
-            this.siPolicy = new SiPolicy(); 
+            this.siPolicy = Helper.DeserializeXMLStringtoPolicy(Properties.Resources.EmptyWDAC);
+
+            this.DisplayObjects = new List<EventDisplayObject>();
+
+            this.SelectedRow = 0;
+            this.RuleIdsToAdd = new List<int>();
         }
 
         /// <summary>
@@ -43,7 +56,6 @@ namespace WDAC_Wizard
             // Set publisher rule by default
             this.ruleTypeComboBox.SelectedIndex = 0;
             this.publisherRulePanel.Visible = true;
-            this.customRulePanel.Visible = true;
 
             // Highlight/select the first row in the table
 
@@ -80,7 +92,42 @@ namespace WDAC_Wizard
         /// <param name="e"></param>
         private void AddButton_Click(object sender, EventArgs e)
         {
+            // Update UI and SiPolicy object
+            EventDisplayObject dp = this.DisplayObjects[this.SelectedRow];
+            dp.Action = "Adding"; 
+            CiEvent ciEvent = this.CiEvents[this.SelectedRow];
 
+            switch(this.ruleTypeComboBox.SelectedIndex)
+            {
+                case 0: // Publisher
+                    if(IsValidPublisherUiState())
+                    {
+                        // this.siPolicy = PolicyHelper.AddSiPolicyPublisherRule(ciEvent, this.siPolicy);
+                    }
+                    break;
+
+                case 1: // File Path Rule
+                    if(IsValidFilePathUiState())
+                    {
+                        this.siPolicy = PolicyHelper.AddSiPolicyFilePathRule(ciEvent, this.siPolicy, this.FilePathUIState);
+                    }
+                    break; 
+
+                case 2: // File Attributes Rule
+                case 3:
+                    if(IsValidFileAttributesUiState())
+                    {
+                        this.siPolicy = PolicyHelper.AddSiPolicyFileAttributeRule(ciEvent, this.siPolicy, this.FileAttributesUIState);
+                    }
+                    break;
+
+                case 4: // Hash rule
+                    this.siPolicy = PolicyHelper.AddSiPolicyHashRules(ciEvent, this.siPolicy);
+                    break; 
+            }
+
+            this.eventsDataGridView.Refresh();
+            // Need to scroll somewhere else to update the cellvalue 
         }
 
         /// <summary>
@@ -94,17 +141,20 @@ namespace WDAC_Wizard
             ResetCustomRulesPanel();
 
             int selectedRow = e.RowIndex;
-            SetCustomRulesPanel(
+            
+            SetPublisherPanel(
                 this.CiEvents[selectedRow].SignerInfo.IssuerName,
                 this.CiEvents[selectedRow].SignerInfo.PublisherName,
                 this.CiEvents[selectedRow].OriginalFilename,
                 this.CiEvents[selectedRow].FileVersion,
                 this.CiEvents[selectedRow].ProductName);
+
+            this.SelectedRow = selectedRow;
         }
 
         /// <summary>
         /// Resets the custom rules panel 
-        /// </summary>
+        /// </summary>this.SelectedRow = selectedRow; 
         private void ResetCustomRulesPanel()
         {
             // Uncheck boxes
@@ -129,46 +179,115 @@ namespace WDAC_Wizard
             this.ruleTypeComboBox.SelectedIndex = 0; 
         }
 
+
         /// <summary>
-        /// Sets the text in the publisher textboxes and the default checkbox states
+        /// Gets the state of the checkboxes and determines whether the UI state is valid
         /// </summary>
-        /// <param name="issuer"></param>
-        /// <param name="publisher"></param>
-        /// <param name="filename"></param>
-        /// <param name="version"></param>
-        /// <param name="product"></param>
-        private void SetCustomRulesPanel(string issuer, string publisher, string filename, string version, string product)
+        /// <returns></returns>
+        public bool IsValidPublisherUiState()
         {
-            this.issuerTextBox.Text = issuer; 
-            this.publisherTextBox.Text = publisher;
-            this.filenameTextBox.Text = filename;
-            this.versionTextBox.Text = version;
-            this.productTextBox.Text = product;
+            // UI States:
+            // this.PublisherUIState[0] == 1 always; it cannot be modified
+            this.PublisherUIState[1] = this.publisherCheckBox.Checked == true ? 1 : 0;
+            this.PublisherUIState[2] = this.filenameCheckBox.Checked == true ? 1 : 0;
+            this.PublisherUIState[3] = this.versionCheckBox.Checked == true ? 1 : 0;
+            this.PublisherUIState[4] = this.productCheckBox.Checked == true ? 1 : 0;
 
-            // Default checkbox checked and enabled states
-            if(!String.IsNullOrEmpty(publisher))
+            if(String.IsNullOrEmpty(this.issuerTextBox.Text) ||
+                this.issuerTextBox.Text == Properties.Resources.BadEventPubValue )
             {
-                this.publisherCheckBox.Checked = true;
-                this.publisherCheckBox.Enabled = true;
+                return false; 
             }
 
-            if (!String.IsNullOrEmpty(filename))
+            if (PublisherUIState[1] == 1 && (String.IsNullOrEmpty(this.publisherTextBox.Text) || 
+                this.publisherTextBox.Text == Properties.Resources.BadEventPubValue))
             {
-                this.filenameCheckBox.Checked = true;
-                this.filenameCheckBox.Enabled = true;
+                return false;
             }
 
-            if (!String.IsNullOrEmpty(version))
+            if (PublisherUIState[2] == 1 && String.IsNullOrEmpty(this.filenameTextBox.Text))
             {
-                this.versionCheckBox.Checked = true;
-                this.versionCheckBox.Enabled = true;
+                return false;
             }
 
-            if (!String.IsNullOrEmpty(product))
+            if (PublisherUIState[3] == 1 && String.IsNullOrEmpty(this.versionCheckBox.Text))
             {
-                this.productCheckBox.Checked = true;
-                this.productCheckBox.Enabled = true;
+                return false;
             }
+
+            if (PublisherUIState[4] == 1 && String.IsNullOrEmpty(this.productTextBox.Text))
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+
+        /// <summary>
+        /// Gets the state of the checkboxes and determines whether the UI state is valid
+        /// </summary>
+        /// <returns></returns>
+        public bool IsValidFileAttributesUiState()
+        {
+            // UI States:
+            this.FileAttributesUIState[0] = this.origFileNameCheckBox.Checked == true ? 1 : 0;
+            this.FileAttributesUIState[1] = this.fileDescCheckBox.Checked == true ? 1 : 0;
+            this.FileAttributesUIState[2] = this.prodNameCheckBox.Checked == true ? 1 : 0;
+            this.FileAttributesUIState[3] = this.intFileNameCheckBox.Checked == true ? 1 : 0;
+            this.FileAttributesUIState[4] = this.pfnCheckBox.Checked == true ? 1 : 0;
+
+            if (FileAttributesUIState[0] == 1 && String.IsNullOrEmpty(this.origFileNameTextBox.Text))
+            {
+                return false;
+            }
+
+            if (FileAttributesUIState[1] == 1 && String.IsNullOrEmpty(this.fileDescTextBox.Text))
+            {
+                return false;
+            }
+
+            if (FileAttributesUIState[2] == 1 && String.IsNullOrEmpty(this.prodNameTextBox.Text))
+            {
+                return false;
+            }
+
+            if (FileAttributesUIState[3] == 1 && String.IsNullOrEmpty(this.intFileNameTextBox.Text))
+            {
+                return false;
+            }
+
+            if (FileAttributesUIState[4] == 1 && String.IsNullOrEmpty(this.pfnTextBox.Text))
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Gets the state of the checkboxes and determines whether the UI state is valid
+        /// </summary>
+        /// <returns></returns>
+        public bool IsValidFilePathUiState()
+        {
+            // UI States:
+            this.FilePathUIState[0] = this.filePathCheckBox.Checked == true ? 1 : 0;
+            this.FilePathUIState[1] = this.folderPathCheckBox.Checked == true ? 1 : 0;
+
+            if (FilePathUIState[0] == 1 && String.IsNullOrEmpty(this.filePathTextBox.Text))
+            {
+                return false;
+            }
+            
+            if(FilePathUIState[1] == 1 && String.IsNullOrEmpty(this.folderPathTextBox.Text))
+            {
+                return false; 
+            }
+
+           
+
+            return true;
         }
 
         private void EventsDataGrid_CellValueNeeded(object sender, DataGridViewCellValueEventArgs e)
@@ -216,6 +335,396 @@ namespace WDAC_Wizard
                     break;
             }
         }
+
+        /// <summary>
+        /// Hides all the panels from the user
+        /// </summary>
+        private void HideAllPanels()
+        {
+            this.publisherRulePanel.Visible = false;
+            this.fileAttributeRulePanel.Visible = false;
+            this.filePathRulePanel.Visible = false; 
+            this.hashRulePanel.Visible = false; 
+        }
+
+        /// <summary>
+        /// User has changed the custom rule type
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void RuleTypeChanged(object sender, EventArgs e)
+        {
+            // Publisher
+            // Path
+            // File Attributes
+            // File Hash
+
+            HideAllPanels();
+
+            switch (this.ruleTypeComboBox.SelectedIndex)
+            {
+                case 0: // Publisher
+                    SetPublisherPanel(
+                        this.CiEvents[this.SelectedRow].SignerInfo.IssuerName,
+                        this.CiEvents[this.SelectedRow].SignerInfo.PublisherName,
+                        this.CiEvents[this.SelectedRow].OriginalFilename,
+                        this.CiEvents[this.SelectedRow].FileVersion,
+                        this.CiEvents[this.SelectedRow].ProductName);
+                    break;
+
+                case 1: // Path
+                    SetFilePathPanel(
+                        this.CiEvents[this.SelectedRow].FilePath);
+                    break;
+
+                case 2: // File Attributes
+                case 3:
+                    SetFileAttributesPanel(
+                        this.CiEvents[this.SelectedRow].OriginalFilename,
+                        this.CiEvents[this.SelectedRow].FileDescription,
+                        this.CiEvents[this.SelectedRow].ProductName,
+                        this.CiEvents[this.SelectedRow].InternalFilename,
+                        this.CiEvents[this.SelectedRow].PackageFamilyName);
+
+                    break;
+
+                case 4: //FileHash
+                    SetFileHashPanel(
+                        this.CiEvents[this.SelectedRow].SHA1,
+                        this.CiEvents[this.SelectedRow].SHA1Page,
+                        this.CiEvents[this.SelectedRow].SHA2,
+                        this.CiEvents[this.SelectedRow].SHA2Page);
+                    break; 
+            }
+        }
+
+        /// <summary>
+        /// Sets the text in the publisher textboxes and the default checkbox states
+        /// </summary>
+        /// <param name="issuer"></param>
+        /// <param name="publisher"></param>
+        /// <param name="filename"></param>
+        /// <param name="version"></param>
+        /// <param name="product"></param>
+        private void SetPublisherPanel(string issuer, string publisher, string filename, string version, string product)
+        {
+            this.issuerTextBox.Text = issuer;
+            this.publisherTextBox.Text = publisher;
+            this.filenameTextBox.Text = filename;
+            this.versionTextBox.Text = version;
+            this.productTextBox.Text = product;
+
+            // Default checkbox checked and enabled states
+            if (!String.IsNullOrEmpty(publisher))
+            {
+                this.publisherCheckBox.Checked = true;
+                this.publisherCheckBox.Enabled = true;
+            }
+
+            if (!String.IsNullOrEmpty(filename))
+            {
+                this.filenameCheckBox.Checked = true;
+                this.filenameCheckBox.Enabled = true;
+            }
+
+            if (!String.IsNullOrEmpty(version))
+            {
+                this.versionCheckBox.Checked = true;
+                this.versionCheckBox.Enabled = true;
+            }
+
+            if (!String.IsNullOrEmpty(product))
+            {
+                this.productCheckBox.Checked = true;
+                this.productCheckBox.Enabled = true;
+            }
+
+            // Unhide the panel
+            this.publisherRulePanel.Visible = true; 
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="originalFilename"></param>
+        /// <param name="fileDescription"></param>
+        /// <param name="productName"></param>
+        /// <param name="internalFilename"></param>
+        /// <param name="packagedAppName"></param>
+        private void SetFileAttributesPanel(string originalFilename, string fileDescription, string productName,
+            string internalFilename, string packagedAppName)
+        {
+            this.origFileNameTextBox.Text = originalFilename;
+            this.fileDescTextBox.Text = fileDescription;
+            this.prodNameTextBox.Text = productName;
+            this.intFileNameTextBox.Text = internalFilename;
+            this.pfnTextBox.Text = packagedAppName;
+
+            // Default checkbox checked and enabled states
+            if (!String.IsNullOrEmpty(originalFilename))
+            {
+                this.origFileNameCheckBox.Checked = true;
+                this.origFileNameCheckBox.Enabled = true;
+            }
+
+            if (!String.IsNullOrEmpty(fileDescription))
+            {
+                this.fileDescCheckBox.Checked = true;
+                this.fileDescCheckBox.Enabled = true;
+            }
+
+            if (!String.IsNullOrEmpty(productName))
+            {
+                this.prodNameCheckBox.Checked = true;
+                this.prodNameCheckBox.Enabled = true;
+            }
+
+            if (!String.IsNullOrEmpty(internalFilename))
+            {
+                this.intFileNameCheckBox.Checked = true;
+                this.intFileNameCheckBox.Enabled = true;
+            }
+
+            if(!String.IsNullOrEmpty(packagedAppName))
+            {
+                this.pfnCheckBox.Checked = true;
+                this.pfnCheckBox.Enabled = true;
+            }
+
+            // Unhide the panel
+            this.fileAttributeRulePanel.Visible = true;
+            this.fileAttributeRulePanel.Location = this.publisherRulePanel.Location; // snap to the loc of pub panel
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="originalFilename"></param>
+        /// <param name="fileDescription"></param>
+        /// <param name="productName"></param>
+        /// <param name="internalFilename"></param>
+        /// <param name="packagedAppName"></param>
+        private void SetFileHashPanel(byte[] sha1, byte[] sha1page, byte[] sha2, byte[] sha2page)
+        {
+            this.sha1TextBox.Text = Helper.ConvertHash(sha1);
+            this.sha1PageTextBox.Text = Helper.ConvertHash(sha1page);
+            this.sha2TextBox.Text = Helper.ConvertHash(sha2);
+            this.sha2PageTextBox.Text = Helper.ConvertHash(sha2page);
+
+            // Unhide the panel
+            this.hashRulePanel.Visible = true;
+            this.hashRulePanel.Location = this.publisherRulePanel.Location; // snap to the loc of pub panel
+        }
+
+        private void SetFilePathPanel(string filepath)
+        {
+            this.filePathTextBox.Text = filepath;
+            this.folderPathTextBox.Text = Path.GetDirectoryName(filepath);
+
+            this.filePathCheckBox.Checked = true;
+            this.folderPathCheckBox.Checked = true; 
+
+            // Unhide the panel
+            this.filePathRulePanel.Visible = true;
+            this.filePathRulePanel.Location = this.publisherRulePanel.Location; // snap to the loc of pub panel
+        }
+    }
+
+    internal static class PolicyHelper
+    {
+        // Counts of file rules created to pipe into IDs
+        static public int cFilePublisherRules = 0;
+        static public int cFileAttribRules = 0;
+        static public int cFilePathRules = 0;
+        static public int cFileHashRules = 0;
+
+        /// <summary>
+        /// Creates up to 2 path rules. One for the parent path and one for the full path
+        /// </summary>
+        /// <param name="ciEvent"></param>
+        /// <param name="siPolicy"></param>
+        /// <returns></returns>
+        public static SiPolicy AddSiPolicyFileAttributeRule(CiEvent ciEvent, SiPolicy siPolicy, int[] uiState)
+        {
+            List<Allow> allowFileAttributeRules = new List<Allow>(); 
+
+            Allow allowRule = new Allow();
+            allowRule.FriendlyName = String.Format("Allow file {0} by file attributes; Correlation Id: {1}", 
+                ciEvent.FileName, ciEvent.CorrelationId);
+            allowRule.ID = "ID_ALLOW_B_" + cFilePathRules.ToString();
+            cFileAttribRules++;
+
+            // Original filename
+            if (uiState[0] == 1)
+            {
+                allowRule.FileName = ciEvent.OriginalFilename;
+            }
+
+            // file description
+            if (uiState[1] == 1)
+            {
+                allowRule.FileDescription = ciEvent.FileDescription;
+            }
+
+            // Product name
+            if (uiState[2] == 1)
+            {
+                allowRule.ProductName = ciEvent.ProductName;
+            }
+
+            // Internal File name
+            if (uiState[3] == 1)
+            {
+                allowRule.InternalName = ciEvent.InternalFilename;
+            }
+
+            // Package name
+            if (uiState[4] == 1)
+            {
+                allowRule.PackageFamilyName = ciEvent.PackageFamilyName;
+            }
+
+            allowFileAttributeRules.Add(allowRule);
+
+            // Add the Allow rule to FileRules and FileRuleRef section with Windows Signing Scenario
+            siPolicy = AddSiPolicyAllowRules(allowFileAttributeRules, siPolicy);
+            return siPolicy;
+        }
+
+
+
+        /// <summary>
+        /// Creates up to 2 path rules. One for the parent path and one for the full path
+        /// </summary>
+        /// <param name="ciEvent"></param>
+        /// <param name="siPolicy"></param>
+        /// <returns></returns>
+        public static SiPolicy AddSiPolicyFilePathRule(CiEvent ciEvent, SiPolicy siPolicy, int[] uiState)
+        {
+            List<Allow> allowPathRules = new List<Allow>();
+
+            // FilePath
+            if(uiState[0] == 1)
+            {
+                Allow allowRule = new Allow();
+                allowRule.FilePath = ciEvent.FilePath;
+                allowRule.FriendlyName = String.Format("Allow path: {0}; Correlation Id: {1}", allowRule.FilePath, ciEvent.CorrelationId);
+                allowRule.ID = "ID_ALLOW_C_" + cFilePathRules.ToString();
+                cFilePathRules++;
+                allowPathRules.Add(allowRule);
+            }
+
+            // FolderPath
+            if (uiState[1] == 1)
+            {
+                Allow allowRule = new Allow();
+                allowRule.FilePath = Path.GetDirectoryName(ciEvent.FilePath) + "\\*";
+                allowRule.FriendlyName = String.Format("Allow path: {0}; Correlation Id: {1}", allowRule.FilePath, ciEvent.CorrelationId);
+                allowRule.ID = "ID_ALLOW_C_" + cFilePathRules.ToString();
+                cFilePathRules++;
+                allowPathRules.Add(allowRule);
+            }
+
+            // Add the Allow rule to FileRules and FileRuleRef section with Windows Signing Scenario
+            siPolicy = AddSiPolicyAllowRules(allowPathRules, siPolicy);
+            return siPolicy;
+        }
+
+        /// <summary>
+        /// Creates 4 hash rules (SHA1, SHA2 page and flat)
+        /// </summary>
+        /// <param name="ciEvent"></param>
+        /// <param name="siPolicy"></param>
+        /// <returns></returns>
+        public static SiPolicy AddSiPolicyHashRules(CiEvent ciEvent, SiPolicy siPolicy)
+        {
+            List<Allow> allowHashRules = new List<Allow>();
+            
+            // SHA1
+            Allow allowRule = new Allow();
+            allowRule.Hash = ciEvent.SHA1;
+            allowRule.FriendlyName = String.Format("{0} hash rule; Correlation Id: {1}", ciEvent.FileName, ciEvent.CorrelationId);
+            allowRule.ID = String.Format("ID_ALLOW_E_{0}_{1}", cFileHashRules, "SHA1");
+            allowHashRules.Add(allowRule);
+            cFileHashRules++;
+
+            // SHA1 Page
+            allowRule = new Allow();
+            allowRule.Hash = ciEvent.SHA1Page;
+            allowRule.FriendlyName = String.Format("{0} hash rule; Correlation Id: {1}", ciEvent.FileName, ciEvent.CorrelationId);
+            allowRule.ID = String.Format("ID_ALLOW_E_{0}_{1}", cFileHashRules, "SHA1_PAGE");
+            allowHashRules.Add(allowRule);
+            cFileHashRules++;
+
+
+            // SHA2
+            allowRule = new Allow();
+            allowRule.Hash = ciEvent.SHA2;
+            allowRule.FriendlyName = String.Format("{0} hash rule; Correlation Id: {1}", ciEvent.FileName, ciEvent.CorrelationId);
+            allowRule.ID = String.Format("ID_ALLOW_E_{0}_{1}", cFileHashRules, "SHA2");
+            allowHashRules.Add(allowRule);
+            cFileHashRules++;
+
+            // SHA2 Page
+            allowRule = new Allow();
+            allowRule.Hash = ciEvent.SHA1Page;
+            allowRule.FriendlyName = String.Format("{0} hash rule; Correlation Id: {1}", ciEvent.FileName, ciEvent.CorrelationId);
+            allowRule.ID = String.Format("ID_ALLOW_E_{0}_{1}", cFileHashRules, "SHA2_PAGE");
+            allowHashRules.Add(allowRule);
+            cFileHashRules++;
+
+            // Add the Allow rule to FileRules and FileRuleRef section with Windows Signing Scenario
+            siPolicy = AddSiPolicyAllowRules(allowHashRules, siPolicy);
+            return siPolicy;
+        }
+
+        /// <summary>
+        /// Handles adding the new Allow Rule object to the provided siPolicy
+        /// </summary>
+        /// <param name="allowRule"></param>
+        /// <param name="siPolicy"></param>
+        /// <returns></returns>
+        private static SiPolicy AddSiPolicyAllowRules(List<Allow> allowRules, SiPolicy siPolicy)
+        {
+            // Copy and replace the FileRules obj[] in siPolicy
+            // FileRules always initalized - no need to check if null
+
+            foreach(Allow allowRule in allowRules)
+            {
+                object[] fileRulesCopy = new object[siPolicy.FileRules.Length + 1];
+                for (int i = 0; i < fileRulesCopy.Length - 1; i++)
+                {
+                    fileRulesCopy[i] = siPolicy.FileRules[i];
+                }
+
+                fileRulesCopy[fileRulesCopy.Length - 1] = allowRule;
+                siPolicy.FileRules = fileRulesCopy;
+
+                // Copy and replace the FileRulesRef section to add to Signing Scenarios
+                FileRulesRef refCopy = new FileRulesRef();
+                if (siPolicy.SigningScenarios[1].ProductSigners.FileRulesRef == null)
+                {
+                    refCopy.FileRuleRef = new FileRuleRef[1];
+                    refCopy.FileRuleRef[0] = new FileRuleRef();
+                    refCopy.FileRuleRef[0].RuleID = allowRule.ID;
+                }
+                else
+                {
+                    refCopy.FileRuleRef = new FileRuleRef[siPolicy.SigningScenarios[1].ProductSigners.FileRulesRef.FileRuleRef.Length + 1];
+                    for (int i = 0; i < refCopy.FileRuleRef.Length - 1; i++)
+                    {
+                        refCopy.FileRuleRef[i] = siPolicy.SigningScenarios[1].ProductSigners.FileRulesRef.FileRuleRef[i];
+                    }
+
+                    refCopy.FileRuleRef[refCopy.FileRuleRef.Length - 1] = new FileRuleRef();
+                    refCopy.FileRuleRef[refCopy.FileRuleRef.Length - 1].RuleID = allowRule.ID;
+                }
+
+                siPolicy.SigningScenarios[1].ProductSigners.FileRulesRef = refCopy;
+            }
+            
+            return siPolicy;
+        }
     }
 
     // Class for the datastore
@@ -240,7 +749,7 @@ namespace WDAC_Wizard
 
         public EventDisplayObject(string eventId, string filename, string product, string policyName, string publisher)
         {
-            this.Action = "-";
+            this.Action = "   ---   ";
             this.EventId = eventId;
             this.Filename = filename;
             this.Product = product;

--- a/WDAC-Policy-Wizard/app/src/EventLogRuleConfiguration.resx
+++ b/WDAC-Policy-Wizard/app/src/EventLogRuleConfiguration.resx
@@ -135,22 +135,4 @@
   <metadata name="publisherColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
-  <metadata name="addedColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="eventIdColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="filenameColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="productColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="policyColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="publisherColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
 </root>

--- a/WDAC-Policy-Wizard/app/src/EventLogRuleConfiguration.resx
+++ b/WDAC-Policy-Wizard/app/src/EventLogRuleConfiguration.resx
@@ -1,0 +1,156 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="addedColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="eventIdColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="filenameColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="productColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="policyColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="publisherColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="addedColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="eventIdColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="filenameColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="productColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="policyColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="publisherColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+</root>

--- a/WDAC-Policy-Wizard/app/src/Helper.cs
+++ b/WDAC-Policy-Wizard/app/src/Helper.cs
@@ -254,6 +254,36 @@ namespace WDAC_Wizard
         }
 
         /// <summary>
+        /// Deserialize the xml policy string to SiPolicy
+        /// </summary>
+        /// <param name="xmlPath"></param>
+        /// <returns>SiPolicy object</returns>
+        public static SiPolicy DeserializeXMLStringtoPolicy(string xmlContents)
+        {
+            SiPolicy siPolicy;
+
+            try
+            {
+                var stream = new MemoryStream();
+                var writer = new StreamWriter(stream);
+                writer.Write(xmlContents);
+                writer.Flush();
+                stream.Position = 0;
+
+                XmlSerializer serializer = new XmlSerializer(typeof(SiPolicy));
+                StreamReader reader = new StreamReader(stream);
+                siPolicy = (SiPolicy)serializer.Deserialize(reader);
+                reader.Close();
+            }
+            catch (Exception exp)
+            {
+                return null;
+            }
+
+            return siPolicy;
+        }
+
+        /// <summary>
         /// Serialize the SiPolicy object to XML file
         /// </summary>
         /// <param name="siPolicy">SiPolicy object</param>
@@ -689,6 +719,27 @@ namespace WDAC_Wizard
             }
 
             return octet; 
+        }
+
+        /// <summary>
+        /// Converts a hash byte[] to hash hex string
+        /// </summary>
+        /// <param name="hashByte"></param>
+        /// <returns></returns>
+        public static string ConvertHash(byte[] hashByte)
+        {
+            if(hashByte == null)
+            {
+                return string.Empty; 
+            }
+
+            string hashstring = string.Empty; 
+            for(int i = 0; i < hashByte.Length; i++)
+            {
+                hashstring += hashByte[i].ToString("X");
+            }
+
+            return hashstring;
         }
 
         /// <summary>

--- a/WDAC-Policy-Wizard/app/src/Helper.cs
+++ b/WDAC-Policy-Wizard/app/src/Helper.cs
@@ -817,7 +817,7 @@ namespace WDAC_Wizard
         };
     }
 
-    public class Signer
+    public class WDACSigner
     {
         public string ID { get; set; }
         public string Name { get; set; }
@@ -825,7 +825,7 @@ namespace WDAC_Wizard
         public string CommonName { get; set; }
         public List<string> FileAttribRefs { get; set; }
 
-        public Signer()
+        public WDACSigner()
         {
             this.FileAttribRefs = new List<string>();
         }

--- a/WDAC-Policy-Wizard/app/src/MainForm.cs
+++ b/WDAC-Policy-Wizard/app/src/MainForm.cs
@@ -40,6 +40,7 @@ namespace WDAC_Wizard
         public Logger Log { get; set; }
         public List<string> PageList;
         public WDAC_Policy Policy { get; set; }
+        public List<CiEvent> CiEvents { get; set; }
         // Runspace param to access all PS Variables and eliminate overhead opening each time
         private Runspace runspace;
         private int RulesNumber;
@@ -48,7 +49,15 @@ namespace WDAC_Wizard
 
         // Edit Workflow datastructs
         private BuildPage _BuildPage;
-        private SigningRules_Control _SigningRulesControl; 
+        private SigningRules_Control _SigningRulesControl;
+        public EditWorkflowType EditWorkflow;
+
+        public enum EditWorkflowType
+        {
+            Edit = 0,
+            DeviceEventLog = 1,
+            ArbitraryEventLog = 2
+        }
 
         public MainWindow()
         {
@@ -63,6 +72,7 @@ namespace WDAC_Wizard
             this.RulesNumber = 0;
 
             this.Policy = new WDAC_Policy();
+            this.CiEvents = new List<CiEvent>(); 
             this.PageList = new List<string>();
             this.ExeFolderPath = GetExecutablePath(false);
 
@@ -456,12 +466,25 @@ namespace WDAC_Wizard
                             }
                             else
                             {
-                                var _RulesPage = new ConfigTemplate_Control(this);
-                                _RulesPage.Name = pageKey;
-                                this.PageList.Add(_RulesPage.Name);
-                                this.Controls.Add(_RulesPage);
-                                _RulesPage.BringToFront();
-                                _RulesPage.Focus();
+                                // CHECKS HERE IF EDIT FLOW OR AUDIT FLOW
+                                if(this.EditWorkflow == EditWorkflowType.Edit)
+                                {
+                                    var _RulesPage = new ConfigTemplate_Control(this);
+                                    _RulesPage.Name = pageKey;
+                                    this.PageList.Add(_RulesPage.Name);
+                                    this.Controls.Add(_RulesPage);
+                                    _RulesPage.BringToFront();
+                                    _RulesPage.Focus();
+                                }
+                                else
+                                {
+                                    var _RulesPage = new EventLogRuleConfiguration(this);
+                                    _RulesPage.Name = pageKey;
+                                    this.PageList.Add(_RulesPage.Name);
+                                    this.Controls.Add(_RulesPage);
+                                    _RulesPage.BringToFront();
+                                    _RulesPage.Focus();
+                                }
                             }
 
                             ShowControlPanel(sender, e);

--- a/WDAC-Policy-Wizard/app/src/SigningRules_Control.cs
+++ b/WDAC-Policy-Wizard/app/src/SigningRules_Control.cs
@@ -120,13 +120,13 @@ namespace WDAC_Wizard
             string ruleID = String.Empty;
 
             // Increase efficiency by constructing signers dictionary hint
-            Dictionary<string, Signer> signersDict = new Dictionary<string, Signer>();
+            Dictionary<string, WDACSigner> signersDict = new Dictionary<string, WDACSigner>();
             Dictionary<string, string> fileExceptionsDict = new Dictionary<string, string>();
 
             // Parse the siPolicy Signers to Diction<ID, Signer objs>
             foreach (var siPolicySigner in this.Policy.siPolicy.Signers)
             {
-                Signer signer = new Signer();
+                WDACSigner signer = new WDACSigner();
                 
                 if (siPolicySigner.FileAttribRef != null)
                 {


### PR DESCRIPTION
1. All policy rules are derived from the fields in the {system event logs, arbitrary .evtx event log files}
2. Users can select from publisher rules, attribute rules, file path, hash and packaged apps
3. Within publisher and attribute rules, multiple properties can be combined using the checkboxes

Publisher: 
![image](https://user-images.githubusercontent.com/23045608/175754277-1e73181c-a329-4416-ad46-90990570fd35.png)

![image](https://user-images.githubusercontent.com/23045608/175754281-1b2fda0d-1cd0-48df-a878-6f19c8e4bf44.png)


File Attributes: 
- Original filename, internal name, product name, file description are all selectable/can co-exist
![image](https://user-images.githubusercontent.com/23045608/175754286-bff7fe25-371e-4ec1-bec4-463bf3d08d61.png)

![image](https://user-images.githubusercontent.com/23045608/175754293-f14d5d10-96f8-47e7-b77c-965ccbf98d06.png)

File Path: 
- The user has the option between allowing by the exact file path and/or using the parent dir + wildcard
![image](https://user-images.githubusercontent.com/23045608/175754301-99170129-2f9b-4bde-977b-77d848cf76e4.png)


File Hash: 
- All 4 hashes are always added to the policy
![image](https://user-images.githubusercontent.com/23045608/175754304-41248ed4-2ea5-4a53-9d51-be38f9930fe0.png)


"Add Allow Rule" button creates an SiPolicy object behind the scenes, and updates the table to reflect that the rule has been added to the new policy. 

![image](https://user-images.githubusercontent.com/23045608/175754373-0b562dc0-3927-445e-8b8e-2770f2d373b6.png)
