### PR TITLE
Reading the file version from the FileVersionInfo parts

### DIFF
--- a/WDAC-Policy-Wizard/app/src/CustomRuleConditionsPanel.cs
+++ b/WDAC-Policy-Wizard/app/src/CustomRuleConditionsPanel.cs
@@ -749,10 +749,11 @@ namespace WDAC_Wizard
             FileVersionInfo fileInfo = FileVersionInfo.GetVersionInfo(refPath);
 
             this.PolicyCustomRule.ReferenceFile = fileInfo.FileName; // Returns the file path
+            string fileVersion = Helper.ConcatFileVersion(fileInfo); 
             this.PolicyCustomRule.FileInfo.Add("CompanyName", String.IsNullOrEmpty(fileInfo.CompanyName) ? Properties.Resources.DefaultFileAttributeString : fileInfo.CompanyName.Trim());
             this.PolicyCustomRule.FileInfo.Add("ProductName", String.IsNullOrEmpty(fileInfo.ProductName) ? Properties.Resources.DefaultFileAttributeString : fileInfo.ProductName.Trim());
             this.PolicyCustomRule.FileInfo.Add("OriginalFilename", String.IsNullOrEmpty(fileInfo.OriginalFilename) ? Properties.Resources.DefaultFileAttributeString : fileInfo.OriginalFilename.Trim());
-            this.PolicyCustomRule.FileInfo.Add("FileVersion", String.IsNullOrEmpty(fileInfo.FileVersion) ? Properties.Resources.DefaultFileAttributeString : fileInfo.FileVersion.Trim().Replace(',', '.')); // Replace misleading commas in version with '.'
+            this.PolicyCustomRule.FileInfo.Add("FileVersion", String.IsNullOrEmpty(fileVersion) ? Properties.Resources.DefaultFileAttributeString : fileVersion);
             this.PolicyCustomRule.FileInfo.Add("FileName", String.IsNullOrEmpty(fileInfo.OriginalFilename) ? Properties.Resources.DefaultFileAttributeString : fileInfo.OriginalFilename.Trim());
             this.PolicyCustomRule.FileInfo.Add("FileDescription", String.IsNullOrEmpty(fileInfo.FileDescription) ? Properties.Resources.DefaultFileAttributeString : fileInfo.FileDescription.Trim());
             this.PolicyCustomRule.FileInfo.Add("InternalName", String.IsNullOrEmpty(fileInfo.InternalName) ? Properties.Resources.DefaultFileAttributeString : fileInfo.InternalName.Trim());

--- a/WDAC-Policy-Wizard/app/src/Helper.cs
+++ b/WDAC-Policy-Wizard/app/src/Helper.cs
@@ -432,6 +432,25 @@ namespace WDAC_Wizard
             return true;
         }
 
+        /// <summary>
+        /// Concatenates the file version parts (major, minor, build and private)
+        /// </summary>
+        /// <param name="fileVersionInfo"></param>
+        /// <returns>Major.Minor.Build.Private if file version exists. Null, otherwise.</returns>
+        public static string ConcatFileVersion(FileVersionInfo fileVersionInfo)
+        {
+            if(fileVersionInfo.FileMajorPart == null
+                || fileVersionInfo.FileMinorPart == null
+                || fileVersionInfo.FileBuildPart == null
+                || fileVersionInfo.FilePrivatePart == null)
+            {
+                return null; 
+            }
+
+            return String.Format("{0}.{1}.{2}.{3}", fileVersionInfo.FileMajorPart, fileVersionInfo.FileMinorPart,
+                                   fileVersionInfo.FileBuildPart, fileVersionInfo.FilePrivatePart);
+        }
+
         public static int CompareVersions(string minVersion, string maxVersion)
         {
             var minversionParts = minVersion.Split('.');

--- a/WDAC-Policy-Wizard/app/src/Helper.cs
+++ b/WDAC-Policy-Wizard/app/src/Helper.cs
@@ -442,7 +442,8 @@ namespace WDAC_Wizard
             if(fileVersionInfo.FileMajorPart == null
                 || fileVersionInfo.FileMinorPart == null
                 || fileVersionInfo.FileBuildPart == null
-                || fileVersionInfo.FilePrivatePart == null)
+                || fileVersionInfo.FilePrivatePart == null
+                || fileVersionInfo.FileVersion == null)
             {
                 return null; 
             }


### PR DESCRIPTION
The Wizard has been creating rules using the unaltered file version from the FileVersionInfo API. When ISV and IHV partners malform the version info, the Wizard will create the rule with junk in the MinimumFileVersion field causing the compiler to complain during conversion to policy binary. 

This fix uses the 4 FileVersion parts and concatenates them together to create a string that is supported in the WDAC compiler. 

Some examples: 
1. "5.2.12-26" --> **5.2.12.26**
2. "6.1.7600.16385 built by: WDK_6001.18001" --> **"6.1.7600.16385**


 
Closing #178 
