### PR TITLE
Fixed unsupported crypto check to allow ECC signed files to be allowe…

### DIFF
--- a/WDAC-Policy-Wizard/app/src/Helper.cs
+++ b/WDAC-Policy-Wizard/app/src/Helper.cs
@@ -429,7 +429,7 @@ namespace WDAC_Wizard
         /// Checks for unsupported crypto oids (ECC, ECSDA)
         /// </summary>
         /// <returns>True, if unsupported crypto oids are parsed</returns>
-        public static bool IsCertChainInvalid(X509Chain certChain)
+        public static bool IsCryptoInvalid(X509Chain certChain)
         {
             foreach(var cert in certChain.ChainElements)
             {
@@ -2738,8 +2738,6 @@ namespace WDAC_Wizard
 
         public SigningScenarioStates SigningScenarioCheckStates;
 
-
-
         public enum RulePermission { Allow, Deny };
 
         // enums: 
@@ -2749,11 +2747,12 @@ namespace WDAC_Wizard
 
         // Variables:
         public string ReferenceFile { get; set; }
-        public Dictionary<string, string> FileInfo { get; set; } //
+        public Dictionary<string, string> FileInfo { get; set; }    // FileInfo dict containing PE metadata and sig CNs
+        public bool SupportedCrypto { get; set; }                   // Boolean flag indicating whether the crypto detected is supported in WDAC
         public string PSVariable { get; set; }
         public string VersionNumber { get; set; }
-        public string RuleIndex { get; set; } // Index of return struct in Get-SystemDriver cmdlet
-        public int RowNumber { get; set;  }     // Index of the row in the datagrid
+        public string RuleIndex { get; set; }                       // Index of return struct in Get-SystemDriver cmdlet
+        public int RowNumber { get; set;  }                         // Index of the row in the datagrid
 
         // Custom values
         public bool UsingCustomValues { get; set; }
@@ -2784,6 +2783,7 @@ namespace WDAC_Wizard
             this.Permission = RulePermission.Allow; // Allow by default to match the default state of the UI
 
             this.FileInfo = new Dictionary<string, string>();
+            this.SupportedCrypto = true; 
             this.ExceptionList = new List<PolicyCustomRules>();
             this.FolderContents = new List<string>();
 

--- a/WDAC-Policy-Wizard/app/src/SigningRules_Control.cs
+++ b/WDAC-Policy-Wizard/app/src/SigningRules_Control.cs
@@ -990,7 +990,14 @@ namespace WDAC_Wizard
             }
             else
             {
-                displayObject = (DisplayObject)this.displayObjects[e.RowIndex];
+                if(e.RowIndex  < this.displayObjects.Count)
+                {
+                    displayObject = (DisplayObject)this.displayObjects[e.RowIndex];
+                }
+                else
+                {
+                    return; 
+                }
             }
 
             // Set the cell value to paint using the Customer object retrieved.

--- a/WDAC-Policy-Wizard/app/src/SigningRules_Control.cs
+++ b/WDAC-Policy-Wizard/app/src/SigningRules_Control.cs
@@ -990,14 +990,7 @@ namespace WDAC_Wizard
             }
             else
             {
-                if(e.RowIndex  < this.displayObjects.Count)
-                {
-                    displayObject = (DisplayObject)this.displayObjects[e.RowIndex];
-                }
-                else
-                {
-                    return; 
-                }
+                displayObject = (DisplayObject)this.displayObjects[e.RowIndex];
             }
 
             // Set the cell value to paint using the Customer object retrieved.


### PR DESCRIPTION
…d/denied by non pub rules

Closing #243 

1. Unsupported crypto error message only appears when a non RSA signed file is the target for a publisher rule
2. Creating a file path, hash or attributes rule off an ECC signed file will not trigger the error msg on its own
3. Creating a file path, hash, file attributes rule off an ECC signed file --> publisher rule triggers the error message and clears the UI

![image](https://github.com/MicrosoftDocs/WDAC-Toolkit/assets/23045608/5dedb748-ade5-40e5-8444-b64548a351eb)

![image](https://github.com/MicrosoftDocs/WDAC-Toolkit/assets/23045608/ee37618e-65c6-4f04-83b6-91b8c526ca95)
