### PR TITLE
Fixing the duplicate unsigned SI policy rule option bug

### DIFF
--- a/WDAC-Policy-Wizard/app/src/ConfigTemplate_Control.cs
+++ b/WDAC-Policy-Wizard/app/src/ConfigTemplate_Control.cs
@@ -523,8 +523,6 @@ namespace WDAC_Wizard
             // Merge with configRules:
             foreach(var rule in this.Policy.siPolicy.Rules)
             {
-                this._MainWindow.Policy.PolicyRuleOptions.Add(rule);
-
                 string value = ParseRule(rule.Item.ToString())[0]; 
                 string name = ParseRule(rule.Item.ToString())[1];
 
@@ -541,11 +539,13 @@ namespace WDAC_Wizard
                         else
                         {
                             this.Policy.ConfigRules[name]["CurrentValue"] = value;
+                            this._MainWindow.Policy.PolicyRuleOptions.Add(rule);
                         }
                     }
                     else
                     {
                         this.Policy.ConfigRules[name]["CurrentValue"] = value;
+                        this._MainWindow.Policy.PolicyRuleOptions.Add(rule);
                     }
                 }
             }

--- a/WDAC-Policy-Wizard/app/src/ConfigTemplate_Control.cs
+++ b/WDAC-Policy-Wizard/app/src/ConfigTemplate_Control.cs
@@ -530,6 +530,12 @@ namespace WDAC_Wizard
                 {
                     if(this.Policy._PolicyType == WDAC_Policy.PolicyType.SupplementalPolicy)
                     {
+                        // If valid supplemental, add to PolicyRuleOptions struct to be set during policy build
+                        if(this.Policy.ConfigRules[name]["ValidSupplemental"] == "True")
+                        {
+                            this._MainWindow.Policy.PolicyRuleOptions.Add(rule);
+                        }
+
                         // If the policy rule is not a valid supplemental option AND should not be inherited from base, e.g. AllowSupplementals
                         // Set the value to not enabled (Get Opposite Value)
                         if(this.Policy.ConfigRules[name]["ValidSupplemental"] == "False-NoInherit")
@@ -539,7 +545,6 @@ namespace WDAC_Wizard
                         else
                         {
                             this.Policy.ConfigRules[name]["CurrentValue"] = value;
-                            this._MainWindow.Policy.PolicyRuleOptions.Add(rule);
                         }
                     }
                     else

--- a/WDAC-Policy-Wizard/app/src/MainForm.cs
+++ b/WDAC-Policy-Wizard/app/src/MainForm.cs
@@ -951,7 +951,8 @@ namespace WDAC_Wizard
             List<RuleType> ruleOptionsList = this.Policy.PolicyRuleOptions;
 
             // Assert supplemental policies and legacy policies cannot have the Supplemental (rule #17) option
-            if (this.Policy._Format == WDAC_Policy.Format.Legacy)
+            if (this.Policy._Format == WDAC_Policy.Format.Legacy 
+                && Policy.HasRuleOption(OptionType.EnabledAllowSupplementalPolicies))
             {
                 for(int i=0; i < ruleOptionsList.Count; i++)
                 {
@@ -963,8 +964,10 @@ namespace WDAC_Wizard
                 }
             }
 
-            // Assert unsigned CI policy (rule #6) - fixes issues with converting to binary where the policy is unsigned
-            if (Properties.Settings.Default.convertPolicyToBinary)
+            // Assert unsigned CI policy (rule #6)
+            // Fixes issues with converting to binary where the policy does not specify PolicySigners
+            if (Properties.Settings.Default.convertPolicyToBinary 
+                && !Policy.HasRuleOption(OptionType.EnabledUnsignedSystemIntegrityPolicy))
             {
                 RuleType unsignedPolicyRule = new RuleType();
                 unsignedPolicyRule.Item = OptionType.EnabledUnsignedSystemIntegrityPolicy;

--- a/WDAC-Policy-Wizard/app/src/Policy.cs
+++ b/WDAC-Policy-Wizard/app/src/Policy.cs
@@ -212,5 +212,23 @@ namespace WDAC_Wizard
 
             return false; 
         }
+
+        /// <summary>
+        /// Checks if a given rule option is already specified in the Policy
+        /// </summary>
+        /// <param name="targetRuleOption">Rule OptionType to query the Policy object for</param>
+        /// <returns></returns>
+        public bool HasRuleType(OptionType targetRuleOption)
+        {
+            foreach (var ruleOption in this.siPolicy.Rules)
+            {
+                if (ruleOption.Item == targetRuleOption)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
     }
 }

--- a/WDAC-Policy-Wizard/app/src/Policy.cs
+++ b/WDAC-Policy-Wizard/app/src/Policy.cs
@@ -195,5 +195,22 @@ namespace WDAC_Wizard
             return false; 
         }
 
