### PR TITLE
Implemented Signer exceptions workflow

### DIFF
--- a/WDAC-Policy-Wizard/app/Properties/Resources.Designer.cs
+++ b/WDAC-Policy-Wizard/app/Properties/Resources.Designer.cs
@@ -878,8 +878,17 @@ namespace WDAC_Wizard.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The list of selected rule levels is empty. Please select at least 1 rule level to use while 
-        ///scanning the folder..
+        ///   Looks up a localized string similar to There is an exception rule in progress.
+        ///Are you sure you want to abandon the exception rule creation workflow?.
+        /// </summary>
+        internal static string RuleExceptionInProgressText {
+            get {
+                return ResourceManager.GetString("RuleExceptionInProgressText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The list of selected rule levels is empty. Please select at least 1 rule level to use while scanning the folder..
         /// </summary>
         internal static string RuleLevelEmptyList_Error {
             get {

--- a/WDAC-Policy-Wizard/app/Properties/Resources.resx
+++ b/WDAC-Policy-Wizard/app/Properties/Resources.resx
@@ -504,4 +504,8 @@ Please select the  'Create Rule' button.</value>
   <data name="UnsuccessfulAdvancedHuntingLogConversion" xml:space="preserve">
     <value>The Wizard could not parse any Advanced Hunting events from the CSV file(s).</value>
   </data>
+  <data name="RuleExceptionInProgressText" xml:space="preserve">
+    <value>There is an exception rule in progress.
+Are you sure you want to abandon the exception rule creation workflow?</value>
+  </data>
 </root>

--- a/WDAC-Policy-Wizard/app/src/CustomRuleConditionsPanel.cs
+++ b/WDAC-Policy-Wizard/app/src/CustomRuleConditionsPanel.cs
@@ -69,6 +69,19 @@ namespace WDAC_Wizard
         /// </summary>
         private void Button_CreateRule_Click(object sender, EventArgs e)
         {
+            // Verify first that an exception flow is not in progress
+            if(this.exceptionsControl.IsRuleInProgress())
+            {
+                DialogResult res = MessageBox.Show(Properties.Resources.RuleExceptionInProgressText,
+                                                   "Confirmation",
+                                                   MessageBoxButtons.YesNo,
+                                                   MessageBoxIcon.Question);
+                if(res == DialogResult.No)
+                {
+                    return;
+                }
+            }
+
             // Check COM Object rule for valid GUID
             // Skip scenario and reference file states for COM rules
             if(this.PolicyCustomRule.Type == PolicyCustomRules.RuleType.Com)

--- a/WDAC-Policy-Wizard/app/src/CustomRuleConditionsPanel.cs
+++ b/WDAC-Policy-Wizard/app/src/CustomRuleConditionsPanel.cs
@@ -107,7 +107,6 @@ namespace WDAC_Wizard
                 }
             }
             
-
             // Flag to warn user that N/A's in the CustomRules pane may result in a hash rule
             bool warnUser = false;
 

--- a/WDAC-Policy-Wizard/app/src/CustomRuleConditionsPanel.cs
+++ b/WDAC-Policy-Wizard/app/src/CustomRuleConditionsPanel.cs
@@ -1171,10 +1171,8 @@ namespace WDAC_Wizard
         /// <param name="e"></param>
         private void Button_Next_Click(object sender, EventArgs e)
         {
-            // Assert not a path rule since path rules cannot be excepted in WDAC
-            if(this.PolicyCustomRule.Type == PolicyCustomRules.RuleType.FolderPath 
-                || this.PolicyCustomRule.Type == PolicyCustomRules.RuleType.FilePath 
-                || this.PolicyCustomRule.Type == PolicyCustomRules.RuleType.Hash)
+            // Assert only signer rules can be excepted in WDAC
+            if(this.PolicyCustomRule.Type != PolicyCustomRules.RuleType.Publisher)
             {
                 label_Error.Visible = true;
                 label_Error.Text = Properties.Resources.RuleTypeNoExceptionAllowed;

--- a/WDAC-Policy-Wizard/app/src/CustomRuleConditionsPanel.cs
+++ b/WDAC-Policy-Wizard/app/src/CustomRuleConditionsPanel.cs
@@ -70,7 +70,8 @@ namespace WDAC_Wizard
         private void Button_CreateRule_Click(object sender, EventArgs e)
         {
             // Verify first that an exception flow is not in progress
-            if(this.exceptionsControl.IsRuleInProgress())
+            if(this.exceptionsControl != null
+                && this.exceptionsControl.IsRuleInProgress())
             {
                 DialogResult res = MessageBox.Show(Properties.Resources.RuleExceptionInProgressText,
                                                    "Confirmation",

--- a/WDAC-Policy-Wizard/app/src/Exceptions_Control.Designer.cs
+++ b/WDAC-Policy-Wizard/app/src/Exceptions_Control.Designer.cs
@@ -28,7 +28,6 @@
         /// </summary>
         private void InitializeComponent()
         {
-            this.publisherInfoLabel = new System.Windows.Forms.Label();
             this.panel_ExceptionRule = new System.Windows.Forms.Panel();
             this.ruleCondition_Label = new System.Windows.Forms.Label();
             this.panel_FileFolder = new System.Windows.Forms.Panel();
@@ -57,28 +56,19 @@
             this.textBox_ReferenceFile = new System.Windows.Forms.TextBox();
             this.button_Browse = new System.Windows.Forms.Button();
             this.label11 = new System.Windows.Forms.Label();
+            this.errorLabel = new System.Windows.Forms.Label();
             this.panel_ExceptionRule.SuspendLayout();
             this.panel_FileFolder.SuspendLayout();
             this.panel_Publisher_Scroll.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.dataGridView_Exceptions)).BeginInit();
             this.SuspendLayout();
             // 
-            // publisherInfoLabel
-            // 
-            this.publisherInfoLabel.AutoSize = true;
-            this.publisherInfoLabel.Location = new System.Drawing.Point(9, 769);
-            this.publisherInfoLabel.Name = "publisherInfoLabel";
-            this.publisherInfoLabel.Size = new System.Drawing.Size(124, 17);
-            this.publisherInfoLabel.TabIndex = 106;
-            this.publisherInfoLabel.Text = "publisherInfoLabel";
-            this.publisherInfoLabel.Visible = false;
-            // 
             // panel_ExceptionRule
             // 
             this.panel_ExceptionRule.BackColor = System.Drawing.Color.White;
+            this.panel_ExceptionRule.Controls.Add(this.errorLabel);
             this.panel_ExceptionRule.Controls.Add(this.ruleCondition_Label);
             this.panel_ExceptionRule.Controls.Add(this.panel_FileFolder);
-            this.panel_ExceptionRule.Controls.Add(this.publisherInfoLabel);
             this.panel_ExceptionRule.Controls.Add(this.panel_Publisher_Scroll);
             this.panel_ExceptionRule.Controls.Add(this.dataGridView_Exceptions);
             this.panel_ExceptionRule.Controls.Add(this.ruleCondition_static_Label);
@@ -164,14 +154,14 @@
             this.panel_Publisher_Scroll.Location = new System.Drawing.Point(8, 492);
             this.panel_Publisher_Scroll.Margin = new System.Windows.Forms.Padding(2);
             this.panel_Publisher_Scroll.Name = "panel_Publisher_Scroll";
-            this.panel_Publisher_Scroll.Size = new System.Drawing.Size(494, 261);
+            this.panel_Publisher_Scroll.Size = new System.Drawing.Size(494, 254);
             this.panel_Publisher_Scroll.TabIndex = 108;
             this.panel_Publisher_Scroll.Visible = false;
             // 
             // checkBoxCustomValues
             // 
             this.checkBoxCustomValues.AutoSize = true;
-            this.checkBoxCustomValues.Location = new System.Drawing.Point(9, 237);
+            this.checkBoxCustomValues.Location = new System.Drawing.Point(9, 227);
             this.checkBoxCustomValues.Name = "checkBoxCustomValues";
             this.checkBoxCustomValues.Size = new System.Drawing.Size(153, 21);
             this.checkBoxCustomValues.TabIndex = 126;
@@ -422,6 +412,16 @@
             this.label11.Text = "Reference File:";
             this.label11.TextAlign = System.Drawing.ContentAlignment.TopCenter;
             // 
+            // errorLabel
+            // 
+            this.errorLabel.AutoSize = true;
+            this.errorLabel.Location = new System.Drawing.Point(7, 787);
+            this.errorLabel.Name = "errorLabel";
+            this.errorLabel.Size = new System.Drawing.Size(74, 17);
+            this.errorLabel.TabIndex = 110;
+            this.errorLabel.Text = "errorLabel";
+            this.errorLabel.Visible = false;
+            // 
             // Exceptions_Control
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(120F, 120F);
@@ -443,7 +443,6 @@
         }
 
         #endregion
-        private System.Windows.Forms.Label publisherInfoLabel;
         private System.Windows.Forms.Panel panel_ExceptionRule;
         private System.Windows.Forms.Panel panel_FileFolder;
         private System.Windows.Forms.RadioButton radioButton_Folder;
@@ -472,5 +471,6 @@
         private System.Windows.Forms.CheckBox checkBox_Product;
         private System.Windows.Forms.CheckBox checkBox_OriginalFilename;
         private System.Windows.Forms.CheckBox checkBoxCustomValues;
+        private System.Windows.Forms.Label errorLabel;
     }
 }

--- a/WDAC-Policy-Wizard/app/src/Exceptions_Control.Designer.cs
+++ b/WDAC-Policy-Wizard/app/src/Exceptions_Control.Designer.cs
@@ -66,10 +66,9 @@
             // publisherInfoLabel
             // 
             this.publisherInfoLabel.AutoSize = true;
-            this.publisherInfoLabel.Location = new System.Drawing.Point(11, 914);
-            this.publisherInfoLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.publisherInfoLabel.Location = new System.Drawing.Point(9, 769);
             this.publisherInfoLabel.Name = "publisherInfoLabel";
-            this.publisherInfoLabel.Size = new System.Drawing.Size(118, 16);
+            this.publisherInfoLabel.Size = new System.Drawing.Size(124, 17);
             this.publisherInfoLabel.TabIndex = 106;
             this.publisherInfoLabel.Text = "publisherInfoLabel";
             this.publisherInfoLabel.Visible = false;
@@ -89,10 +88,10 @@
             this.panel_ExceptionRule.Controls.Add(this.textBox_ReferenceFile);
             this.panel_ExceptionRule.Controls.Add(this.button_Browse);
             this.panel_ExceptionRule.Controls.Add(this.label11);
-            this.panel_ExceptionRule.Location = new System.Drawing.Point(156, 0);
+            this.panel_ExceptionRule.Location = new System.Drawing.Point(130, 0);
             this.panel_ExceptionRule.Margin = new System.Windows.Forms.Padding(2);
             this.panel_ExceptionRule.Name = "panel_ExceptionRule";
-            this.panel_ExceptionRule.Size = new System.Drawing.Size(845, 1158);
+            this.panel_ExceptionRule.Size = new System.Drawing.Size(704, 965);
             this.panel_ExceptionRule.TabIndex = 87;
             // 
             // ruleCondition_Label
@@ -100,10 +99,10 @@
             this.ruleCondition_Label.AutoSize = true;
             this.ruleCondition_Label.Font = new System.Drawing.Font("Tahoma", 8.7F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.ruleCondition_Label.ForeColor = System.Drawing.Color.Black;
-            this.ruleCondition_Label.Location = new System.Drawing.Point(8, 172);
+            this.ruleCondition_Label.Location = new System.Drawing.Point(7, 143);
             this.ruleCondition_Label.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.ruleCondition_Label.Name = "ruleCondition_Label";
-            this.ruleCondition_Label.Size = new System.Drawing.Size(131, 22);
+            this.ruleCondition_Label.Size = new System.Drawing.Size(103, 18);
             this.ruleCondition_Label.TabIndex = 109;
             this.ruleCondition_Label.Text = "Rule Condition:";
             this.ruleCondition_Label.Visible = false;
@@ -112,10 +111,10 @@
             // 
             this.panel_FileFolder.Controls.Add(this.radioButton_Folder);
             this.panel_FileFolder.Controls.Add(this.radioButton_File);
-            this.panel_FileFolder.Location = new System.Drawing.Point(592, 588);
+            this.panel_FileFolder.Location = new System.Drawing.Point(493, 490);
             this.panel_FileFolder.Margin = new System.Windows.Forms.Padding(2);
             this.panel_FileFolder.Name = "panel_FileFolder";
-            this.panel_FileFolder.Size = new System.Drawing.Size(168, 41);
+            this.panel_FileFolder.Size = new System.Drawing.Size(140, 34);
             this.panel_FileFolder.TabIndex = 104;
             this.panel_FileFolder.Visible = false;
             // 
@@ -124,10 +123,10 @@
             this.radioButton_Folder.AutoSize = true;
             this.radioButton_Folder.Font = new System.Drawing.Font("Tahoma", 9F);
             this.radioButton_Folder.ForeColor = System.Drawing.Color.Black;
-            this.radioButton_Folder.Location = new System.Drawing.Point(73, 8);
+            this.radioButton_Folder.Location = new System.Drawing.Point(61, 7);
             this.radioButton_Folder.Margin = new System.Windows.Forms.Padding(2);
             this.radioButton_Folder.Name = "radioButton_Folder";
-            this.radioButton_Folder.Size = new System.Drawing.Size(83, 26);
+            this.radioButton_Folder.Size = new System.Drawing.Size(68, 22);
             this.radioButton_Folder.TabIndex = 96;
             this.radioButton_Folder.TabStop = true;
             this.radioButton_Folder.Text = "Folder";
@@ -139,10 +138,10 @@
             this.radioButton_File.AutoSize = true;
             this.radioButton_File.Font = new System.Drawing.Font("Tahoma", 9F);
             this.radioButton_File.ForeColor = System.Drawing.Color.Black;
-            this.radioButton_File.Location = new System.Drawing.Point(2, 8);
+            this.radioButton_File.Location = new System.Drawing.Point(2, 7);
             this.radioButton_File.Margin = new System.Windows.Forms.Padding(2);
             this.radioButton_File.Name = "radioButton_File";
-            this.radioButton_File.Size = new System.Drawing.Size(61, 26);
+            this.radioButton_File.Size = new System.Drawing.Size(49, 22);
             this.radioButton_File.TabIndex = 95;
             this.radioButton_File.TabStop = true;
             this.radioButton_File.Text = "File";
@@ -162,20 +161,19 @@
             this.panel_Publisher_Scroll.Controls.Add(this.textBox_filedescription);
             this.panel_Publisher_Scroll.Controls.Add(this.checkBox_OriginalFilename);
             this.panel_Publisher_Scroll.Controls.Add(this.textBox_originalfilename);
-            this.panel_Publisher_Scroll.Location = new System.Drawing.Point(10, 590);
+            this.panel_Publisher_Scroll.Location = new System.Drawing.Point(8, 492);
             this.panel_Publisher_Scroll.Margin = new System.Windows.Forms.Padding(2);
             this.panel_Publisher_Scroll.Name = "panel_Publisher_Scroll";
-            this.panel_Publisher_Scroll.Size = new System.Drawing.Size(593, 313);
+            this.panel_Publisher_Scroll.Size = new System.Drawing.Size(494, 261);
             this.panel_Publisher_Scroll.TabIndex = 108;
             this.panel_Publisher_Scroll.Visible = false;
             // 
             // checkBoxCustomValues
             // 
             this.checkBoxCustomValues.AutoSize = true;
-            this.checkBoxCustomValues.Location = new System.Drawing.Point(11, 284);
-            this.checkBoxCustomValues.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.checkBoxCustomValues.Location = new System.Drawing.Point(9, 237);
             this.checkBoxCustomValues.Name = "checkBoxCustomValues";
-            this.checkBoxCustomValues.Size = new System.Drawing.Size(152, 21);
+            this.checkBoxCustomValues.Size = new System.Drawing.Size(153, 21);
             this.checkBoxCustomValues.TabIndex = 126;
             this.checkBoxCustomValues.Text = "Use Custom Values";
             this.checkBoxCustomValues.UseVisualStyleBackColor = true;
@@ -185,20 +183,19 @@
             // 
             this.textBox_minversion.BackColor = System.Drawing.SystemColors.Control;
             this.textBox_minversion.Font = new System.Drawing.Font("Tahoma", 9F);
-            this.textBox_minversion.Location = new System.Drawing.Point(180, 221);
+            this.textBox_minversion.Location = new System.Drawing.Point(150, 184);
             this.textBox_minversion.Margin = new System.Windows.Forms.Padding(2);
             this.textBox_minversion.Name = "textBox_minversion";
             this.textBox_minversion.ReadOnly = true;
-            this.textBox_minversion.Size = new System.Drawing.Size(402, 29);
+            this.textBox_minversion.Size = new System.Drawing.Size(336, 26);
             this.textBox_minversion.TabIndex = 125;
             // 
             // checkBox_InternalName
             // 
             this.checkBox_InternalName.AutoSize = true;
-            this.checkBox_InternalName.Location = new System.Drawing.Point(11, 176);
-            this.checkBox_InternalName.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.checkBox_InternalName.Location = new System.Drawing.Point(9, 147);
             this.checkBox_InternalName.Name = "checkBox_InternalName";
-            this.checkBox_InternalName.Size = new System.Drawing.Size(120, 21);
+            this.checkBox_InternalName.Size = new System.Drawing.Size(122, 21);
             this.checkBox_InternalName.TabIndex = 124;
             this.checkBox_InternalName.Text = "Internal Name:";
             this.checkBox_InternalName.UseVisualStyleBackColor = true;
@@ -208,20 +205,19 @@
             // 
             this.textBox_internalname.BackColor = System.Drawing.SystemColors.Control;
             this.textBox_internalname.Font = new System.Drawing.Font("Tahoma", 9F);
-            this.textBox_internalname.Location = new System.Drawing.Point(180, 172);
+            this.textBox_internalname.Location = new System.Drawing.Point(150, 143);
             this.textBox_internalname.Margin = new System.Windows.Forms.Padding(2);
             this.textBox_internalname.Name = "textBox_internalname";
             this.textBox_internalname.ReadOnly = true;
-            this.textBox_internalname.Size = new System.Drawing.Size(402, 29);
+            this.textBox_internalname.Size = new System.Drawing.Size(336, 26);
             this.textBox_internalname.TabIndex = 103;
             // 
             // checkBox_MinVersion
             // 
             this.checkBox_MinVersion.AutoSize = true;
-            this.checkBox_MinVersion.Location = new System.Drawing.Point(11, 227);
-            this.checkBox_MinVersion.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.checkBox_MinVersion.Location = new System.Drawing.Point(9, 189);
             this.checkBox_MinVersion.Name = "checkBox_MinVersion";
-            this.checkBox_MinVersion.Size = new System.Drawing.Size(110, 21);
+            this.checkBox_MinVersion.Size = new System.Drawing.Size(112, 21);
             this.checkBox_MinVersion.TabIndex = 123;
             this.checkBox_MinVersion.Text = "Min. Version:";
             this.checkBox_MinVersion.UseVisualStyleBackColor = true;
@@ -230,8 +226,7 @@
             // checkBox_FileDescription
             // 
             this.checkBox_FileDescription.AutoSize = true;
-            this.checkBox_FileDescription.Location = new System.Drawing.Point(11, 76);
-            this.checkBox_FileDescription.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.checkBox_FileDescription.Location = new System.Drawing.Point(9, 63);
             this.checkBox_FileDescription.Name = "checkBox_FileDescription";
             this.checkBox_FileDescription.Size = new System.Drawing.Size(127, 21);
             this.checkBox_FileDescription.TabIndex = 122;
@@ -243,18 +238,17 @@
             // 
             this.textBox_product.BackColor = System.Drawing.SystemColors.Control;
             this.textBox_product.Font = new System.Drawing.Font("Tahoma", 9F);
-            this.textBox_product.Location = new System.Drawing.Point(180, 122);
+            this.textBox_product.Location = new System.Drawing.Point(150, 102);
             this.textBox_product.Margin = new System.Windows.Forms.Padding(2);
             this.textBox_product.Name = "textBox_product";
             this.textBox_product.ReadOnly = true;
-            this.textBox_product.Size = new System.Drawing.Size(402, 29);
+            this.textBox_product.Size = new System.Drawing.Size(336, 26);
             this.textBox_product.TabIndex = 101;
             // 
             // checkBox_Product
             // 
             this.checkBox_Product.AutoSize = true;
-            this.checkBox_Product.Location = new System.Drawing.Point(11, 126);
-            this.checkBox_Product.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.checkBox_Product.Location = new System.Drawing.Point(9, 105);
             this.checkBox_Product.Name = "checkBox_Product";
             this.checkBox_Product.Size = new System.Drawing.Size(83, 21);
             this.checkBox_Product.TabIndex = 121;
@@ -266,20 +260,19 @@
             // 
             this.textBox_filedescription.BackColor = System.Drawing.SystemColors.Control;
             this.textBox_filedescription.Font = new System.Drawing.Font("Tahoma", 9F);
-            this.textBox_filedescription.Location = new System.Drawing.Point(180, 73);
+            this.textBox_filedescription.Location = new System.Drawing.Point(150, 61);
             this.textBox_filedescription.Margin = new System.Windows.Forms.Padding(2);
             this.textBox_filedescription.Name = "textBox_filedescription";
             this.textBox_filedescription.ReadOnly = true;
-            this.textBox_filedescription.Size = new System.Drawing.Size(402, 29);
+            this.textBox_filedescription.Size = new System.Drawing.Size(336, 26);
             this.textBox_filedescription.TabIndex = 99;
             // 
             // checkBox_OriginalFilename
             // 
             this.checkBox_OriginalFilename.AutoSize = true;
-            this.checkBox_OriginalFilename.Location = new System.Drawing.Point(11, 25);
-            this.checkBox_OriginalFilename.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.checkBox_OriginalFilename.Location = new System.Drawing.Point(9, 21);
             this.checkBox_OriginalFilename.Name = "checkBox_OriginalFilename";
-            this.checkBox_OriginalFilename.Size = new System.Drawing.Size(142, 21);
+            this.checkBox_OriginalFilename.Size = new System.Drawing.Size(144, 21);
             this.checkBox_OriginalFilename.TabIndex = 120;
             this.checkBox_OriginalFilename.Text = "Original Filename:";
             this.checkBox_OriginalFilename.UseVisualStyleBackColor = true;
@@ -289,11 +282,11 @@
             // 
             this.textBox_originalfilename.BackColor = System.Drawing.SystemColors.Control;
             this.textBox_originalfilename.Font = new System.Drawing.Font("Tahoma", 9F);
-            this.textBox_originalfilename.Location = new System.Drawing.Point(180, 24);
+            this.textBox_originalfilename.Location = new System.Drawing.Point(150, 20);
             this.textBox_originalfilename.Margin = new System.Windows.Forms.Padding(2);
             this.textBox_originalfilename.Name = "textBox_originalfilename";
             this.textBox_originalfilename.ReadOnly = true;
-            this.textBox_originalfilename.Size = new System.Drawing.Size(402, 29);
+            this.textBox_originalfilename.Size = new System.Drawing.Size(336, 26);
             this.textBox_originalfilename.TabIndex = 95;
             // 
             // dataGridView_Exceptions
@@ -306,13 +299,12 @@
             this.column_Action,
             this.column_Level,
             this.column_Name});
-            this.dataGridView_Exceptions.Location = new System.Drawing.Point(8, 324);
-            this.dataGridView_Exceptions.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.dataGridView_Exceptions.Location = new System.Drawing.Point(7, 270);
             this.dataGridView_Exceptions.Name = "dataGridView_Exceptions";
             this.dataGridView_Exceptions.ReadOnly = true;
             this.dataGridView_Exceptions.RowHeadersWidth = 51;
             this.dataGridView_Exceptions.RowTemplate.Height = 24;
-            this.dataGridView_Exceptions.Size = new System.Drawing.Size(745, 180);
+            this.dataGridView_Exceptions.Size = new System.Drawing.Size(621, 150);
             this.dataGridView_Exceptions.TabIndex = 107;
             this.dataGridView_Exceptions.VirtualMode = true;
             this.dataGridView_Exceptions.CellValueNeeded += new System.Windows.Forms.DataGridViewCellValueEventHandler(this.DataGridView_Exceptions_CellValueNeeded);
@@ -323,7 +315,7 @@
             this.column_Action.MinimumWidth = 8;
             this.column_Action.Name = "column_Action";
             this.column_Action.ReadOnly = true;
-            this.column_Action.Width = 81;
+            this.column_Action.Width = 76;
             // 
             // column_Level
             // 
@@ -331,7 +323,7 @@
             this.column_Level.MinimumWidth = 6;
             this.column_Level.Name = "column_Level";
             this.column_Level.ReadOnly = true;
-            this.column_Level.Width = 76;
+            this.column_Level.Width = 69;
             // 
             // column_Name
             // 
@@ -339,17 +331,17 @@
             this.column_Name.MinimumWidth = 6;
             this.column_Name.Name = "column_Name";
             this.column_Name.ReadOnly = true;
-            this.column_Name.Width = 103;
+            this.column_Name.Width = 98;
             // 
             // ruleCondition_static_Label
             // 
             this.ruleCondition_static_Label.AutoSize = true;
             this.ruleCondition_static_Label.Font = new System.Drawing.Font("Tahoma", 9F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.ruleCondition_static_Label.ForeColor = System.Drawing.Color.Black;
-            this.ruleCondition_static_Label.Location = new System.Drawing.Point(8, 150);
+            this.ruleCondition_static_Label.Location = new System.Drawing.Point(7, 125);
             this.ruleCondition_static_Label.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.ruleCondition_static_Label.Name = "ruleCondition_static_Label";
-            this.ruleCondition_static_Label.Size = new System.Drawing.Size(149, 22);
+            this.ruleCondition_static_Label.Size = new System.Drawing.Size(122, 18);
             this.ruleCondition_static_Label.TabIndex = 95;
             this.ruleCondition_static_Label.Text = "Rule Condition:";
             // 
@@ -358,10 +350,9 @@
             this.label7.AutoSize = true;
             this.label7.Font = new System.Drawing.Font("Tahoma", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label7.ForeColor = System.Drawing.Color.Black;
-            this.label7.Location = new System.Drawing.Point(8, 78);
-            this.label7.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label7.Location = new System.Drawing.Point(7, 65);
             this.label7.Name = "label7";
-            this.label7.Size = new System.Drawing.Size(746, 44);
+            this.label7.Size = new System.Drawing.Size(606, 36);
             this.label7.TabIndex = 94;
             this.label7.Text = "Exceptions allow you to exclude files that would be included in the rule. Select " +
     "the exception \r\ntype and browse for the reference file off which to base the exc" +
@@ -372,10 +363,9 @@
             this.label8.AutoSize = true;
             this.label8.Font = new System.Drawing.Font("Tahoma", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label8.ForeColor = System.Drawing.Color.Black;
-            this.label8.Location = new System.Drawing.Point(8, 252);
-            this.label8.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label8.Location = new System.Drawing.Point(7, 210);
             this.label8.Name = "label8";
-            this.label8.Size = new System.Drawing.Size(137, 22);
+            this.label8.Size = new System.Drawing.Size(114, 18);
             this.label8.TabIndex = 89;
             this.label8.Text = "Exception Type:";
             this.label8.TextAlign = System.Drawing.ContentAlignment.TopCenter;
@@ -388,20 +378,20 @@
             "File Path",
             "File Attributes",
             "File Hash"});
-            this.comboBox_ExceptionType.Location = new System.Drawing.Point(8, 287);
+            this.comboBox_ExceptionType.Location = new System.Drawing.Point(7, 239);
             this.comboBox_ExceptionType.Margin = new System.Windows.Forms.Padding(2);
             this.comboBox_ExceptionType.Name = "comboBox_ExceptionType";
-            this.comboBox_ExceptionType.Size = new System.Drawing.Size(224, 30);
+            this.comboBox_ExceptionType.Size = new System.Drawing.Size(187, 26);
             this.comboBox_ExceptionType.TabIndex = 89;
             this.comboBox_ExceptionType.SelectedIndexChanged += new System.EventHandler(this.ComboBox_ExceptionType_SelectedIndexChanged);
             // 
             // textBox_ReferenceFile
             // 
             this.textBox_ReferenceFile.Font = new System.Drawing.Font("Tahoma", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.textBox_ReferenceFile.Location = new System.Drawing.Point(8, 547);
+            this.textBox_ReferenceFile.Location = new System.Drawing.Point(7, 456);
             this.textBox_ReferenceFile.Margin = new System.Windows.Forms.Padding(2);
             this.textBox_ReferenceFile.Name = "textBox_ReferenceFile";
-            this.textBox_ReferenceFile.Size = new System.Drawing.Size(560, 29);
+            this.textBox_ReferenceFile.Size = new System.Drawing.Size(467, 26);
             this.textBox_ReferenceFile.TabIndex = 88;
             // 
             // button_Browse
@@ -411,10 +401,10 @@
             this.button_Browse.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.button_Browse.Font = new System.Drawing.Font("Tahoma", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.button_Browse.ForeColor = System.Drawing.Color.DodgerBlue;
-            this.button_Browse.Location = new System.Drawing.Point(592, 546);
+            this.button_Browse.Location = new System.Drawing.Point(493, 455);
             this.button_Browse.Margin = new System.Windows.Forms.Padding(2);
             this.button_Browse.Name = "button_Browse";
-            this.button_Browse.Size = new System.Drawing.Size(128, 34);
+            this.button_Browse.Size = new System.Drawing.Size(107, 28);
             this.button_Browse.TabIndex = 84;
             this.button_Browse.Text = "Browse";
             this.button_Browse.UseVisualStyleBackColor = false;
@@ -425,23 +415,21 @@
             this.label11.AutoSize = true;
             this.label11.Font = new System.Drawing.Font("Tahoma", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label11.ForeColor = System.Drawing.Color.Black;
-            this.label11.Location = new System.Drawing.Point(8, 516);
-            this.label11.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label11.Location = new System.Drawing.Point(7, 430);
             this.label11.Name = "label11";
-            this.label11.Size = new System.Drawing.Size(125, 22);
+            this.label11.Size = new System.Drawing.Size(104, 18);
             this.label11.TabIndex = 87;
             this.label11.Text = "Reference File:";
             this.label11.TextAlign = System.Drawing.ContentAlignment.TopCenter;
             // 
             // Exceptions_Control
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(144F, 144F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(120F, 120F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.Color.White;
             this.Controls.Add(this.panel_ExceptionRule);
-            this.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.Name = "Exceptions_Control";
-            this.Size = new System.Drawing.Size(1201, 1186);
+            this.Size = new System.Drawing.Size(1001, 988);
             this.Load += new System.EventHandler(this.Exceptions_Control_Load);
             this.panel_ExceptionRule.ResumeLayout(false);
             this.panel_ExceptionRule.PerformLayout();

--- a/WDAC-Policy-Wizard/app/src/Exceptions_Control.cs
+++ b/WDAC-Policy-Wizard/app/src/Exceptions_Control.cs
@@ -51,6 +51,14 @@ namespace WDAC_Wizard
             this.panel_Publisher_Scroll.Visible = false;
             this.publisherInfoLabel.Visible = false;
 
+            // File attribute:
+            checkBox_OriginalFilename.Checked = false;
+            checkBox_FileDescription.Checked = false;
+            checkBox_Product.Checked = false;
+            checkBox_InternalName.Checked = false;
+            checkBox_MinVersion.Checked = false;
+            checkBoxCustomValues.Checked = false;
+
             //File Path:
             this.panel_FileFolder.Visible = false;
 
@@ -77,12 +85,6 @@ namespace WDAC_Wizard
 
             switch (selectedOpt)
             {
-                case "Publisher":
-                    // TODO: figure out why publisher exceptions are not compatible with publisher rules
-                    this.ExceptionRule.SetRuleType(PolicyCustomRules.RuleType.Publisher);
-                    this.ExceptionRule.SetRuleLevel(PolicyCustomRules.RuleLevel.FilePublisher); // Match UI by default
-                    break;
-
                 case "File Path":
                     this.ExceptionRule.SetRuleType(PolicyCustomRules.RuleType.FilePath);
                     this.ExceptionRule.SetRuleLevel(PolicyCustomRules.RuleLevel.FilePath);
@@ -106,7 +108,11 @@ namespace WDAC_Wizard
             this.Log.AddInfoMsg(String.Format("Exception File Rule Level Set to {0}", selectedOpt));
         }
 
-
+        /// <summary>
+        /// Fires on Browse Button click. Gets the location of the file or folder provided by the file dialog. 
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
         private void Button_Browse_Click(object sender, EventArgs e)
         {
             // Browse button for reference file:
@@ -120,53 +126,24 @@ namespace WDAC_Wizard
 
             if (this.ExceptionRule.GetRuleType() != PolicyCustomRules.RuleType.FolderPath)
             {
-                string refPath = GetFileLocation();
+                // Open file dialog to get file or folder path
+                string refPath = Helper.BrowseForSingleFile(Properties.Resources.OpenPEFileDialogTitle, Helper.BrowseFileType.PEFile);
 
                 if (refPath == String.Empty)
                     return;
-
-                // Custom rule in progress
-               // this._MainWindow.CustomRuleinProgress = true;
 
                 // Get generic file information to be shown to user
                 ExceptionRule.FileInfo = new Dictionary<string, string>(); // Reset dict
                 FileVersionInfo fileInfo = FileVersionInfo.GetVersionInfo(refPath);
                 ExceptionRule.ReferenceFile = fileInfo.FileName; // Returns the file path
-                ExceptionRule.FileInfo.Add("CompanyName", String.IsNullOrEmpty(fileInfo.CompanyName) ? Properties.Resources.DefaultFileAttributeString : fileInfo.CompanyName);
-                ExceptionRule.FileInfo.Add("ProductName", String.IsNullOrEmpty(fileInfo.ProductName) ? Properties.Resources.DefaultFileAttributeString : fileInfo.ProductName);
-                ExceptionRule.FileInfo.Add("OriginalFilename", String.IsNullOrEmpty(fileInfo.OriginalFilename) ? Properties.Resources.DefaultFileAttributeString : fileInfo.OriginalFilename);
-                ExceptionRule.FileInfo.Add("FileVersion", String.IsNullOrEmpty(fileInfo.FileVersion) ? "0.0.0.0" : fileInfo.FileVersion);
-                ExceptionRule.FileInfo.Add("FileName", String.IsNullOrEmpty(fileInfo.OriginalFilename) ? Properties.Resources.DefaultFileAttributeString : fileInfo.OriginalFilename); // WDAC configCI uses original filename 
-                ExceptionRule.FileInfo.Add("FileDescription", String.IsNullOrEmpty(fileInfo.FileDescription) ? Properties.Resources.DefaultFileAttributeString : fileInfo.FileDescription);
-                ExceptionRule.FileInfo.Add("InternalName", String.IsNullOrEmpty(fileInfo.InternalName) ? Properties.Resources.DefaultFileAttributeString : fileInfo.InternalName);
-
-                // Get cert chain info to be shown to the user
-                string leafCertSubjectName = "";
-                string pcaCertSubjectName = "";
-
-                if(this.ExceptionRule.Type == PolicyCustomRules.RuleType.Publisher)
-                {
-                    try
-                    {
-                        var signer = X509Certificate.CreateFromSignedFile(refPath);
-                        var cert = new X509Certificate2(signer);
-                        var certChain = new X509Chain();
-                        var certChainIsValid = certChain.Build(cert);
-
-                        leafCertSubjectName = cert.SubjectName.Name;
-                        if (certChain.ChainElements.Count > 1)
-                            pcaCertSubjectName = certChain.ChainElements[1].Certificate.SubjectName.Name;
-
-                    }
-                    catch (Exception exp)
-                    {
-                        // Set labelError text in CustomRuleConditionsPanel
-                        this.ConditionsPanel.SetLabel_ErrorText(Properties.Resources.CertificateBuild_Error + fileInfo.FileName);
-                    }
-                }
-                
-                ExceptionRule.FileInfo.Add("LeafCertificate", String.IsNullOrEmpty(leafCertSubjectName) ? Properties.Resources.DefaultFileAttributeString : leafCertSubjectName);
-                ExceptionRule.FileInfo.Add("PCACertificate", String.IsNullOrEmpty(pcaCertSubjectName) ? Properties.Resources.DefaultFileAttributeString : pcaCertSubjectName);
+                string fileVersion = Helper.ConcatFileVersion(fileInfo);
+                ExceptionRule.FileInfo.Add("CompanyName", String.IsNullOrEmpty(fileInfo.CompanyName) ? Properties.Resources.DefaultFileAttributeString : fileInfo.CompanyName.Trim());
+                ExceptionRule.FileInfo.Add("ProductName", String.IsNullOrEmpty(fileInfo.ProductName) ? Properties.Resources.DefaultFileAttributeString : fileInfo.ProductName.Trim());
+                ExceptionRule.FileInfo.Add("OriginalFilename", String.IsNullOrEmpty(fileInfo.OriginalFilename) ? Properties.Resources.DefaultFileAttributeString : fileInfo.OriginalFilename.Trim());
+                ExceptionRule.FileInfo.Add("FileVersion", String.IsNullOrEmpty(fileVersion) ? Properties.Resources.DefaultFileAttributeString : fileVersion);
+                ExceptionRule.FileInfo.Add("FileName", String.IsNullOrEmpty(fileInfo.OriginalFilename) ? Properties.Resources.DefaultFileAttributeString : fileInfo.OriginalFilename.Trim());
+                ExceptionRule.FileInfo.Add("FileDescription", String.IsNullOrEmpty(fileInfo.FileDescription) ? Properties.Resources.DefaultFileAttributeString : fileInfo.FileDescription.Trim());
+                ExceptionRule.FileInfo.Add("InternalName", String.IsNullOrEmpty(fileInfo.InternalName) ? Properties.Resources.DefaultFileAttributeString : fileInfo.InternalName.Trim());
             }
 
             // Set the landing UI depending on the Rule type
@@ -213,7 +190,6 @@ namespace WDAC_Wizard
                     break;
 
                 case PolicyCustomRules.RuleType.FileAttributes:
-                    // Creates a rule -Level FileName -SpecificFileNameLevel InternalName, FileDescription
 
                     // UI 
                     this.textBox_ReferenceFile.Text = ExceptionRule.ReferenceFile;
@@ -260,13 +236,6 @@ namespace WDAC_Wizard
             }
         }
 
-        private void Button_CreateException_Click(object sender, EventArgs e)
-        {
-            // Add the exception to the table
-            this.CustomRule.AddException(this.ExceptionRule);
-            this.ExceptionRule = null; 
-        }
-
         /// <summary>
         /// Opens the folder dialog and grabs the folder path. Requires Folder to be toggled when Browse button 
         /// is selected. 
@@ -274,30 +243,14 @@ namespace WDAC_Wizard
         /// <returns>Returns the full path of the folder</returns>
         private string GetFolderLocation()
         {
-            FolderBrowserDialog openFolderDialog = new FolderBrowserDialog();
-            openFolderDialog.Description = "Browse for a folder to use as a reference for the rule.";
-
-            if (openFolderDialog.ShowDialog() == DialogResult.OK)
-            {
-                openFolderDialog.Dispose();
-                return openFolderDialog.SelectedPath;
-            }
-            else
-            {
-                return String.Empty;
-            }
+            return Helper.GetFolderPath("Browse for a folder to use as a reference for the rule.");
         }
 
         /// <summary>
-        /// Opens the file dialog and grabs the file path for PEs only and checks if path exists. 
+        /// Sets the UI upon loading the exceptions control panel
         /// </summary>
-        /// <returns>Returns the full path+name of the file</returns>
-        private string GetFileLocation()
-        {
-            // Open file dialog to get file or folder path
-            return Helper.BrowseForSingleFile(Properties.Resources.OpenPEFileDialogTitle, Helper.BrowseFileType.PEFile);
-        }
-
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
         private void Exceptions_Control_Load(object sender, EventArgs e)
         {
             // On load, set the rule condition label
@@ -375,6 +328,11 @@ namespace WDAC_Wizard
             }
         }
 
+        /// <summary>
+        /// Formats the Rule Condition text at the top of the page
+        /// </summary>
+        /// <param name="ruleConditionString"></param>
+        /// <returns></returns>
         public string FormatText(string ruleConditionString)
         {
             int MAX_LEN = 100;
@@ -435,8 +393,10 @@ namespace WDAC_Wizard
             return ruleConditionString; 
         }
 
-        // Triggered by Add Exception button click on custom rule conditions panel. 
-        // Add exception to the exception table
+        /// <summary>
+        /// Triggered by Add Exception button click on custom rule conditions panel. 
+        /// Add exception to the exception table
+        /// </summary>
         public void AddException()
         {
             //Set ExceptionRule.Level to opposite of the PolicyCustomRule.Level
@@ -450,11 +410,23 @@ namespace WDAC_Wizard
             }
 
             // Check that fields are valid, otherwise break and show error msg
-            if(this.ExceptionRule == null || this.ExceptionRule.ReferenceFile == null 
-                || this.ExceptionRule.Level == PolicyCustomRules.RuleLevel.None)
+            if(this.ExceptionRule == null 
+                || String.IsNullOrEmpty(this.ExceptionRule.ReferenceFile)
+                || this.ExceptionRule.Type == PolicyCustomRules.RuleType.None
+                || !this.ExceptionRule.IsAnyBoxChecked())
             {
                 this.ConditionsPanel.SetLabel_ErrorText("Invalid exception selection. Please select a level and reference file");
                 return; 
+            }
+
+            // Get the values from the textboxes for the file attributes rule
+            if(this.ExceptionRule.Type == PolicyCustomRules.RuleType.FileAttributes)
+            {
+                this.ExceptionRule.CustomValues.FileName = textBox_originalfilename.Text;
+                this.ExceptionRule.CustomValues.Description = textBox_filedescription.Text;
+                this.ExceptionRule.CustomValues.ProductName = textBox_product.Text;
+                this.ExceptionRule.CustomValues.InternalName = textBox_internalname.Text; 
+                this.ExceptionRule.CustomValues.MinVersion= textBox_minversion.Text;
             }
 
             // Add the exception to the custom rule and table
@@ -463,7 +435,7 @@ namespace WDAC_Wizard
             // New Display object
             DisplayObject displayObject = new DisplayObject();
             displayObject.Action = this.ExceptionRule.Permission.ToString();
-            displayObject.Level = this.ExceptionRule.Level.ToString();
+            displayObject.Level = this.ExceptionRule.Type.ToString();
             displayObject.Name = Path.GetFileName(this.ExceptionRule.ReferenceFile.ToString());
 
             this.displayObjects.Add(displayObject);
@@ -524,6 +496,11 @@ namespace WDAC_Wizard
             
         }
 
+        /// <summary>
+        /// Checkbox state for Original Filename was updated.Modify the checkbox state struct. 
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
         private void checkBox_OriginalFilename_CheckedChanged(object sender, EventArgs e)
         {
             if (this.checkBox_OriginalFilename.Checked)
@@ -545,6 +522,11 @@ namespace WDAC_Wizard
             this.ExceptionRule.CheckboxCheckStates.checkBox0 = false;
         }
 
+        /// <summary>
+        /// Checkbox state for File Description was updated. Modify the checkbox state struct. 
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
         private void checkBox_FileDescription_CheckedChanged(object sender, EventArgs e)
         {
             if (this.checkBox_FileDescription.Checked)
@@ -566,6 +548,11 @@ namespace WDAC_Wizard
             this.ExceptionRule.CheckboxCheckStates.checkBox1 = false;
         }
 
+        /// <summary>
+        /// Checkbox state for product name was updated. Modify the checkbox state struct. 
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
         private void checkBox_Product_CheckedChanged(object sender, EventArgs e)
         {
             if (this.checkBox_Product.Checked)
@@ -587,6 +574,11 @@ namespace WDAC_Wizard
             this.ExceptionRule.CheckboxCheckStates.checkBox3 = false;
         }
 
+        /// <summary>
+        /// Checkbox state for internal name was updated. Modify the checkbox state struct. 
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
         private void checkBox_InternalName_CheckedChanged(object sender, EventArgs e)
         {
             if (this.checkBox_InternalName.Checked)
@@ -608,6 +600,11 @@ namespace WDAC_Wizard
             this.ExceptionRule.CheckboxCheckStates.checkBox3 = false;
         }
 
+        /// <summary>
+        /// Checkbox state for minimum version was updated. Modify the checkbox state struct. 
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
         private void checkBox_MinVersion_CheckedChanged(object sender, EventArgs e)
         {
             if (this.checkBox_MinVersion.Checked)
@@ -638,6 +635,10 @@ namespace WDAC_Wizard
             this.publisherInfoLabel.Visible = false;
         }
 
+        /// <summary>
+        /// Sets the label to visible and the text to errorText
+        /// </summary>
+        /// <param name="errorText"></param>
         private void SetLabel_ErrorText(string errorText)
         {
             this.publisherInfoLabel.Focus();

--- a/WDAC-Policy-Wizard/app/src/Exceptions_Control.cs
+++ b/WDAC-Policy-Wizard/app/src/Exceptions_Control.cs
@@ -412,8 +412,7 @@ namespace WDAC_Wizard
             // Check that fields are valid, otherwise break and show error msg
             if(this.ExceptionRule == null 
                 || String.IsNullOrEmpty(this.ExceptionRule.ReferenceFile)
-                || this.ExceptionRule.Type == PolicyCustomRules.RuleType.None
-                || !this.ExceptionRule.IsAnyBoxChecked())
+                || this.ExceptionRule.Type == PolicyCustomRules.RuleType.None)
             {
                 this.ConditionsPanel.SetLabel_ErrorText("Invalid exception selection. Please select a level and reference file");
                 return; 
@@ -422,6 +421,12 @@ namespace WDAC_Wizard
             // Get the values from the textboxes for the file attributes rule
             if(this.ExceptionRule.Type == PolicyCustomRules.RuleType.FileAttributes)
             {
+                if(!this.ExceptionRule.IsAnyBoxChecked())
+                {
+                    this.ConditionsPanel.SetLabel_ErrorText(Properties.Resources.InvalidCheckboxState);
+                    return;
+                }
+
                 this.ExceptionRule.CustomValues.FileName = textBox_originalfilename.Text;
                 this.ExceptionRule.CustomValues.Description = textBox_filedescription.Text;
                 this.ExceptionRule.CustomValues.ProductName = textBox_product.Text;

--- a/WDAC-Policy-Wizard/app/src/Exceptions_Control.resx
+++ b/WDAC-Policy-Wizard/app/src/Exceptions_Control.resx
@@ -123,10 +123,4 @@
   <metadata name="column_Name.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
-  <metadata name="column_Level.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="column_Name.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
 </root>

--- a/WDAC-Policy-Wizard/app/src/Exceptions_Control.resx
+++ b/WDAC-Policy-Wizard/app/src/Exceptions_Control.resx
@@ -123,4 +123,10 @@
   <metadata name="column_Name.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <metadata name="column_Level.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="column_Name.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
 </root>

--- a/WDAC-Policy-Wizard/app/src/Helper.cs
+++ b/WDAC-Policy-Wizard/app/src/Helper.cs
@@ -1280,30 +1280,40 @@ namespace WDAC_Wizard
             string friendlyName = "Deny files based on file attributes: ";
 
             // Add only the checked attributes
+            // Original filename
             if (customRule.CheckboxCheckStates.checkBox0)
             {
                 denyRule.FileName = customRule.CustomValues.FileName;
                 friendlyName += denyRule.FileName + " and ";
             }
 
+            // File description
             if (customRule.CheckboxCheckStates.checkBox1)
             {
                 denyRule.FileDescription = customRule.CustomValues.Description;
                 friendlyName += denyRule.FileDescription + " and ";
             }
 
+            // Product name
             if (customRule.CheckboxCheckStates.checkBox2)
             {
                 denyRule.ProductName = customRule.CustomValues.ProductName;
                 friendlyName += denyRule.ProductName + " and ";
             }
 
+            // Internal name
             if (customRule.CheckboxCheckStates.checkBox3)
             {
                 denyRule.InternalName = customRule.CustomValues.InternalName;
                 friendlyName += denyRule.InternalName + " and ";
             }
 
+            // Min Version
+            if (customRule.CheckboxCheckStates.checkBox4 && isException)
+            {
+                denyRule.MinimumFileVersion = customRule.CustomValues.MinVersion;
+                friendlyName += denyRule.MinimumFileVersion + " and ";
+            }
 
             denyRule.FriendlyName = friendlyName.Substring(0, friendlyName.Length - 5);
             if(!isException)
@@ -1316,7 +1326,7 @@ namespace WDAC_Wizard
             }
 
             // Add the deny rule to FileRules and FileRuleRef section with Windows Signing Scenario
-            siPolicy = AddDenyRule(denyRule, siPolicy, customRule.SigningScenarioCheckStates);
+            siPolicy = AddDenyRule(denyRule, siPolicy, customRule.SigningScenarioCheckStates, isException);
 
             return siPolicy;
         }
@@ -2678,19 +2688,24 @@ namespace WDAC_Wizard
             this.ExceptionList.Add(ruleException);
         }
 
+        /// <summary>
+        /// Adds the PolicyCustomRule exception to the ExceptionsList list
+        /// </summary>
+        /// <param name="ruleException"></param>
         public void AddException(PolicyCustomRules ruleException)
         {
-            if(ruleException.Type != PolicyCustomRules.RuleType.None 
-                || ruleException.Level != PolicyCustomRules.RuleLevel.None
-                || ruleException.FileInfo != null 
-                || ruleException.ReferenceFile!= null)
-            {
-                this.ExceptionList.Add(ruleException);
-            }
-            else
-            {
-                // Log error or something
-            }
+            this.ExceptionList.Add(ruleException);
+        }
+
+        /// <summary>
+        /// Returns true if at least one checkbox is checked. False, otherwise. 
+        /// </summary>
+        /// <returns></returns>
+        public bool IsAnyBoxChecked()
+        {
+            return this.CheckboxCheckStates.checkBox0 || this.CheckboxCheckStates.checkBox1
+                || this.CheckboxCheckStates.checkBox2 || this.CheckboxCheckStates.checkBox3 
+                || this.CheckboxCheckStates.checkBox4;
         }
     }
 


### PR DESCRIPTION
The allow and deny signer exceptions workflow was completely broken. Closing #184 

Exceptions can be created from: 
1. File attributes
2. File path 
3. File hash

Ex. File attributes are multi-selectable and accept custom values
![image](https://user-images.githubusercontent.com/23045608/213822360-1ad177a6-7ba1-49cb-a0f6-93c14d7798d9.png)

These changes also added a check for rule in progress workflow: 
![image](https://user-images.githubusercontent.com/23045608/213822528-73309e00-626b-42a9-ab86-1aee85962e2a.png)

**Asserts that file path rules can not except a signer rule:**
![image](https://user-images.githubusercontent.com/23045608/213822208-21a7727b-5d4d-479d-ac9d-f6d332571f7f.png)
