### PR TITLE
Fixed bug where path was not displayed in the table

### DIFF
--- a/WDAC-Policy-Wizard/app/src/Helper.cs
+++ b/WDAC-Policy-Wizard/app/src/Helper.cs
@@ -1093,7 +1093,6 @@ namespace WDAC_Wizard
         public static SiPolicy CreateAllowPathRule(PolicyCustomRules customRule, SiPolicy siPolicy, bool isException=false)
         {
             Allow allowRule = new Allow();
-            allowRule.FriendlyName = String.Format("Allow by path: {0}", allowRule.FilePath);
             string path;
 
             if (!isException)
@@ -1104,7 +1103,7 @@ namespace WDAC_Wizard
             else
             {
                 allowRule.ID = String.Format("ID_ALLOW_EX_{0}", cFileExceptions++);
-                path = customRule.ReferenceFile;
+                path = customRule.ReferenceFile; 
             }
 
             // If using env variables, convert the path to a macro
@@ -1116,6 +1115,8 @@ namespace WDAC_Wizard
             {
                 allowRule.FilePath = path;
             }
+
+            allowRule.FriendlyName = String.Format("Allow by path: {0}", allowRule.FilePath);
 
             // Add the Allow rule to FileRules and FileRuleRef section with Windows Signing Scenario
             siPolicy = AddAllowRule(allowRule, siPolicy, customRule.SigningScenarioCheckStates, isException);
@@ -1131,7 +1132,6 @@ namespace WDAC_Wizard
         public static SiPolicy CreateDenyPathRule(PolicyCustomRules customRule, SiPolicy siPolicy, bool isException=false)
         {
             Deny denyRule = new Deny();
-            denyRule.FriendlyName = String.Format("Deny by path: {0}", denyRule.FilePath);
             string path; 
 
             if (!isException)
@@ -1154,8 +1154,9 @@ namespace WDAC_Wizard
             {
                 denyRule.FilePath = path;
             }
-            
-            
+
+            denyRule.FriendlyName = String.Format("Deny by path: {0}", denyRule.FilePath);
+
             // Add the deny rule to FileRules and FileRuleRef section with Windows Signing Scenario
             siPolicy = AddDenyRule(denyRule, siPolicy, customRule.SigningScenarioCheckStates, isException);
 

--- a/WDAC-Policy-Wizard/app/src/SigningRules_Control.Designer.cs
+++ b/WDAC-Policy-Wizard/app/src/SigningRules_Control.Designer.cs
@@ -75,9 +75,9 @@ namespace WDAC_Wizard
             this.label1.ForeColor = System.Drawing.Color.Black;
             this.label1.Location = new System.Drawing.Point(162, 33);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(220, 29);
+            this.label1.Size = new System.Drawing.Size(114, 29);
             this.label1.TabIndex = 47;
-            this.label1.Text = "Policy Signing Rules";
+            this.label1.Text = "File Rules";
             // 
             // rulesDataGrid
             // 
@@ -112,7 +112,7 @@ namespace WDAC_Wizard
             this.column_Action.MinimumWidth = 6;
             this.column_Action.Name = "column_Action";
             this.column_Action.ReadOnly = true;
-            this.column_Action.Width = 85;
+            this.column_Action.Width = 76;
             // 
             // column_Level
             // 
@@ -121,7 +121,7 @@ namespace WDAC_Wizard
             this.column_Level.MinimumWidth = 6;
             this.column_Level.Name = "column_Level";
             this.column_Level.ReadOnly = true;
-            this.column_Level.Width = 78;
+            this.column_Level.Width = 71;
             // 
             // Column_Name
             // 
@@ -130,7 +130,7 @@ namespace WDAC_Wizard
             this.Column_Name.MinimumWidth = 6;
             this.Column_Name.Name = "Column_Name";
             this.Column_Name.ReadOnly = true;
-            this.Column_Name.Width = 82;
+            this.Column_Name.Width = 74;
             // 
             // Column_Files
             // 
@@ -139,7 +139,7 @@ namespace WDAC_Wizard
             this.Column_Files.MinimumWidth = 6;
             this.Column_Files.Name = "Column_Files";
             this.Column_Files.ReadOnly = true;
-            this.Column_Files.Width = 148;
+            this.Column_Files.Width = 127;
             // 
             // Column_Exceptions
             // 
@@ -148,7 +148,7 @@ namespace WDAC_Wizard
             this.Column_Exceptions.MinimumWidth = 6;
             this.Column_Exceptions.Name = "Column_Exceptions";
             this.Column_Exceptions.ReadOnly = true;
-            this.Column_Exceptions.Width = 120;
+            this.Column_Exceptions.Width = 105;
             // 
             // column_ID
             // 
@@ -157,7 +157,7 @@ namespace WDAC_Wizard
             this.column_ID.MinimumWidth = 8;
             this.column_ID.Name = "column_ID";
             this.column_ID.ReadOnly = true;
-            this.column_ID.Width = 72;
+            this.column_ID.Width = 77;
             // 
             // label8
             // 
@@ -178,10 +178,10 @@ namespace WDAC_Wizard
             this.label3.ForeColor = System.Drawing.Color.Black;
             this.label3.Location = new System.Drawing.Point(162, 70);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(556, 18);
+            this.label3.Size = new System.Drawing.Size(591, 18);
             this.label3.TabIndex = 80;
-            this.label3.Text = "Create allow or deny rules for signed files based on its publisher, path or hash " +
-    "value.";
+            this.label3.Text = "Create allow or deny rules for files based on publisher, path, file attributes or" +
+    " hash values.";
             // 
             // deleteButton
             // 
@@ -236,7 +236,7 @@ namespace WDAC_Wizard
             this.checkBox_KernelList.AutoSize = true;
             this.checkBox_KernelList.Location = new System.Drawing.Point(163, 634);
             this.checkBox_KernelList.Name = "checkBox_KernelList";
-            this.checkBox_KernelList.Size = new System.Drawing.Size(378, 24);
+            this.checkBox_KernelList.Size = new System.Drawing.Size(320, 21);
             this.checkBox_KernelList.TabIndex = 98;
             this.checkBox_KernelList.Text = "Merge with Recommended Kernel Block Rules";
             this.checkBox_KernelList.UseVisualStyleBackColor = true;
@@ -247,7 +247,7 @@ namespace WDAC_Wizard
             this.checkBox_UserModeList.AutoSize = true;
             this.checkBox_UserModeList.Location = new System.Drawing.Point(163, 607);
             this.checkBox_UserModeList.Name = "checkBox_UserModeList";
-            this.checkBox_UserModeList.Size = new System.Drawing.Size(412, 24);
+            this.checkBox_UserModeList.Size = new System.Drawing.Size(348, 21);
             this.checkBox_UserModeList.TabIndex = 99;
             this.checkBox_UserModeList.Text = "Merge with Recommended User Mode Block Rules";
             this.checkBox_UserModeList.UseVisualStyleBackColor = true;
@@ -268,7 +268,7 @@ namespace WDAC_Wizard
             this.label_Progress.AutoSize = true;
             this.label_Progress.Location = new System.Drawing.Point(11, 2);
             this.label_Progress.Name = "label_Progress";
-            this.label_Progress.Size = new System.Drawing.Size(131, 20);
+            this.label_Progress.Size = new System.Drawing.Size(111, 17);
             this.label_Progress.TabIndex = 1;
             this.label_Progress.Text = "Removing Rules";
             this.label_Progress.TextAlign = System.Drawing.ContentAlignment.TopCenter;

--- a/WDAC-Policy-Wizard/app/src/SigningRules_Control.cs
+++ b/WDAC-Policy-Wizard/app/src/SigningRules_Control.cs
@@ -329,7 +329,7 @@ namespace WDAC_Wizard
                         // Do nothing for FileAttribute rows
                         continue; 
                     }
-                    
+
 
                     // Determine the filerule type - Hash, FilePath, FileAttribute (Name, Product Name, Original FileNme)
 
@@ -343,36 +343,53 @@ namespace WDAC_Wizard
                         //}
                     }
 
