### PR TITLE
Filepath rules and empty applocker rule collection bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -334,3 +334,6 @@ AppLocker-Policy-Converter/app/test-policies/WDACPolicy_Test_AuthRoot.xml
 *.cip
 AppLocker-Policy-Converter/app/test-policies/WDACPolicy.xml
 WDAC-Policy-Wizard/app/MSIX/WDAC Wizard.exe
+
+# Test policies
+AppLocker-Policy-Converter/app/test-policies/*

--- a/AppLocker-Policy-Converter/app/AppLocker-Policy-Converter/AppLocker-Policy-Converter/AppLocker-Policy-Converter.csproj
+++ b/AppLocker-Policy-Converter/app/AppLocker-Policy-Converter/AppLocker-Policy-Converter/AppLocker-Policy-Converter.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/AppLocker-Policy-Converter/app/AppLocker-Policy-Converter/AppLocker-Policy-Converter/Helper.cs
+++ b/AppLocker-Policy-Converter/app/AppLocker-Policy-Converter/AppLocker-Policy-Converter/Helper.cs
@@ -382,8 +382,8 @@ namespace AppLocker_Policy_Converter
             // while having a strict exe allowlist. This would result in an allow all WDAC policy with unintended consequences
             if(path == "*")
             {
-                WarningMessages.Add(String.Format("WARNING: SKIPPING <FilePathCondition Path=\"*\" /> from rule ID = {0}. ALLOW OR DENY \"*\" RULES MUST BE MANUALLY ADDED " +
-                                    "YOUR WDAC POLICY.", filePathRule.Id));
+                ErrorMessages.Add(String.Format("ERROR: <FilePathCondition Path=\"*\" /> from rule ID = {0} cannot be converted. " +
+                    "ALLOW OR DENY \"*\" RULES MUST BE MANUALLY ADDED YOUR WDAC POLICY.", filePathRule.Id));
                 return siPolicy; 
             }
 

--- a/AppLocker-Policy-Converter/app/AppLocker-Policy-Converter/AppLocker-Policy-Converter/Program.cs
+++ b/AppLocker-Policy-Converter/app/AppLocker-Policy-Converter/AppLocker-Policy-Converter/Program.cs
@@ -239,7 +239,7 @@ namespace AppLocker_Policy_Converter
             {
                 if(ruleCollection.Items == null)
                 {
-                    break; 
+                    continue; 
                 }
 
                 for(int i = 0; i < ruleCollection.Items.Length; i++)

--- a/AppLocker-Policy-Converter/app/AppLocker-Policy-Converter/AppLocker-Policy-Converter/Program.cs
+++ b/AppLocker-Policy-Converter/app/AppLocker-Policy-Converter/AppLocker-Policy-Converter/Program.cs
@@ -46,11 +46,21 @@ namespace AppLocker_Policy_Converter
                 return -1;
             }
 
+            // Parse the AppLocker policies to AppLockerPolicy objects
             List<(AppLockerPolicy, string)> appLockerPolicies = ParseAppLockerPolicies(applockerPolicyPaths);
+
+            // Convert each rule from the AppLocker policy objects to SiPolicy/WDAC policy objects
             SiPolicy wdacPolicy = ConvertPolicies(appLockerPolicies, outputPath);
 
+            // Set new policy GUIDs in the WDAC policy and friendly names
             wdacPolicy = FormatPolicy(wdacPolicy);
+
+            // Write the WDAC XML policy to disk at outputPath
             Helper.SerializePolicytoXML(wdacPolicy, outputPath);
+
+            // Dump all the warnings and errors created 
+            Helper.DumpWarningMsgs();
+            Helper.DumpErrorMsgs();
 
             return 0; 
         }


### PR DESCRIPTION
Fixed a couple of bugs: 

1. Empty applocker rule collections, eg. DLL, would cause the tool to exit early without converting other non-empty rule collections further down in the policy. 
2. Fixed filepath rule conversions where - 

2.1. Unsupported macros like %PROGRAMFILES%\* 
2.2. Rules where there are 1 wildcards in the middle of the path: 

E.g. %WINDIR%\Folder1\*\FolderX\tool.dll --> "*\FolderX\tool.dll"
This way, the intended binaries are still allowed/blocked without being too permissive E.g. %WINDIR%\Folder1\*

3. Fail all rules with more than 1 wildcard in the path
4. "Beautified" the tool output by grouping all the warnings and errors and dumping them at the end of program:

![image](https://user-images.githubusercontent.com/23045608/217400702-6d865a16-cbd8-489a-af80-4b6e0179939d.png)


![image](https://user-images.githubusercontent.com/23045608/217400735-ad14acc0-a8db-44f6-a2a9-7d2cf61a6253.png)


