### PR TITLE
Added optional save location to edit page

### DIFF
--- a/WDAC-Policy-Wizard/app/Properties/Resources.Designer.cs
+++ b/WDAC-Policy-Wizard/app/Properties/Resources.Designer.cs
@@ -147,6 +147,15 @@ namespace WDAC_Wizard.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Choose a location to save your edited WDAC Policy.
+        /// </summary>
+        internal static string BrowseForXmlSaveLoc {
+            get {
+                return ResourceManager.GetString("BrowseForXmlSaveLoc", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>
         internal static System.Drawing.Bitmap cancel {
@@ -895,7 +904,7 @@ namespace WDAC_Wizard.Properties {
         ///      &lt;Option&gt;Enabled:UMCI&lt;/Option&gt;
         ///    &lt;/Rule&gt;
         ///    &lt;Rule&gt;
-        ///      &lt;Option&gt;Enabled:Inherit D [rest of string was truncated]&quot;;.
+        ///      &lt;Option&gt;Enabled:Inherit Default Policy&lt;/ [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string SignedReputable {
             get {

--- a/WDAC-Policy-Wizard/app/Properties/Resources.resx
+++ b/WDAC-Policy-Wizard/app/Properties/Resources.resx
@@ -474,4 +474,7 @@ Please select the  'Create Rule' button.</value>
   <data name="SupplementalPolicyDenyRuleError" xml:space="preserve">
     <value>Deny rules are ignored in supplemental policies by WDAC. Since supplemental policies are meant to expand what the base policy trusts, only allow rules are supported in supplemental policies. </value>
   </data>
+  <data name="BrowseForXmlSaveLoc" xml:space="preserve">
+    <value>Choose a location to save your edited WDAC Policy</value>
+  </data>
 </root>

--- a/WDAC-Policy-Wizard/app/src/EditWorkflow.Designer.cs
+++ b/WDAC-Policy-Wizard/app/src/EditWorkflow.Designer.cs
@@ -137,7 +137,7 @@ namespace WDAC_Wizard
             this.policyInfoPanel.Location = new System.Drawing.Point(2, 64);
             this.policyInfoPanel.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.policyInfoPanel.Name = "policyInfoPanel";
-            this.policyInfoPanel.Size = new System.Drawing.Size(648, 173);
+            this.policyInfoPanel.Size = new System.Drawing.Size(648, 189);
             this.policyInfoPanel.TabIndex = 111;
             this.policyInfoPanel.Visible = false;
             // 
@@ -331,7 +331,7 @@ namespace WDAC_Wizard
             this.panel_EventLog_Conversion.Controls.Add(this.label6);
             this.panel_EventLog_Conversion.Controls.Add(this.panel_Progress);
             this.panel_EventLog_Conversion.Controls.Add(this.button_ParseEventLog);
-            this.panel_EventLog_Conversion.Location = new System.Drawing.Point(3, 249);
+            this.panel_EventLog_Conversion.Location = new System.Drawing.Point(3, 265);
             this.panel_EventLog_Conversion.Name = "panel_EventLog_Conversion";
             this.panel_EventLog_Conversion.Size = new System.Drawing.Size(856, 388);
             this.panel_EventLog_Conversion.TabIndex = 1;
@@ -422,7 +422,7 @@ namespace WDAC_Wizard
             this.panel_Edit_XML.Controls.Add(this.textBoxPolicyPath);
             this.panel_Edit_XML.Location = new System.Drawing.Point(3, 3);
             this.panel_Edit_XML.Name = "panel_Edit_XML";
-            this.panel_Edit_XML.Size = new System.Drawing.Size(857, 240);
+            this.panel_Edit_XML.Size = new System.Drawing.Size(857, 256);
             this.panel_Edit_XML.TabIndex = 0;
             // 
             // label3
@@ -455,7 +455,7 @@ namespace WDAC_Wizard
             this.label7.AutoSize = true;
             this.label7.Font = new System.Drawing.Font("Tahoma", 9.5F);
             this.label7.ForeColor = System.Drawing.Color.Black;
-            this.label7.Location = new System.Drawing.Point(23, 119);
+            this.label7.Location = new System.Drawing.Point(23, 134);
             this.label7.Name = "label7";
             this.label7.Size = new System.Drawing.Size(222, 19);
             this.label7.TabIndex = 113;
@@ -467,7 +467,7 @@ namespace WDAC_Wizard
             this.buttonNewSaveLocation.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.buttonNewSaveLocation.Font = new System.Drawing.Font("Tahoma", 9F);
             this.buttonNewSaveLocation.ForeColor = System.Drawing.Color.DodgerBlue;
-            this.buttonNewSaveLocation.Location = new System.Drawing.Point(502, 138);
+            this.buttonNewSaveLocation.Location = new System.Drawing.Point(502, 153);
             this.buttonNewSaveLocation.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.buttonNewSaveLocation.Name = "buttonNewSaveLocation";
             this.buttonNewSaveLocation.Size = new System.Drawing.Size(110, 28);
@@ -479,7 +479,7 @@ namespace WDAC_Wizard
             // textBoxSaveLocation
             // 
             this.textBoxSaveLocation.Font = new System.Drawing.Font("Tahoma", 9F);
-            this.textBoxSaveLocation.Location = new System.Drawing.Point(20, 139);
+            this.textBoxSaveLocation.Location = new System.Drawing.Point(20, 154);
             this.textBoxSaveLocation.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.textBoxSaveLocation.Name = "textBoxSaveLocation";
             this.textBoxSaveLocation.ReadOnly = true;

--- a/WDAC-Policy-Wizard/app/src/EditWorkflow.Designer.cs
+++ b/WDAC-Policy-Wizard/app/src/EditWorkflow.Designer.cs
@@ -64,6 +64,9 @@ namespace WDAC_Wizard
             this.panel_Edit_XML = new System.Windows.Forms.Panel();
             this.label3 = new System.Windows.Forms.Label();
             this.label_Error = new System.Windows.Forms.Label();
+            this.label7 = new System.Windows.Forms.Label();
+            this.buttonNewSaveLocation = new System.Windows.Forms.Button();
+            this.textBoxSaveLocation = new System.Windows.Forms.TextBox();
             this.policyInfoPanel.SuspendLayout();
             this.panel_Progress.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox_Progress)).BeginInit();
@@ -123,15 +126,18 @@ namespace WDAC_Wizard
             // 
             // policyInfoPanel
             // 
+            this.policyInfoPanel.Controls.Add(this.label7);
             this.policyInfoPanel.Controls.Add(this.label5);
+            this.policyInfoPanel.Controls.Add(this.buttonNewSaveLocation);
             this.policyInfoPanel.Controls.Add(this.textBox_PolicyName);
+            this.policyInfoPanel.Controls.Add(this.textBoxSaveLocation);
             this.policyInfoPanel.Controls.Add(this.label_policyName);
             this.policyInfoPanel.Controls.Add(this.textBox_PolicyID);
             this.policyInfoPanel.Controls.Add(this.label_fileLocation);
             this.policyInfoPanel.Location = new System.Drawing.Point(2, 64);
             this.policyInfoPanel.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.policyInfoPanel.Name = "policyInfoPanel";
-            this.policyInfoPanel.Size = new System.Drawing.Size(648, 125);
+            this.policyInfoPanel.Size = new System.Drawing.Size(648, 173);
             this.policyInfoPanel.TabIndex = 111;
             this.policyInfoPanel.Visible = false;
             // 
@@ -325,7 +331,7 @@ namespace WDAC_Wizard
             this.panel_EventLog_Conversion.Controls.Add(this.label6);
             this.panel_EventLog_Conversion.Controls.Add(this.panel_Progress);
             this.panel_EventLog_Conversion.Controls.Add(this.button_ParseEventLog);
-            this.panel_EventLog_Conversion.Location = new System.Drawing.Point(3, 214);
+            this.panel_EventLog_Conversion.Location = new System.Drawing.Point(3, 249);
             this.panel_EventLog_Conversion.Name = "panel_EventLog_Conversion";
             this.panel_EventLog_Conversion.Size = new System.Drawing.Size(856, 388);
             this.panel_EventLog_Conversion.TabIndex = 1;
@@ -416,7 +422,7 @@ namespace WDAC_Wizard
             this.panel_Edit_XML.Controls.Add(this.textBoxPolicyPath);
             this.panel_Edit_XML.Location = new System.Drawing.Point(3, 3);
             this.panel_Edit_XML.Name = "panel_Edit_XML";
-            this.panel_Edit_XML.Size = new System.Drawing.Size(857, 198);
+            this.panel_Edit_XML.Size = new System.Drawing.Size(857, 240);
             this.panel_Edit_XML.TabIndex = 0;
             // 
             // label3
@@ -443,6 +449,43 @@ namespace WDAC_Wizard
             this.label_Error.Text = "Convert the device\'s Code Integrity event log or an arbitrary log file to a WDAC " +
     "policy XML file";
             this.label_Error.Visible = false;
+            // 
+            // label7
+            // 
+            this.label7.AutoSize = true;
+            this.label7.Font = new System.Drawing.Font("Tahoma", 9.5F);
+            this.label7.ForeColor = System.Drawing.Color.Black;
+            this.label7.Location = new System.Drawing.Point(23, 119);
+            this.label7.Name = "label7";
+            this.label7.Size = new System.Drawing.Size(222, 19);
+            this.label7.TabIndex = 113;
+            this.label7.Text = "New Save Location (optional):";
+            // 
+            // buttonNewSaveLocation
+            // 
+            this.buttonNewSaveLocation.FlatAppearance.BorderColor = System.Drawing.SystemColors.MenuHighlight;
+            this.buttonNewSaveLocation.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.buttonNewSaveLocation.Font = new System.Drawing.Font("Tahoma", 9F);
+            this.buttonNewSaveLocation.ForeColor = System.Drawing.Color.DodgerBlue;
+            this.buttonNewSaveLocation.Location = new System.Drawing.Point(502, 138);
+            this.buttonNewSaveLocation.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
+            this.buttonNewSaveLocation.Name = "buttonNewSaveLocation";
+            this.buttonNewSaveLocation.Size = new System.Drawing.Size(110, 28);
+            this.buttonNewSaveLocation.TabIndex = 114;
+            this.buttonNewSaveLocation.Text = "Browse";
+            this.buttonNewSaveLocation.UseVisualStyleBackColor = true;
+            this.buttonNewSaveLocation.Click += new System.EventHandler(this.ButtonNewSaveLocation_Pressed);
+            // 
+            // textBoxSaveLocation
+            // 
+            this.textBoxSaveLocation.Font = new System.Drawing.Font("Tahoma", 9F);
+            this.textBoxSaveLocation.Location = new System.Drawing.Point(20, 139);
+            this.textBoxSaveLocation.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
+            this.textBoxSaveLocation.Name = "textBoxSaveLocation";
+            this.textBoxSaveLocation.ReadOnly = true;
+            this.textBoxSaveLocation.Size = new System.Drawing.Size(462, 26);
+            this.textBoxSaveLocation.TabIndex = 112;
+            this.textBoxSaveLocation.DoubleClick += new System.EventHandler(this.ButtonNewSaveLocation_Pressed);
             // 
             // EditWorkflow
             // 
@@ -512,5 +555,8 @@ namespace WDAC_Wizard
         private System.Windows.Forms.PictureBox parseresult_PictureBox;
         private System.Windows.Forms.Label parseResults_Label;
         private System.Windows.Forms.TextBox textBox_EventLog;
+        private System.Windows.Forms.Label label7;
+        private System.Windows.Forms.Button buttonNewSaveLocation;
+        private System.Windows.Forms.TextBox textBoxSaveLocation;
     }
 }

--- a/WDAC-Policy-Wizard/app/src/EditWorkflow.cs
+++ b/WDAC-Policy-Wizard/app/src/EditWorkflow.cs
@@ -362,5 +362,23 @@ namespace WDAC_Wizard
             Point urPoint = new Point(PAD_X, PAD_Y);
             this.panel_EventLog_Conversion.Location = urPoint;
         }
+
+        /// <summary>
+        /// Sets the save location (SchemaPath) for a file under edit 
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void ButtonNewSaveLocation_Pressed(object sender, EventArgs e)
+        {
+            string saveLocation = Helper.SaveSingleFile(Properties.Resources.BrowseForXmlSaveLoc, Helper.BrowseFileType.Policy); 
+            if(!String.IsNullOrEmpty(saveLocation))
+            {
+                this.textBoxSaveLocation.Text = saveLocation;
+                this.textBoxSaveLocation.SelectionStart = this.textBoxSaveLocation.TextLength - 1;
+                this.textBoxSaveLocation.ScrollToCaret();
+
+                this._MainWindow.Policy.SchemaPath = saveLocation; 
+            }
+        }
     }
 }

