### PR TITLE
Fixed the version update logic for policies under edit

### DIFF
--- a/WDAC-Policy-Wizard/app/src/MainForm.cs
+++ b/WDAC-Policy-Wizard/app/src/MainForm.cs
@@ -1537,16 +1537,17 @@ namespace WDAC_Wizard
                     // Since we don't have a new save location, copy the TemplatePath
                     // and append '_Edit' to the file path.
                     // Check if _v10.0.x.y is already in string ie. editing the output of an editing workflow
-                    if (this.Policy.EditPathContainsVersionInfo())
+                    int versionNumPos = this.Policy.EditPathContainsVersionInfo(); 
+                    if (versionNumPos > 0)
                     {
-                        const int sOFFSET = 14;
-                        this.Policy.SchemaPath = String.Format("{0}_v{1}.xml", this.Policy.EditPolicyPath.Substring(0,
-                                                               this.Policy.EditPolicyPath.Length - sOFFSET), this.Policy.UpdateVersion());
+                        string filePathWithoutVer = this.Policy.EditPolicyPath.Substring(0, versionNumPos);
+                        this.Policy.SchemaPath = String.Format("{0}_v{1}.xml", filePathWithoutVer, this.Policy.UpdateVersion());
                     }
                     else
                     {
-                        this.Policy.SchemaPath = String.Format("{0}_v{1}.xml", Path.GetFileNameWithoutExtension(this.Policy.EditPolicyPath), 
-                                                               this.Policy.UpdateVersion());
+                        string filePathWithoutExt = Path.Combine(Path.GetDirectoryName(this.Policy.EditPolicyPath), 
+                                                                 Path.GetFileNameWithoutExtension(this.Policy.EditPolicyPath));
+                        this.Policy.SchemaPath = String.Format("{0}_v{1}.xml", filePathWithoutExt, this.Policy.UpdateVersion());
                     }
                 }
                 else


### PR DESCRIPTION
Closing #203 

Bug where the filenames of policies under edit are being truncated:

![image](https://user-images.githubusercontent.com/23045608/218803805-33acf1a9-553c-47b5-9dfe-3a150f1bed03.png)

Fixed the off by one bug. Also fixed the logic for version updates. Prior to the update, '9' was the highest integer supported in the Wizard so updated versions would follow:

10.0.0.9 --> 10.0.1.0

Now, the Wizard supports up to 2^16 UINT16 MAX:

10.0.0.9 --> 10.0.0.10
10.0.0.65535 --> 10.0.1.0