### PR TITLE
Updated the rule-options UI/UX for edit policies

### DIFF
--- a/WDAC-Policy-Wizard/app/src/ConfigTemplate_Control.cs
+++ b/WDAC-Policy-Wizard/app/src/ConfigTemplate_Control.cs
@@ -97,7 +97,8 @@ namespace WDAC_Wizard
                 }
 
                 // Depending on the policy, e.g. supplementals, do not allow user to modify the state of some rule-options
-                if (this.Policy._PolicyType == WDAC_Policy.PolicyType.SupplementalPolicy)
+                if (this.Policy._PolicyType == WDAC_Policy.PolicyType.SupplementalPolicy
+                    || this.Policy.siPolicy.PolicyType == global::PolicyType.SupplementalPolicy)
                 { 
                     switch(this.Policy.ConfigRules[key]["ValidSupplemental"]){
                     case "True":


### PR DESCRIPTION
**Before the change,** all rule options for supplemental policies under edit could be modified. 
![image](https://user-images.githubusercontent.com/23045608/197234326-d021b030-633c-40ba-8131-5631d17a5ea0.png)


**With the change,** only valid supplemental rule options can be modified. This is akin to the new supplemental policy workflow. 
![image](https://user-images.githubusercontent.com/23045608/197234239-cb8bcbf1-beef-4649-907d-eed6f964c31e.png)

Addresses issue #155