--- a/WDAC-Policy-Wizard/app/src/MainForm.cs
+++ b/WDAC-Policy-Wizard/app/src/MainForm.cs
@@ -1413,14 +1413,14 @@ namespace WDAC_Wizard
                     // Check if _v10.0.x.y is already in string ie. editing the output of an editing workflow
                     if (this.Policy.EditPathContainsVersionInfo())
                     {
-                        int sOFFSET = 14;
+                        const int sOFFSET = 14;
                         this.Policy.SchemaPath = String.Format("{0}_v{1}.xml", this.Policy.EditPolicyPath.Substring(0,
-                            this.Policy.EditPolicyPath.Length - sOFFSET), this.Policy.UpdateVersion());
+                                                               this.Policy.EditPolicyPath.Length - sOFFSET), this.Policy.UpdateVersion());
                     }
                     else
                     {
-                        this.Policy.SchemaPath = String.Format("{0}_v{1}.xml", this.Policy.EditPolicyPath.Substring(
-                        0, this.Policy.EditPolicyPath.Length - 4), this.Policy.UpdateVersion());
+                        this.Policy.SchemaPath = String.Format("{0}_v{1}.xml", Path.GetFileNameWithoutExtension(this.Policy.EditPolicyPath), 
+                                                               this.Policy.UpdateVersion());
                     }
                 }
                 else

