### PR TITLE
Bug Fix: Wrong label would appear when user toggled the custom value checkbox on the customer rule panel

### DIFF
--- a/WDAC-Policy-Wizard/app/src/CustomRuleConditionsPanel.cs
+++ b/WDAC-Policy-Wizard/app/src/CustomRuleConditionsPanel.cs
@@ -1465,9 +1465,14 @@ namespace WDAC_Wizard
 
                 // Format the version text boxes
                 this.textBoxSlider_4.Size = this.textBoxSlider_0.Size;
-                this.checkBoxAttribute1.Text = "Min version:";
                 this.textBox_MaxVersion.Visible = false;
                 this.label_To.Visible = false;
+
+                // Flip the label back to Min Version (from Version Range) if Pubisher rule
+                if (this.PolicyCustomRule.Type == PolicyCustomRules.RuleType.Publisher)
+                {
+                    this.checkBoxAttribute4.Text = "Min version:";
+                }
 
                 // Re-populate the text boxes
                 this.textBoxSlider_0.Text = this.DefaultValues[0];


### PR DESCRIPTION
Fixed bug #185 by checking if the rule is a publisher rule before updating the label text

Closes #185 

From this (bug):
![image](https://user-images.githubusercontent.com/23045608/213759607-0f9c66f1-b7e3-4690-98f7-d9bf253923f2.png)

**to this (expected):**
![image](https://user-images.githubusercontent.com/23045608/213760016-621e56c9-b0e3-4eee-8c7a-9d80905aaee2.png)
