### PR TITLE
Bug Fix - MDE AH Parsing is not showing unsigned files

### DIFF
--- a/WDAC-Policy-Wizard/app/src/AdvancedHunting.cs
+++ b/WDAC-Policy-Wizard/app/src/AdvancedHunting.cs
@@ -179,7 +179,7 @@ namespace WDAC_Wizard
         }
 
         /// <summary>
-        /// Creates a 3077 CiEvent from the fields in the AH Record
+        /// Creates a 3089 Ci SignerEvent from the fields in the AH Record
         /// </summary>
         /// <param name="record"></param>
         /// <returns></returns>
@@ -241,7 +241,7 @@ namespace WDAC_Wizard
                 }
 
                 // In the case where the file is unsigned
-                if (ciEvents.Count == 0)
+                if (ciEvent.SignerInfo.DeviceId == null)
                 {
                     correlatedCiEvents.Add(ciEvent);
                 }

--- a/WDAC-Policy-Wizard/app/src/EventLog.cs
+++ b/WDAC-Policy-Wizard/app/src/EventLog.cs
@@ -1,6 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Collections.Generic;
 using System.Diagnostics.Eventing.Reader;
 
 
@@ -510,26 +511,27 @@ namespace WDAC_Wizard
             }
 
             // Check file identifiers
-            byte[] fileHash = newEvent.SHA2;
+            byte[] fileHash = newEvent.SHA2 != null ? newEvent.SHA2 : new byte[] { 0 };
             string filePath = newEvent.FilePath; // could be same file but different path
             int eventId = newEvent.EventId;
 
             string publisher = newEvent.SignerInfo.PublisherName;
 
             // Check policy hash - could be blocked by different policies in the evtx
-            byte[] policyHash = newEvent.PolicyHash; 
+            string policyId = newEvent.PolicyId; 
 
             foreach(CiEvent existingEvent in existingEvents)
             {
-                if(fileHash == existingEvent.SHA2 &&
-                    filePath == existingEvent.FilePath && 
-                    policyHash == existingEvent.PolicyHash &&
-                    publisher == existingEvent.SignerInfo.PublisherName &&
-                    eventId == existingEvent.EventId)
-                {
-                    return true; 
-                }
+                byte[] existingEventSHA2 = existingEvent.SHA2 != null ? existingEvent.SHA2 : new byte[] { 0 };
 
+                if (eventId == existingEvent.EventId
+                    && fileHash.SequenceEqual(existingEventSHA2)
+                    && filePath == existingEvent.FilePath
+                    && policyId == existingEvent.PolicyId
+                    && publisher == existingEvent.SignerInfo.PublisherName)
+                {
+                    return true;
+                }
             }
 
             return false; 


### PR DESCRIPTION
1. Fixed a bug causing unsigned files, files without a corresponding 3089, not to be shown to the user. 
2. Fixed a bug causing duplicate events (same hash, same folderpath, same policy auditing/blocking) to be shown to the user. Fixed this issue by correctly checking each hash (byte[]) value using a1.SequenceEqual(a2). Before, was trying to use "==" which always returned false
3. Fixed an issue where null hash values (byte[]'s) could cause a null exception and crash the app