### PR TITLE
Updated the build page and messages when cip/xml cannot be opened

### DIFF
--- a/WDAC-Policy-Wizard/app/Properties/Resources.Designer.cs
+++ b/WDAC-Policy-Wizard/app/Properties/Resources.Designer.cs
@@ -109,7 +109,7 @@ namespace WDAC_Wizard.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The WDAC Wizard could not open the WDAC XML file. The most likely reason is that the Wizard failed to build the policy file.
+        ///   Looks up a localized string similar to The WDAC Wizard could not open the WDAC BIN file. The most likely reason is that the Wizard failed to convert the policy XML file to binary.
         ///
         ///Please check the log file in .
         /// </summary>
@@ -1332,7 +1332,7 @@ namespace WDAC_Wizard.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The WDAC Wizard could not open the WDAC XML file. The most likely reason is that the Wizard failed to convert the policy XML file to binary.
+        ///   Looks up a localized string similar to The WDAC Wizard could not open the WDAC XML file. The most likely reason is that the Wizard failed to build the policy file.
         ///
         ///Please check the log file in .
         /// </summary>

--- a/WDAC-Policy-Wizard/app/Properties/Resources.Designer.cs
+++ b/WDAC-Policy-Wizard/app/Properties/Resources.Designer.cs
@@ -109,6 +109,17 @@ namespace WDAC_Wizard.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The WDAC Wizard could not open the WDAC XML file. The most likely reason is that the Wizard failed to build the policy file.
+        ///
+        ///Please check the log file in .
+        /// </summary>
+        internal static string BINFileOpen_Error {
+            get {
+                return ResourceManager.GetString("BINFileOpen_Error", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>
         internal static System.Drawing.Bitmap blank_check_box {
@@ -401,6 +412,16 @@ namespace WDAC_Wizard.Properties {
             get {
                 object obj = ResourceManager.GetObject("externalLink", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The WDAC Wizard encountered this exception trying to open this file 
+        /// .
+        /// </summary>
+        internal static string FileOpen_Exception {
+            get {
+                return ResourceManager.GetString("FileOpen_Exception", resourceCulture);
             }
         }
         
@@ -819,6 +840,17 @@ namespace WDAC_Wizard.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to There was an error building your policy. Press home to begin again.
+        ///
+        ///Please check the log file in .
+        /// </summary>
+        internal static string PolicyBuild_Error {
+            get {
+                return ResourceManager.GetString("PolicyBuild_Error", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to This rule applies to all files signed by this issuing CA and publisher..
         /// </summary>
         internal static string PublisherInfo {
@@ -1125,7 +1157,7 @@ namespace WDAC_Wizard.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The Wizard has detected cryto in the signed file that is not supported in WDAC. Unfortunately, a publisher rule cannot be used to allow or deny this file. .
+        ///   Looks up a localized string similar to A cryptographic algorithm that isn&apos;t supported by WDAC was found. Unfortunately, a publisher rule cannot be used to allow or deny this file. .
         /// </summary>
         internal static string UnsupportedCrypto_Error {
             get {
@@ -1296,6 +1328,17 @@ namespace WDAC_Wizard.Properties {
         internal static string WindowsTemplate {
             get {
                 return ResourceManager.GetString("WindowsTemplate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The WDAC Wizard could not open the WDAC XML file. The most likely reason is that the Wizard failed to convert the policy XML file to binary.
+        ///
+        ///Please check the log file in .
+        /// </summary>
+        internal static string XMLFileOpen_Error {
+            get {
+                return ResourceManager.GetString("XMLFileOpen_Error", resourceCulture);
             }
         }
     }

--- a/WDAC-Policy-Wizard/app/Properties/Resources.resx
+++ b/WDAC-Policy-Wizard/app/Properties/Resources.resx
@@ -517,7 +517,7 @@ Are you sure you want to abandon the exception rule creation workflow?</value>
   <data name="UnsupportedCrypto_Error" xml:space="preserve">
     <value>A cryptographic algorithm that isn't supported by WDAC was found. Unfortunately, a publisher rule cannot be used to allow or deny this file. </value>
   </data>
-  <data name="BINFileOpen_Error" xml:space="preserve">
+  <data name="XMLFileOpen_Error" xml:space="preserve">
     <value>The WDAC Wizard could not open the WDAC XML file. The most likely reason is that the Wizard failed to build the policy file.
 
 Please check the log file in </value>
@@ -531,8 +531,8 @@ Please check the log file in </value>
 
 Please check the log file in </value>
   </data>
-  <data name="XMLFileOpen_Error" xml:space="preserve">
-    <value>The WDAC Wizard could not open the WDAC XML file. The most likely reason is that the Wizard failed to convert the policy XML file to binary.
+  <data name="BINFileOpen_Error" xml:space="preserve">
+    <value>The WDAC Wizard could not open the WDAC BIN file. The most likely reason is that the Wizard failed to convert the policy XML file to binary.
 
 Please check the log file in </value>
   </data>

--- a/WDAC-Policy-Wizard/app/Properties/Resources.resx
+++ b/WDAC-Policy-Wizard/app/Properties/Resources.resx
@@ -517,4 +517,23 @@ Are you sure you want to abandon the exception rule creation workflow?</value>
   <data name="UnsupportedCrypto_Error" xml:space="preserve">
     <value>A cryptographic algorithm that isn't supported by WDAC was found. Unfortunately, a publisher rule cannot be used to allow or deny this file. </value>
   </data>
+  <data name="BINFileOpen_Error" xml:space="preserve">
+    <value>The WDAC Wizard could not open the WDAC XML file. The most likely reason is that the Wizard failed to build the policy file.
+
+Please check the log file in </value>
+  </data>
+  <data name="FileOpen_Exception" xml:space="preserve">
+    <value>The WDAC Wizard encountered this exception trying to open this file 
+ </value>
+  </data>
+  <data name="PolicyBuild_Error" xml:space="preserve">
+    <value>There was an error building your policy. Press home to begin again.
+
+Please check the log file in </value>
+  </data>
+  <data name="XMLFileOpen_Error" xml:space="preserve">
+    <value>The WDAC Wizard could not open the WDAC XML file. The most likely reason is that the Wizard failed to convert the policy XML file to binary.
+
+Please check the log file in </value>
+  </data>
 </root>

--- a/WDAC-Policy-Wizard/app/src/BuildPage.Designer.cs
+++ b/WDAC-Policy-Wizard/app/src/BuildPage.Designer.cs
@@ -37,8 +37,9 @@ namespace WDAC_Wizard
             this.progressBar = new System.Windows.Forms.ProgressBar();
             this.finishLabel = new System.Windows.Forms.Label();
             this.progress_Label = new System.Windows.Forms.Label();
-            this.hyperlinkLabel = new System.Windows.Forms.Label();
+            this.xmlFilePathLabel = new System.Windows.Forms.Label();
             this.finishPanel = new System.Windows.Forms.Panel();
+            this.binFilePathLabel = new System.Windows.Forms.Label();
             this.label4 = new System.Windows.Forms.Label();
             this.progressString_Label = new System.Windows.Forms.Label();
             this.finishPanel.SuspendLayout();
@@ -98,22 +99,23 @@ namespace WDAC_Wizard
             this.progress_Label.Text = "50%";
             this.progress_Label.Visible = false;
             // 
-            // hyperlinkLabel
+            // xmlFilePathLabel
             // 
-            this.hyperlinkLabel.AutoSize = true;
-            this.hyperlinkLabel.Font = new System.Drawing.Font("Tahoma", 9.5F);
-            this.hyperlinkLabel.ForeColor = System.Drawing.SystemColors.MenuHighlight;
-            this.hyperlinkLabel.Location = new System.Drawing.Point(1, 76);
-            this.hyperlinkLabel.Name = "hyperlinkLabel";
-            this.hyperlinkLabel.Size = new System.Drawing.Size(123, 19);
-            this.hyperlinkLabel.TabIndex = 85;
-            this.hyperlinkLabel.Text = "Unable to locate";
-            this.hyperlinkLabel.Click += new System.EventHandler(this.HyperlinkLabel_Click);
+            this.xmlFilePathLabel.AutoSize = true;
+            this.xmlFilePathLabel.Font = new System.Drawing.Font("Tahoma", 9.5F);
+            this.xmlFilePathLabel.ForeColor = System.Drawing.SystemColors.MenuHighlight;
+            this.xmlFilePathLabel.Location = new System.Drawing.Point(1, 76);
+            this.xmlFilePathLabel.Name = "xmlFilePathLabel";
+            this.xmlFilePathLabel.Size = new System.Drawing.Size(155, 19);
+            this.xmlFilePathLabel.TabIndex = 85;
+            this.xmlFilePathLabel.Text = "XmlFilePath Location";
+            this.xmlFilePathLabel.Click += new System.EventHandler(this.XmlFilePathLabel_Click);
             // 
             // finishPanel
             // 
+            this.finishPanel.Controls.Add(this.binFilePathLabel);
             this.finishPanel.Controls.Add(this.label4);
-            this.finishPanel.Controls.Add(this.hyperlinkLabel);
+            this.finishPanel.Controls.Add(this.xmlFilePathLabel);
             this.finishPanel.Controls.Add(this.finishLabel);
             this.finishPanel.Location = new System.Drawing.Point(167, 223);
             this.finishPanel.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
@@ -121,6 +123,18 @@ namespace WDAC_Wizard
             this.finishPanel.Size = new System.Drawing.Size(867, 182);
             this.finishPanel.TabIndex = 87;
             this.finishPanel.Visible = false;
+            // 
+            // binFilePathLabel
+            // 
+            this.binFilePathLabel.AutoSize = true;
+            this.binFilePathLabel.Font = new System.Drawing.Font("Tahoma", 9.5F);
+            this.binFilePathLabel.ForeColor = System.Drawing.SystemColors.MenuHighlight;
+            this.binFilePathLabel.Location = new System.Drawing.Point(3, 127);
+            this.binFilePathLabel.Name = "binFilePathLabel";
+            this.binFilePathLabel.Size = new System.Drawing.Size(150, 19);
+            this.binFilePathLabel.TabIndex = 88;
+            this.binFilePathLabel.Text = "BinFilePath Location";
+            this.binFilePathLabel.Click += new System.EventHandler(this.BinFilePathLabel_Click);
             // 
             // label4
             // 
@@ -172,9 +186,10 @@ namespace WDAC_Wizard
         private System.Windows.Forms.ProgressBar progressBar;
         private System.Windows.Forms.Label finishLabel;
         private System.Windows.Forms.Label progress_Label;
-        private System.Windows.Forms.Label hyperlinkLabel;
+        private System.Windows.Forms.Label xmlFilePathLabel;
         private System.Windows.Forms.Panel finishPanel;
         private System.Windows.Forms.Label label4;
         private System.Windows.Forms.Label progressString_Label;
+        private System.Windows.Forms.Label binFilePathLabel;
     }
 }

--- a/WDAC-Policy-Wizard/app/src/BuildPage.cs
+++ b/WDAC-Policy-Wizard/app/src/BuildPage.cs
@@ -85,6 +85,12 @@ namespace WDAC_Wizard
         /// </summary>
         public string FormatText(string longstring)
         {
+            // Check null/empty and break
+            if(String.IsNullOrEmpty(longstring))
+            {
+                return longstring;
+            }
+
             if(longstring.Length > PATH_LENGTH_LIMIT)
             {
                 // Get the last instance of the \ between the start and the path limit (80)

--- a/WDAC-Policy-Wizard/app/src/MainForm.cs
+++ b/WDAC-Policy-Wizard/app/src/MainForm.cs
@@ -36,11 +36,13 @@ namespace WDAC_Wizard
         public string ErrorMsg { get; set; }             // Accompanying message error description for ErrorOnPage flag 
         public bool RedoFlowRequired { get; set; }       // Flag which prohibts user from making changes on page 1 then skipping back to page 4, for instance
         public bool CustomRuleinProgress { get; set; }   // Flag set when user has kicked off the custom rule procedure. Ensures user does not go to build page without accidentally creating the rule
+        public bool BinaryFileCreated { get; set; }      // Flag set when the conversion to binary file (.cip/.p7b) was successful. False, otherwise.
 
         public Logger Log { get; set; }
         public List<string> PageList;
         public WDAC_Policy Policy { get; set; }
         public List<CiEvent> CiEvents { get; set; }
+
         // Runspace param to access all PS Variables and eliminate overhead opening each time
         private Runspace runspace;
         private int RulesNumber;
@@ -83,7 +85,6 @@ namespace WDAC_Wizard
 
             // Check for configci cmdlet availability
             LicenseCheck(); 
-
         }
 
         // ###############
@@ -849,7 +850,7 @@ namespace WDAC_Wizard
             // Convert the policy from XML to Binary file
             if (Properties.Settings.Default.convertPolicyToBinary)
             {
-                ConvertPolicyToBinary();
+                this.BinaryFileCreated = ConvertPolicyToBinary();
             }
 
             worker.ReportProgress(100);
@@ -905,9 +906,11 @@ namespace WDAC_Wizard
             {
                 this._BuildPage.UpdateProgressBar(100, " ");
 
-                if (this.Policy.BinPath != null)
+                // If we successfully converted the policy XML to binary, show both file paths
+                // If conversion was unsuccessful, show only the XML path
+                if (this.BinaryFileCreated)
                 {
-                    this._BuildPage.ShowFinishMsg(this.Policy.SchemaPath + Environment.NewLine + Environment.NewLine + this.Policy.BinPath);
+                    this._BuildPage.ShowFinishMsg(this.Policy.SchemaPath, this.Policy.BinPath);
                 }
                 else
                 {


### PR DESCRIPTION
Closing #211 

This PR adds UI/UX for users to distinguish when Bin conversion failed. Also added the ability for the binary folder path to be opened in explorer when the label is selected. 

1. XML file cannot be opened UI:
![image](https://user-images.githubusercontent.com/23045608/220801329-a62bc77f-8cca-4261-adfd-90fb80ef03bb.png)

2. XML or bin directory encountered an error trying to open UI:
![image](https://user-images.githubusercontent.com/23045608/220801477-4617e011-9217-4271-aeb6-c9f9fd389d38.png)

3. Binary policy label is now clickable. Explorer will launch and open the directory where the CIP is contained - 
![image](https://user-images.githubusercontent.com/23045608/220801669-e9075b09-c54a-4d3b-89c8-c28c4c415b3f.png)

![image](https://user-images.githubusercontent.com/23045608/220801706-2e2326a0-b077-426c-be58-47c0b8132753.png)

