### PR TITLE
Removed wildcard checks for path rules given updates to wdac path rul…

### DIFF
--- a/AppLocker-Policy-Converter/app/AppLocker-Policy-Converter/AppLocker-Policy-Converter/Helper.cs
+++ b/AppLocker-Policy-Converter/app/AppLocker-Policy-Converter/AppLocker-Policy-Converter/Helper.cs
@@ -626,7 +626,7 @@ namespace AppLocker_Policy_Converter
 
             int cWildcards = appLockerPathRule.Count(f => (f == '*'));
 
-            // Assert the only position is front or back
+            // Updated 22H2: wildcards are now supported in the middle of the path
             if(cWildcards == 1)
             {
                 int idx = appLockerPathRule.IndexOf('*'); 
@@ -640,29 +640,22 @@ namespace AppLocker_Policy_Converter
                 else
                 {
                     // 1 Wildcard is in the middle of the path
-                    // This is NOT SUPPORTED in WDAC - truncate the path
                     // E.g. %WINDIR%\Folder1\*\FolderX\tool.dll -->
                     // *\FolderX\tool.dll
-                    // This way, the intended binaries are still allowed/blocked
-                    // without being too permissive E.g. %WINDIR%\Folder1\*
+              
+                    // Updated: Win11 22H2 and 21H2 now support this - show warning about support
 
-                    wdacPathRule = "*" + appLockerPathRule.Substring(idx+1);
-
-                    WarningMessages.Add(String.Format("WARNING: AppLocker Path Rule \"{0}\" is not a valid WDAC Path Rule. Replacing " +
-                        "with the following Path Rule: \"{1}\"", appLockerPathRule, wdacPathRule));
-
-                    return wdacPathRule;
+                    WarningMessages.Add(String.Format("WARNING: AppLocker Path Rule \"{0}\" is a valid WDAC Path " +
+                                        "Rule on Windows 11 systems only.",appLockerPathRule));
                 }
             }
 
-            // WDAC supports at most 1 wildcard * in the path. This type of rule is not supported
-            // Throw an error
+            // Multiple wildcards found
+            // Now supported on Windows 11. Just warn the user about the support
             if (cWildcards > 1)
             {
-                ErrorMessages.Add(String.Format("ERROR: AppLocker Path Rule \"{0}\" is not a valid WDAC Path Rule. " +
-                                                "It will need to be manually converted.", appLockerPathRule));
-                
-                return null; 
+                WarningMessages.Add(String.Format("WARNING: AppLocker Path Rule \"{0}\" is valid in WDAC on Windows 11 systems only.",
+                                                    appLockerPathRule));
             }
             
             return appLockerPathRule; 

--- a/WDAC-Policy-Wizard/app/App.config
+++ b/WDAC-Policy-Wizard/app/App.config
@@ -28,6 +28,9 @@
             <setting name="showMultiplePolicyDefault" serializeAs="String">
                 <value>True</value>
             </setting>
+            <setting name="warnWildcardPath" serializeAs="String">
+                <value>True</value>
+            </setting>
         </WDAC_Wizard.Properties.Settings>
     </userSettings>
   <runtime>

