### PR TITLE
Fixes Bug #235 - Wizard outputs multiple policy format when single policy is desired

### DIFF
--- a/WDAC-Policy-Wizard/app/src/MainForm.cs
+++ b/WDAC-Policy-Wizard/app/src/MainForm.cs
@@ -1076,6 +1076,15 @@ namespace WDAC_Wizard
                     siPolicy.PolicyID = siPolicy.BasePolicyID;
                 }
 
+                // If single policy/legacy policy, ensure the correct IDs are set on the policy
+                else if (this.Policy._Format == WDAC_Policy.Format.Legacy)
+                {
+                    siPolicy.BasePolicyID = null;
+                    siPolicy.PolicyID = null;
+                    siPolicy.PolicyTypeSpecified = false; 
+                    siPolicy.PolicyTypeID = Properties.Resources.LegacyPolicyID_GUID; 
+                }
+
                 // If supplemental policy, set the Base policy guid; reset the policy ID and set the policy name
                 else if (this.Policy._PolicyType == WDAC_Policy.PolicyType.SupplementalPolicy)
                 {


### PR DESCRIPTION
Fixes an issue where the WDAC Wizard would output XML and {guid}.cip when the user walked through the single policy format workflow. 

The issue was when custom rules were created and merged, the output policy format was always multiple policy format. 

The fix always sets the single policy format attributes like the legacy PolicyTypeID and clears the BasePolicyID and the PolicyID iff the format is single policy. 

Closing #235 

Tested by creating custom rules (signer, file path, hash, folder scan, COM, etc) as well as merging the recommended block rules. Single policy format is now always output