+        /// <summary>
+        /// Checks if a given rule option is already specified in the Policy
+        /// </summary>
+        /// <param name="targetRuleOption">Rule OptionType to query the Policy object for</param>
+        /// <returns></returns>
+        public bool HasRuleOption(OptionType targetRuleOption)
+        {
+            foreach(var ruleOption in this.PolicyRuleOptions)
+            {
+                if(ruleOption.Item == targetRuleOption)
+                {
+                    return true; 
+                }
+            }
+
+            return false; 
+        }
     }
 }

--- a/WDAC-Policy-Wizard/app/src/PolicyType.Designer.cs
+++ b/WDAC-Policy-Wizard/app/src/PolicyType.Designer.cs
@@ -131,7 +131,7 @@ namespace WDAC_Wizard
             this.panelSuppl_Base.Controls.Add(this.label2);
             this.panelSuppl_Base.Location = new System.Drawing.Point(3, 101);
             this.panelSuppl_Base.Name = "panelSuppl_Base";
-            this.panelSuppl_Base.Size = new System.Drawing.Size(688, 143);
+            this.panelSuppl_Base.Size = new System.Drawing.Size(805, 143);
             this.panelSuppl_Base.TabIndex = 96;
             this.panelSuppl_Base.Visible = false;
             // 
@@ -142,7 +142,7 @@ namespace WDAC_Wizard
             this.basePolicyValidation_Panel.Location = new System.Drawing.Point(10, 87);
             this.basePolicyValidation_Panel.Margin = new System.Windows.Forms.Padding(2);
             this.basePolicyValidation_Panel.Name = "basePolicyValidation_Panel";
-            this.basePolicyValidation_Panel.Size = new System.Drawing.Size(449, 35);
+            this.basePolicyValidation_Panel.Size = new System.Drawing.Size(793, 35);
             this.basePolicyValidation_Panel.TabIndex = 99;
             this.basePolicyValidation_Panel.Visible = false;
             // 
@@ -161,12 +161,12 @@ namespace WDAC_Wizard
             // Verified_Label
             // 
             this.Verified_Label.AutoSize = true;
-            this.Verified_Label.Font = new System.Drawing.Font("Tahoma", 9.5F);
+            this.Verified_Label.Font = new System.Drawing.Font("Tahoma", 9F);
             this.Verified_Label.ForeColor = System.Drawing.SystemColors.ActiveCaptionText;
             this.Verified_Label.Location = new System.Drawing.Point(37, 8);
             this.Verified_Label.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.Verified_Label.Name = "Verified_Label";
-            this.Verified_Label.Size = new System.Drawing.Size(332, 19);
+            this.Verified_Label.Size = new System.Drawing.Size(297, 18);
             this.Verified_Label.TabIndex = 16;
             this.Verified_Label.Text = "This base policy allows supplemental policies.";
             this.Verified_Label.Visible = false;


### PR DESCRIPTION
Added a check to determine if rule number 6 is already in the policy or policy template before setting it to prevent duplicate instances. 

Fixes issue #150 