### PR TITLE
Fixed bug where the Wizard would drop file rules

### DIFF
--- a/WDAC-Policy-Wizard/app/src/Helper.cs
+++ b/WDAC-Policy-Wizard/app/src/Helper.cs
@@ -1595,7 +1595,7 @@ namespace WDAC_Wizard
                         else
                         {
                             refCopy.FileRuleRef = new FileRuleRef[siPolicy.SigningScenarios[i].ProductSigners.FileRulesRef.FileRuleRef.Length + 1];
-                            for (int j = 0; j < refCopy.FileRuleRef.Length - j; j++)
+                            for (int j = 0; j < refCopy.FileRuleRef.Length - 1; j++)
                             {
                                 refCopy.FileRuleRef[j] = siPolicy.SigningScenarios[i].ProductSigners.FileRulesRef.FileRuleRef[j];
                             }


### PR DESCRIPTION
The issue was in the new helper method to add file rule references to the signing scenario. There was a bug in the loop causing multiple file rule references to be omitted from the signing scenario and dropped from the final policy

Closing #173 