--- a/WDAC-Policy-Wizard/app/Properties/Resources.Designer.cs
+++ b/WDAC-Policy-Wizard/app/Properties/Resources.Designer.cs
@@ -517,6 +517,15 @@ namespace WDAC_Wizard.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Invalid path rule. %OSDRIVE%, %WINDIR%, %SYSTEM32% are the only supported macros..
+        /// </summary>
+        internal static string InvalidPath_Error {
+            get {
+                return ResourceManager.GetString("InvalidPath_Error", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Invalid publisher CN input. Publisher input must follow format: &apos;CN=PublisherName&apos; or &apos;PublisherName&apos;. Other fields
         ///like &apos;O=&apos; or &apos;L=&apos; must be removed..
         /// </summary>
@@ -587,17 +596,6 @@ namespace WDAC_Wizard.Properties {
         internal static string InvalidVersionRange_Error {
             get {
                 return ResourceManager.GetString("InvalidVersionRange_Error", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Invalid path rule. Note: only one wildcard (*) is allowed per path rule. Wildcards can only be
-        ///located at the beginning or end of a path rule. %OSDRIVE%, %WINDIR%, %SYSTEM32%
-        ///are the supported macros..
-        /// </summary>
-        internal static string InvalidWildcardPath_Error {
-            get {
-                return ResourceManager.GetString("InvalidWildcardPath_Error", resourceCulture);
             }
         }
         
@@ -1125,7 +1123,7 @@ namespace WDAC_Wizard.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The Wizard has detected cryto in the signed file that is not supported in WDAC. Unfortunately, a publisher rule cannot be used to allow or deny this file. .
+        ///   Looks up a localized string similar to A cryptographic algorithm that isn&apos;t supported by WDAC was found. Unfortunately, a publisher rule cannot be used to allow or deny this file. .
         /// </summary>
         internal static string UnsupportedCrypto_Error {
             get {

--- a/WDAC-Policy-Wizard/app/Properties/Resources.Designer.cs
+++ b/WDAC-Policy-Wizard/app/Properties/Resources.Designer.cs
@@ -790,6 +790,17 @@ namespace WDAC_Wizard.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to This path rule is only supported on Windows 11 (versions 21H2 and 22H2). It will be ignored on Windows 10 and all Windows Server versions. Select Cancel to fix the path rule.
+        ///
+        ///Do you want the Wizard to warn you about these types of path rules in the future? .
+        /// </summary>
+        internal static string PathRule_Warning {
+            get {
+                return ResourceManager.GetString("PathRule_Warning", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to This rule applies to all files signed by a certificate from this issuing CA. .
         /// </summary>
         internal static string PCACertificateInfo {

--- a/WDAC-Policy-Wizard/app/Properties/Resources.resx
+++ b/WDAC-Policy-Wizard/app/Properties/Resources.resx
@@ -404,10 +404,8 @@ and &lt; 65535.65535.65535.65535</value>
   <data name="InvalidVersion_Error" xml:space="preserve">
     <value>Invalid input. Version input must follow w.x.y.z format and &lt; 65535.65535.65535.65535</value>
   </data>
-  <data name="InvalidWildcardPath_Error" xml:space="preserve">
-    <value>Invalid path rule. Note: only one wildcard (*) is allowed per path rule. Wildcards can only be
-located at the beginning or end of a path rule. %OSDRIVE%, %WINDIR%, %SYSTEM32%
-are the supported macros.</value>
+  <data name="InvalidPath_Error" xml:space="preserve">
+    <value>Invalid path rule. %OSDRIVE%, %WINDIR%, %SYSTEM32% are the only supported macros.</value>
   </data>
   <data name="PFNEmptyList_Error" xml:space="preserve">
     <value>The list of selected packaged apps is empty. Please select at least 1 packaged app</value>

--- a/WDAC-Policy-Wizard/app/Properties/Resources.resx
+++ b/WDAC-Policy-Wizard/app/Properties/Resources.resx
@@ -515,4 +515,9 @@ Are you sure you want to abandon the exception rule creation workflow?</value>
   <data name="UnsupportedCrypto_Error" xml:space="preserve">
     <value>A cryptographic algorithm that isn't supported by WDAC was found. Unfortunately, a publisher rule cannot be used to allow or deny this file. </value>
   </data>
+  <data name="PathRule_Warning" xml:space="preserve">
+    <value>This path rule is only supported on Windows 11 (versions 21H2 and 22H2). It will be ignored on Windows 10 and all Windows Server versions. Select Cancel to fix the path rule.
+
+Do you want the Wizard to warn you about these types of path rules in the future? </value>
+  </data>
 </root>

--- a/WDAC-Policy-Wizard/app/Properties/Settings.Designer.cs
+++ b/WDAC-Policy-Wizard/app/Properties/Settings.Designer.cs
@@ -94,5 +94,17 @@ namespace WDAC_Wizard.Properties {
                 this["showMultiplePolicyDefault"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        public bool warnWildcardPath {
+            get {
+                return ((bool)(this["warnWildcardPath"]));
+            }
+            set {
+                this["warnWildcardPath"] = value;
+            }
+        }
     }
 }

--- a/WDAC-Policy-Wizard/app/Properties/Settings.settings
+++ b/WDAC-Policy-Wizard/app/Properties/Settings.settings
@@ -20,5 +20,8 @@
     <Setting Name="showMultiplePolicyDefault" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="warnWildcardPath" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/WDAC-Policy-Wizard/app/src/CustomRuleConditionsPanel.cs
+++ b/WDAC-Policy-Wizard/app/src/CustomRuleConditionsPanel.cs
@@ -332,8 +332,8 @@ namespace WDAC_Wizard
                     if(!Helper.IsValidPathRule(this.PolicyCustomRule.CustomValues.Path))
                     {
                         label_Error.Visible = true;
-                        label_Error.Text = Properties.Resources.InvalidWildcardPath_Error;
-                        this.Log.AddWarningMsg("Invalid custom path rule");
+                        label_Error.Text = Properties.Resources.InvalidPath_Error;
+                        this.Log.AddWarningMsg("Invalid custom path rule for path: " + this.PolicyCustomRule.CustomValues.Path);
                         return;
                     }
                 }

--- a/WDAC-Policy-Wizard/app/src/CustomRuleConditionsPanel.cs
+++ b/WDAC-Policy-Wizard/app/src/CustomRuleConditionsPanel.cs
@@ -329,12 +329,45 @@ namespace WDAC_Wizard
                 // Check custom path
                 if (this.PolicyCustomRule.CustomValues.Path != null)
                 {
+                    // Check if this is a valid path rules. I.e. supported macros
                     if(!Helper.IsValidPathRule(this.PolicyCustomRule.CustomValues.Path))
                     {
                         label_Error.Visible = true;
                         label_Error.Text = Properties.Resources.InvalidPath_Error;
                         this.Log.AddWarningMsg("Invalid custom path rule for path: " + this.PolicyCustomRule.CustomValues.Path);
                         return;
+                    }
+
+                    // Check number of wildcards.
+                    // If the number is greater than 1, warn the user IFF the warn setting (default on) is on
+                    if(Helper.GetNumberofWildcards(this.PolicyCustomRule.CustomValues.Path) > 1
+                       && Properties.Settings.Default.warnWildcardPath)
+                    {
+                        this.Log.AddWarningMsg("Warning - Path Rule Windows Version Support for path: " + this.PolicyCustomRule.CustomValues.Path);
+
+                        var res = MessageBox.Show(Properties.Resources.PathRule_Warning,
+                                                  "Warning - Path Rule Windows Version Support",
+                                                  MessageBoxButtons.YesNoCancel, 
+                                                  MessageBoxIcon.Warning);
+
+                        this.Log.AddInfoMsg("Message box result: " + res.ToString());
+
+                        // User wants to modify the rule
+                        // Escape the checks so they may edit the path
+                        if (res == DialogResult.Cancel)
+                        {
+                            return; 
+                        }
+
+                        // User does not want to be warned about path rules on Windows 11 only. 
+                        // Set the warnWildcardPath to false to bypass future warnings
+                        if(res == DialogResult.No)
+                        {
+                            Properties.Settings.Default.warnWildcardPath = false;
+                            Properties.Settings.Default.Save();
+
+                            this.Log.AddInfoMsg("Set warnWildcardPath to: false");
+                        }
                     }
                 }
 

--- a/WDAC-Policy-Wizard/app/src/Helper.cs
+++ b/WDAC-Policy-Wizard/app/src/Helper.cs
@@ -511,30 +511,16 @@ namespace WDAC_Wizard
             return 0;
         }
 
+        /// <summary>
+        /// Validates the custom path rule against the requirements for path rules in WDAC
+        /// Updated 22H2: path rules now support multiple wildcards throughout the path
+        /// </summary>
+        /// <param name="customPath"></param>
+        /// <returns>True if valid path rule in WDAC. False, otherwise.</returns>
         public static bool IsValidPathRule(string customPath)
         {
             // Check for at most 1 wildcard param (*)
-            if (customPath.Contains("*"))
-            {
-                var wildCardParts = customPath.Split('*');
-                if (wildCardParts.Length > 2)
-                {
-                    return false;
-                }
-                else
-                {
-                    // Start or end must be empty
-                    if (String.IsNullOrEmpty(wildCardParts[0]) || String.IsNullOrEmpty(wildCardParts[1]))
-                    {
-                        // Continue - either side is empty
-                    }
-                    else
-                    {
-                        // wildcard in middle of path - not supported
-                        return false;
-                    }
-                }
-            }
+            // This check was removed since WDAC path rules can support multiple wildcards
 
             // Check for macros (%OSDRIVE%, %WINDIR%, %SYSTEM32%)
             if (customPath.Contains("%"))
@@ -542,11 +528,9 @@ namespace WDAC_Wizard
                 var macroParts = customPath.Split('%');
                 if (macroParts.Length == 3)
                 {
-                    if (macroParts[1] == "OSDRIVE" || macroParts[1] == "WINDIR" || macroParts[1] == "SYSTEM32")
-                    {
-                        // continue with rest of checks
-                    }
-                    else
+                    if (!(macroParts[1] == "OSDRIVE" 
+                        || macroParts[1] == "WINDIR" 
+                        || macroParts[1] == "SYSTEM32"))
                     {
                         return false;
                     }
@@ -560,6 +544,11 @@ namespace WDAC_Wizard
             return true;
         }
 
+        /// <summary>
+        /// Maps the input to one of the supported macro paths in WDAC, if one exists.
+        /// </summary>
+        /// <param name="_path"></param>
+        /// <returns></returns>
         public static string GetEnvPath(string _path)
         {
             // if the path contains one of the following environment variables -- return true as the cmdlets can replace it

--- a/WDAC-Policy-Wizard/app/src/Helper.cs
+++ b/WDAC-Policy-Wizard/app/src/Helper.cs
@@ -545,6 +545,32 @@ namespace WDAC_Wizard
         }
 
         /// <summary>
+        /// Checks for the presence of "?" or "*" wildcard characters in a custom path
+        /// </summary>
+        /// <param name="customPath">Returns the number of wildcards found</param>
+        /// <returns></returns>
+        public static int GetNumberofWildcards(string customPath)
+        {
+            int nWildCards = 0; 
+            foreach(char c in customPath)
+            {
+                if(c == '*')
+                {
+                    nWildCards++; 
+                }
+
+                // Add 2 to wildcards to automatically trigger the validation on the CustomRuleConditions
+                // If only 1 '?' it would pass the check
+                else if(c== '?')
+                {
+                    nWildCards += 2; 
+                }
+            }
+
+            return nWildCards; 
+        }
+
+        /// <summary>
         /// Maps the input to one of the supported macro paths in WDAC, if one exists.
         /// </summary>
         /// <param name="_path"></param>


### PR DESCRIPTION
…es support

Wizard updates:
- Removed all checks around wildcards. I no longer enforce a max number of wildcards or their position

AppLocker Policy Converter tool: 
- Removed all checks around wildcards. No enforcement of a max number of wildcards or position
- The tool will warn the user that these rules will only work (currently) on Windows 11 systems