### PR TITLE
Added a check for zero rules created blocking advancement

### DIFF
--- a/WDAC-Policy-Wizard/app/Properties/Resources.Designer.cs
+++ b/WDAC-Policy-Wizard/app/Properties/Resources.Designer.cs
@@ -529,6 +529,15 @@ namespace WDAC_Wizard.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to At least one rule must be created before building the policy file. .
+        /// </summary>
+        internal static string InvalidEventRulesCreated {
+            get {
+                return ResourceManager.GetString("InvalidEventRulesCreated", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Kernel mode components cannot be allowed or denied using packaged app or path rules..
         /// </summary>
         internal static string InvalidKMCIRule {

--- a/WDAC-Policy-Wizard/app/Properties/Resources.resx
+++ b/WDAC-Policy-Wizard/app/Properties/Resources.resx
@@ -542,4 +542,7 @@ Do you want the Wizard to warn you about these types of path rules in the future
   <data name="NullXmlPath" xml:space="preserve">
     <value>The policy path must be given before continuing.</value>
   </data>
+  <data name="InvalidEventRulesCreated" xml:space="preserve">
+    <value>At least one rule must be created before building the policy file. </value>
+  </data>
 </root>

--- a/WDAC-Policy-Wizard/app/src/EventLogRuleConfiguration.cs
+++ b/WDAC-Policy-Wizard/app/src/EventLogRuleConfiguration.cs
@@ -45,6 +45,10 @@ namespace WDAC_Wizard
 
             this.SelectedRow = 0;
             this.RuleIdsToAdd = new List<int>();
+
+            // Set error flag - Bug #234
+            this._MainWindow.ErrorOnPage = true;
+            this._MainWindow.ErrorMsg = Properties.Resources.InvalidEventRulesCreated; 
         }
 
         /// <summary>
@@ -102,7 +106,8 @@ namespace WDAC_Wizard
                     {
                         dp.Action = "Added to policy";
                         this.siPolicy = PolicyHelper.AddSiPolicyPublisherRule(ciEvent, this.siPolicy, PublisherUIState);
-                        this._MainWindow.EventLogPolicy = this.siPolicy; 
+                        this._MainWindow.EventLogPolicy = this.siPolicy;
+                        ClearErrorMsg();
                     }
                     break;
 
@@ -112,6 +117,7 @@ namespace WDAC_Wizard
                         dp.Action = "Added to policy"; 
                         this.siPolicy = PolicyHelper.AddSiPolicyFilePathRule(ciEvent, this.siPolicy, this.FilePathUIState);
                         this._MainWindow.EventLogPolicy = this.siPolicy;
+                        ClearErrorMsg();
                     }
                     break; 
 
@@ -122,6 +128,7 @@ namespace WDAC_Wizard
                         dp.Action = "Added to policy"; 
                         this.siPolicy = PolicyHelper.AddSiPolicyFileAttributeRule(ciEvent, this.siPolicy, this.FileAttributesUIState);
                         this._MainWindow.EventLogPolicy = this.siPolicy;
+                        ClearErrorMsg();
                     }
                     break;
 
@@ -131,6 +138,7 @@ namespace WDAC_Wizard
                         dp.Action = "Added to policy";
                         this.siPolicy = PolicyHelper.AddSiPolicyHashRules(ciEvent, this.siPolicy);
                         this._MainWindow.EventLogPolicy = this.siPolicy;
+                        ClearErrorMsg();
                     }
                     break; 
             }
@@ -757,6 +765,15 @@ namespace WDAC_Wizard
             // Unhide the panel
             this.filePathRulePanel.Visible = true;
             this.filePathRulePanel.Location = this.publisherRulePanel.Location; // snap to the loc of pub panel
+        }
+
+        /// <summary>
+        /// Clears the prior error message from MainForm's UI
+        /// </summary>
+        private void ClearErrorMsg()
+        {
+            this._MainWindow.ErrorOnPage = false; 
+            this._MainWindow.DisplayInfoText(0);
         }
     }
 


### PR DESCRIPTION
#234 was reported after 0 AH event rules were created. Selecting Next resulted in an empty policy. Suggested that the Wizard add a check for 0 event rules created. 

Now when a user attempts to advance without any rules created, the Wizard will not advance and show the following UI:

![image](https://github.com/MicrosoftDocs/WDAC-Toolkit/assets/23045608/974c8fc3-c25d-4c22-95a5-06e5adb07e01)


Closing #234 