### PR TITLE
Fixed NullException on Settings Page

### DIFF
--- a/WDAC-Policy-Wizard/app/App.config
+++ b/WDAC-Policy-Wizard/app/App.config
@@ -19,9 +19,6 @@
             <setting name="convertPolicyToBinary" serializeAs="String">
                 <value>True</value>
             </setting>
-            <setting name="showMultiplePolicyDefault" serializeAs="String">
-                <value>True</value>
-            </setting>
             <setting name="useDriverBlockRules" serializeAs="String">
                 <value>False</value>
             </setting>

--- a/WDAC-Policy-Wizard/app/MSIX/WDAC Wizard.exe.config
+++ b/WDAC-Policy-Wizard/app/MSIX/WDAC Wizard.exe.config
@@ -16,13 +16,7 @@
             <setting name="useDefaultStrings" serializeAs="String">
                 <value>True</value>
             </setting>
-            <setting name="allowTelemetry" serializeAs="String">
-                <value>True</value>
-            </setting>
             <setting name="convertPolicyToBinary" serializeAs="String">
-                <value>True</value>
-            </setting>
-            <setting name="showMultiplePolicyDefault" serializeAs="String">
                 <value>True</value>
             </setting>
             <setting name="useDriverBlockRules" serializeAs="String">

--- a/WDAC-Policy-Wizard/app/MSIX/WDAC Wizard.exe.config
+++ b/WDAC-Policy-Wizard/app/MSIX/WDAC Wizard.exe.config
@@ -39,7 +39,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.6.0" newVersion="4.0.6.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
@@ -52,6 +52,14 @@
       <dependentAssembly>
         <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.2" newVersion="4.0.1.2" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/WDAC-Policy-Wizard/app/Properties/Settings.Designer.cs
+++ b/WDAC-Policy-Wizard/app/Properties/Settings.Designer.cs
@@ -61,18 +61,6 @@ namespace WDAC_Wizard.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("True")]
-        public bool showMultiplePolicyDefault {
-            get {
-                return ((bool)(this["showMultiplePolicyDefault"]));
-            }
-            set {
-                this["showMultiplePolicyDefault"] = value;
-            }
-        }
-        
-        [global::System.Configuration.UserScopedSettingAttribute()]
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("False")]
         public bool useDriverBlockRules {
             get {

--- a/WDAC-Policy-Wizard/app/Properties/Settings.settings
+++ b/WDAC-Policy-Wizard/app/Properties/Settings.settings
@@ -11,9 +11,6 @@
     <Setting Name="convertPolicyToBinary" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
-    <Setting Name="showMultiplePolicyDefault" Type="System.Boolean" Scope="User">
-      <Value Profile="(Default)">True</Value>
-    </Setting>
     <Setting Name="useDriverBlockRules" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>

--- a/WDAC-Policy-Wizard/app/src/SettingsPage.cs
+++ b/WDAC-Policy-Wizard/app/src/SettingsPage.cs
@@ -303,15 +303,15 @@ namespace WDAC_Wizard
             // if the setting is set to false, otherwise keep the default UI state of checked
             foreach (var settingName in settingDict.Keys)
             {
+                string checkBoxName = settingName + "_CheckBox";
+
                 // Skip this setting, there is no checkbox to update
-                if(settingName.Contains("showMultiplePolicyDefault"))
+                if (this.Controls.Find(checkBoxName, true).Length < 1)
                 {
                     continue; 
                 }
-                
-                string checkBoxName = settingName + "_CheckBox"; 
-                
-                if(!settingDict[settingName]) //False case
+
+                if (!settingDict[settingName]) //False case
                 {
                     this.Controls.Find(checkBoxName, true).FirstOrDefault().Tag = "Unchecked";
                     this.Controls.Find(checkBoxName, true).FirstOrDefault().BackgroundImage = Properties.Resources.check_box_unchecked; 


### PR DESCRIPTION
Closing #192 

Root cause:
There was a stale setting trying to be set on the page. 

The setting has since been removed from the config file so it will not be set. Also added a check if we cannot find a setting, break from trying to set it. 