### PR TITLE
Added unsupported crypto check

### DIFF
--- a/WDAC-Policy-Wizard/app/Properties/Resources.Designer.cs
+++ b/WDAC-Policy-Wizard/app/Properties/Resources.Designer.cs
@@ -1125,6 +1125,15 @@ namespace WDAC_Wizard.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The Wizard has detected cryto in the signed file that is not supported in WDAC. Unfortunately, a publisher rule cannot be used to allow or deny this file. .
+        /// </summary>
+        internal static string UnsupportedCrypto_Error {
+            get {
+                return ResourceManager.GetString("UnsupportedCrypto_Error", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to This option is not currently supported ....
         /// </summary>
         internal static string UnsupportedRule_Info {

--- a/WDAC-Policy-Wizard/app/Properties/Resources.resx
+++ b/WDAC-Policy-Wizard/app/Properties/Resources.resx
@@ -514,4 +514,7 @@ Are you sure you want to abandon the exception rule creation workflow?</value>
   <data name="ChoosePolicyToEdit_Error" xml:space="preserve">
     <value>Please select a policy XML file to edit before continuing</value>
   </data>
+  <data name="UnsupportedCrypto_Error" xml:space="preserve">
+    <value>The Wizard has detected cryto in the signed file that is not supported in WDAC. Unfortunately, a publisher rule cannot be used to allow or deny this file. </value>
+  </data>
 </root>

--- a/WDAC-Policy-Wizard/app/Properties/Resources.resx
+++ b/WDAC-Policy-Wizard/app/Properties/Resources.resx
@@ -515,6 +515,6 @@ Are you sure you want to abandon the exception rule creation workflow?</value>
     <value>Please select a policy XML file to edit before continuing</value>
   </data>
   <data name="UnsupportedCrypto_Error" xml:space="preserve">
-    <value>The Wizard has detected cryto in the signed file that is not supported in WDAC. Unfortunately, a publisher rule cannot be used to allow or deny this file. </value>
+    <value>A cryptographic algorithm that isn't supported by WDAC was found. Unfortunately, a publisher rule cannot be used to allow or deny this file. </value>
   </data>
 </root>

--- a/WDAC-Policy-Wizard/app/src/CustomRuleConditionsPanel.cs
+++ b/WDAC-Policy-Wizard/app/src/CustomRuleConditionsPanel.cs
@@ -875,7 +875,7 @@ namespace WDAC_Wizard
                 {
                     this.Log.AddWarningMsg(String.Format("Unsupported Crypto detected for {0} signed by {1}", refPath, leafCertSubjectName)); 
                     DialogResult res = MessageBox.Show(Properties.Resources.UnsupportedCrypto_Error ,
-                                                        "Unsuported Crypto Algorithm Detected",
+                                                        "Unsupported Cryptographic Algorithm Found",
                                                         MessageBoxButtons.OK, 
                                                         MessageBoxIcon.Error);
                     return false; 

--- a/WDAC-Policy-Wizard/app/src/CustomRuleConditionsPanel.cs
+++ b/WDAC-Policy-Wizard/app/src/CustomRuleConditionsPanel.cs
@@ -800,7 +800,21 @@ namespace WDAC_Wizard
                 this._MainWindow.CustomRuleinProgress = true;
 
                 // Get generic file information to be shown to user
-                SetFileSignerInfo(refPath);
+                bool status = SetFileSignerInfo(refPath);
+
+                // Unsupported crypto or antother issue with the file
+                // Start over
+                if(!status)
+                {
+                    // Renew the custom rule instance
+                    this.PolicyCustomRule = new PolicyCustomRules();
+
+                    // Reset UI view
+                    ClearCustomRulesPanel(true);
+                    this._MainWindow.CustomRuleinProgress = false;
+
+                    return;
+                }
             }
 
             // Set the landing UI depending on the Rule type
@@ -817,7 +831,8 @@ namespace WDAC_Wizard
         /// Retrieves the file attribute and signer info
         /// </summary>
         /// <param name="refPath"></param>
-        private void SetFileSignerInfo(string refPath)
+        /// <returns>True if successful. False otherwise. </returns>
+        private bool SetFileSignerInfo(string refPath)
         {
             this.PolicyCustomRule.FileInfo = new Dictionary<string, string>(); // Reset dict
             FileVersionInfo fileInfo = FileVersionInfo.GetVersionInfo(refPath);
@@ -854,6 +869,17 @@ namespace WDAC_Wizard
                     // Remove everything past C=..
                     pcaCertSubjectName = Helper.FormatSubjectName(pcaCertSubjectName);
                 }
+
+                // Check that the parsed certificate chain uses supported crytpo
+                if(Helper.IsCertChainInvalid(certChain))
+                {
+                    this.Log.AddWarningMsg(String.Format("Unsupported Crypto detected for {0} signed by {1}", refPath, leafCertSubjectName)); 
+                    DialogResult res = MessageBox.Show(Properties.Resources.UnsupportedCrypto_Error ,
+                                                        "Unsuported Crypto Algorithm Detected",
+                                                        MessageBoxButtons.OK, 
+                                                        MessageBoxIcon.Error);
+                    return false; 
+                }
             }
 
             catch (Exception exp)
@@ -865,6 +891,8 @@ namespace WDAC_Wizard
 
             this.PolicyCustomRule.FileInfo.Add("LeafCertificate", String.IsNullOrEmpty(leafCertSubjectName) ? Properties.Resources.DefaultFileAttributeString : leafCertSubjectName);
             this.PolicyCustomRule.FileInfo.Add("PCACertificate", String.IsNullOrEmpty(pcaCertSubjectName) ? Properties.Resources.DefaultFileAttributeString : pcaCertSubjectName);
+
+            return true;
         }
 
         /// <summary>


### PR DESCRIPTION
Added checks in the Wizard to detect when a file signed by any of the following. These algos are not supported in WDAC and will fail at the time of policy creation. Exposing the warning/error to the user so they know to select another rule type:

{ "1.3.132.0.34", "ECC_P384" },
{  "1.3.132.0.35", "ECC_P512" },
{  "1.2.840.10045.3.1.7", "ECC_P256" },
{  "1.2.840.10045.4.1", "ECDSA_SHA1" },
{  "1.2.840.10045.4.3", "ECDSA_SPECIFIED" },
{  "1.2.840.10045.4.3.2", "ECDSA_SHA256" },
{  "1.2.840.10045.4.3.3", "ECDSA_SHA384" },
{  "1.2.840.10045.4.3.4", "ECDSA_SH512" }

**UI shown to user:**
![image](https://user-images.githubusercontent.com/23045608/219767622-edbb9e17-f473-4a46-9cc4-b8d20f0b4cf0.png)

Tested using multiple ECC-signed files. Compared against RSA-signed files.

Closing #181 