--- a/WDAC-Policy-Wizard/app/src/MainForm.cs
+++ b/WDAC-Policy-Wizard/app/src/MainForm.cs
@@ -1400,23 +1400,32 @@ namespace WDAC_Wizard
             //             merge results from MergeCustomRulesPolicy (if applicable) into policy 
             //             defined by user: Path: this.SchemaPath
 
-            // If Edit mode is selected, this.SchemaPath is null while this.TemplatePath points to the .xml file 
-            // the user would like to edit. Since we don't explicitly prompt the user for a new path. copy the TemplatePath
-            // and append '_Edit' to the file path.
+            // If Edit mode is selected, since the 'New Save Location' field is optional, the Policy.SchemaPath can either be set or null.  
+            // If the field is null, set the save locaiton to the same location as the EditPolicyPath.
+            // Otherwise, keep Policy.SchemaPath as is
+            
             if (this.Policy.PolicyWorkflow == WDAC_Policy.Workflow.Edit)
             {
-                // Check if _v10.0.x.y is already in string ie. editing the output of an editing workflow
-                if(this.Policy.EditPathContainsVersionInfo())
+                if(String.IsNullOrEmpty(this.Policy.SchemaPath))
                 {
-                    int sOFFSET = 14;
-                    this.Policy.SchemaPath = String.Format("{0}_v{1}.xml", this.Policy.EditPolicyPath.Substring(0,
-                        this.Policy.EditPolicyPath.Length - sOFFSET),this.Policy.UpdateVersion());
+                    // Since we don't have a new save location, copy the TemplatePath
+                    // and append '_Edit' to the file path.
+                    // Check if _v10.0.x.y is already in string ie. editing the output of an editing workflow
+                    if (this.Policy.EditPathContainsVersionInfo())
+                    {
+                        int sOFFSET = 14;
+                        this.Policy.SchemaPath = String.Format("{0}_v{1}.xml", this.Policy.EditPolicyPath.Substring(0,
+                            this.Policy.EditPolicyPath.Length - sOFFSET), this.Policy.UpdateVersion());
+                    }
+                    else
+                    {
+                        this.Policy.SchemaPath = String.Format("{0}_v{1}.xml", this.Policy.EditPolicyPath.Substring(
+                        0, this.Policy.EditPolicyPath.Length - 4), this.Policy.UpdateVersion());
+                    }
                 }
-
                 else
                 {
-                    this.Policy.SchemaPath = String.Format("{0}_v{1}.xml", this.Policy.EditPolicyPath.Substring(
-                    0, this.Policy.EditPolicyPath.Length - 4), this.Policy.UpdateVersion());
+                    this.Policy.UpdateVersion(); 
                 }
             }
 


### PR DESCRIPTION
Users can now override the default save location for the policy under edit. The save location is optional so an empty save location will result in the current behavior. 

![image](https://user-images.githubusercontent.com/23045608/194618476-812a6962-02a6-4f47-830d-4cc71ae178a5.png)


Addresses feature request #126 