-                    else if (filePath != null || fileName != null)
+                    // Filepath Rule
+                    else if (filePath != null)
                     {
                         level = "FilePath";
-                        fileAttrList = "FileName: " + fileAttrList; 
+                        fileAttrList = "Filepath: " + filePath;
                     }
 
+                    // Packaged App Rule
                     else if (packageFamilyName != null)
                     {
-                        level = "Package Name"; 
+                        level = "Package Name";
+                        fileAttrList = "Packaged Family Name (PFN): " + packageFamilyName;
                     }
 
+                    // Allow/Deny with File attributes rules
+                    // I.e. no publisher information
                     else
                     {
                         level = "FileAttributes";
 
                         // Precede the friendlyName with the Original FileName sub-level 
-                        if (fileName != null)
-                            friendlyName = String.Format("FileName; {0}", friendlyName);
+                        if (fileName != null) 
+                        { 
+                            fileAttrList += String.Format("FileName: {0}, ", fileName);
+                        }
 
-                        else if (productName != null)
-                            friendlyName = String.Format("ProductName; {0}", friendlyName);
+                        if (productName != null)
+                        {
+                            fileAttrList = String.Format("ProductName: {0}, ", productName);
+                        }
 
-                        else if (fileDescription != null)
-                            friendlyName = String.Format("FileDescription; {0}", friendlyName);
+                        if (fileDescription != null)
+                        {
+                            fileAttrList = String.Format("FileDescription: {0}, ", fileDescription);
+                        }
 
-                        else if (internalName != null)
-                            friendlyName = String.Format("InternalName; {0}", friendlyName);
+                        if (internalName != null)
+                        {
+                            fileAttrList = String.Format("InternalName: {0}, ", friendlyName);
+                        }
 
-                        else
-                            this.Log.AddWarningMsg("DisplayRules() could not detect a sub-level for FileAttributes ");
+                        // Remove trailing comma and whitespace
+                        if(!String.IsNullOrEmpty(fileAttrList))
+                        {
+                            char[] trimChars = { ',', ' ' };
+                            fileAttrList = fileAttrList.TrimEnd(trimChars);
+                        }
                     }
 
                     // Only display if ID not found in the fileExceptionsDict -- in otherwords, this is a file rule NOT an exception


### PR DESCRIPTION
Fixed bug where the filepath in the table and friendly name: 

![image](https://user-images.githubusercontent.com/23045608/223889248-00a76452-921e-4a7c-b2b3-6a7a8a23b562.png)

Closing #219 

It now shows:

![image](https://user-images.githubusercontent.com/23045608/223893934-7d1d952a-7fdc-496a-bcc1-977e7e9a13b4.png)
