### PR TITLE
210 invalid signed version rules

### DIFF
--- a/WDAC-Policy-Wizard/app/Properties/Resources.resx
+++ b/WDAC-Policy-Wizard/app/Properties/Resources.resx
@@ -533,6 +533,7 @@ Please check the log file in </value>
     <value>The WDAC Wizard could not open the WDAC BIN file. The most likely reason is that the Wizard failed to convert the policy XML file to binary.
 
 Please check the log file in </value>
+  </data>
   <data name="PathRule_Warning" xml:space="preserve">
     <value>This path rule is only supported on Windows 11 (versions 21H2 and 22H2). It will be ignored on Windows 10 and all Windows Server versions. Select Cancel to fix the path rule.
 

--- a/WDAC-Policy-Wizard/app/src/Helper.cs
+++ b/WDAC-Policy-Wizard/app/src/Helper.cs
@@ -1231,8 +1231,9 @@ namespace WDAC_Wizard
                 fileAttrib.MinimumFileVersion = customRule.CustomValues.MinVersion.Trim();
             }
 
-            if (customRule.CheckboxCheckStates.checkBox4 && 
-                customRule.CustomValues.MaxVersion != null && customRule.CustomValues.MaxVersion != "*")
+            if (customRule.CheckboxCheckStates.checkBox4 
+                && customRule.CustomValues.MaxVersion != null 
+                && customRule.CustomValues.MaxVersion != "*")
             {
                 fileAttrib.MaximumFileVersion = customRule.CustomValues.MaxVersion.Trim(); 
             }
@@ -1245,6 +1246,15 @@ namespace WDAC_Wizard
             if (customRule.CheckboxCheckStates.checkBox2)
             {
                 fileAttrib.ProductName = customRule.CustomValues.ProductName;
+            }
+
+            // Issue #210 - the WDAC policy compiler will complain that version info without one of product, filename, etc.
+            // is not a valid rule. Add Filename="*" like the SignedVersion PS cmd does
+            if(fileAttrib.MinimumFileVersion != null 
+                || fileAttrib.MinimumFileVersion != null 
+                && (fileAttrib.FileName == null || fileAttrib.ProductName == null))
+            {
+                fileAttrib.FileName = "*"; 
             }
 
             // Add FileAttrib references
@@ -2293,6 +2303,15 @@ namespace WDAC_Wizard
             {
                 fileAttrib.ProductName = customRule.FileInfo["ProductName"];
                 friendlyName += fileAttrib.ProductName + " and ";
+            }
+
+            // Issue #210 - the WDAC policy compiler will complain that version info without one of product, filename, etc.
+            // is not a valid rule. Add Filename="*" like the SignedVersion PS cmd does
+            if (fileAttrib.MinimumFileVersion != null 
+                || fileAttrib.MinimumFileVersion != null
+                && (fileAttrib.FileName == null || fileAttrib.ProductName == null))
+            {
+                fileAttrib.FileName = "*";
             }
 
             fileAttrib.FriendlyName = friendlyName.Substring(0, friendlyName.Length - 5); // remove trailing " and "

--- a/WDAC-Policy-Wizard/app/src/Helper.cs
+++ b/WDAC-Policy-Wizard/app/src/Helper.cs
@@ -1264,6 +1264,22 @@ namespace WDAC_Wizard
             // Add signer references
             siPolicy = AddSiPolicySigner(signers, siPolicy, customRule.Permission, customRule.SigningScenarioCheckStates);
 
+            // Process exceptions
+            if (customRule.ExceptionList.Count > 0)
+            {
+                if (customRule.Permission == PolicyCustomRules.RulePermission.Allow)
+                {
+                    // Create except deny rules to add to allowed signers
+                    ExceptDenyRule[] exceptDenyRules = CreateExceptDenyRules(customRule.ExceptionList, siPolicy);
+                    siPolicy = AddExceptionsToAllowSigners(exceptDenyRules, siPolicy, customRule.SigningScenarioCheckStates);
+                }
+                else
+                {
+                    // Create except Allowrules
+                    ExceptAllowRule[] exceptAllowRules = CreateExceptAllowRules(customRule.ExceptionList, siPolicy);
+                    siPolicy = AddExceptionsToDeniedSigners(exceptAllowRules, siPolicy, customRule.SigningScenarioCheckStates);
+                }
+            }
             return siPolicy;            
         }
 
@@ -1325,6 +1341,17 @@ namespace WDAC_Wizard
                 allowRule.ID = String.Format("ID_ALLOW_EX_{0}", cFileExceptions++);
             }
 
+            // Issue #210 - the WDAC policy compiler will complain that version info without one of product, filename, etc.
+            // is not a valid rule. Add Filename="*" like the SignedVersion PS cmd does
+            if (allowRule.MinimumFileVersion != null
+                && (allowRule.FileName == null
+                    || allowRule.InternalName == null
+                    || allowRule.ProductName == null
+                    || allowRule.FileDescription == null))
+            {
+                allowRule.FileName = "*";
+            }
+
             // Add the Allow rule to FileRules and FileRuleRef section with Windows Signing Scenario
             siPolicy = AddAllowRule(allowRule, siPolicy, customRule.SigningScenarioCheckStates, isException);
                         
@@ -1379,6 +1406,7 @@ namespace WDAC_Wizard
             }
 
             denyRule.FriendlyName = friendlyName.Substring(0, friendlyName.Length - 5);
+
             if(!isException)
             {
                 denyRule.ID = String.Format("ID_DENY_A_{0}", cFileDenyRules++);
@@ -1386,6 +1414,17 @@ namespace WDAC_Wizard
             else
             {
                 denyRule.ID = String.Format("ID_DENY_EX_{0}", cFileExceptions++);
+            }
+
+            // Issue #210 - the WDAC policy compiler will complain that version info without one of product, filename, etc.
+            // is not a valid rule. Add Filename="*" like the SignedVersion PS cmd does
+            if (denyRule.MinimumFileVersion != null
+                && (denyRule.FileName == null 
+                    || denyRule.InternalName == null
+                    || denyRule.ProductName == null
+                    || denyRule.FileDescription == null))
+            {
+                denyRule.FileName = "*";
             }
 
             // Add the deny rule to FileRules and FileRuleRef section with Windows Signing Scenario


### PR DESCRIPTION
Closing #210 

1. Fixes an issue with creating "SignedVersion" publisher rules with a file attribute with only version information. The compiler does not view a file attribute with only version (max and min) as enough to qualify a rule. 

Added FileName="*" in this case just like the -Level SignedVersion in the powershell cmdlets do

2. Also did a driver by fix where FilePublisher rules with custom CN, filename or version info would ignore linked exception rules.


After the fix - 

<FileAttrib ID="ID_FILEATTRIB_A_0_0_0" FriendlyName="Allow files based on file attributes: 10.0.25309.1002" FileName="*" MinimumFileVersion="10.0.25309.1002" />
    <Deny ID="ID_DENY_EX_0_0_0" FriendlyName="Deny files based on file attributes: 16.1.20399.201" FileName="*" MinimumFileVersion="16.1.20399.201" />

