### PR TITLE
247 some wdac policies after merge have large runs of zeros appended to their ids

### DIFF
--- a/WDAC-Policy-Wizard/app/src/Helper.cs
+++ b/WDAC-Policy-Wizard/app/src/Helper.cs
@@ -61,7 +61,7 @@ namespace WDAC_Wizard
         }
 
         // Counts of Deny, Allow, FileAttrib and Signers
-        const string UNDERSCORE_PATTERN = @"_0_0_0_0_0_0";
+        const string UNDERSCORE_PATTERN = @"_0_0_0";
         static int cDenyRules = 0;
         static int cAllowRules = 0;
         static int cFileAttribs = 0;

--- a/WDAC-Policy-Wizard/app/src/MainForm.cs
+++ b/WDAC-Policy-Wizard/app/src/MainForm.cs
@@ -1149,8 +1149,8 @@ namespace WDAC_Wizard
             }
 
             // Lastly, re-format Allow/Deny, FileAttrib and Signer IDs, if applicable
-            siPolicy = Helper.FormatRuleIDs(siPolicy); 
-
+            siPolicy = Helper.FormatFileRuleIDs(siPolicy);
+            siPolicy = Helper.FormatSignerRuleIDs(siPolicy);
 
             try
             {

--- a/WDAC-Policy-Wizard/app/src/MainForm.cs
+++ b/WDAC-Policy-Wizard/app/src/MainForm.cs
@@ -844,7 +844,8 @@ namespace WDAC_Wizard
                 CreateComObjectRules(worker);
             }
 
-            // Set additional parameters, for instance, policy name, GUIDs, version, etc
+            // Set additional parameters,
+            // for instance, policy name, GUIDs, version, etc
             SetAdditionalParameters(worker);
 
             // Convert the policy from XML to Binary file
@@ -1043,6 +1044,7 @@ namespace WDAC_Wizard
             // 2. Settings PolicyInfo.Name and PolicyInfo.Id
             // 3. VersionExpolicy 
             // 4. HVCI state
+            // 5. Format IDs in the case of Issue #247
 
             this.Log.AddInfoMsg("-- Set Additional Parameters --");
 
@@ -1133,7 +1135,7 @@ namespace WDAC_Wizard
                 this.Log.AddInfoMsg("Additional parameters set - VersionEx " + siPolicy.VersionEx);
             }
 
-            // Lastly, set HVCI state
+            // Set HVCI state
             if (this.Policy.EnableHVCI)
             {
                 // Enable HVCI since HVCI is not a Rule-Option
@@ -1145,6 +1147,10 @@ namespace WDAC_Wizard
                 siPolicy.HvciOptions = 0;
                 this.Log.AddInfoMsg("Additional parameters set - HVCI set to 0");
             }
+
+            // Lastly, re-format Allow/Deny, FileAttrib and Signer IDs, if applicable
+            siPolicy = Helper.FormatRuleIDs(siPolicy); 
+
 
             try
             {


### PR DESCRIPTION
Added logic in the final step of the policy conversion to detect large runs of zeros and remove the the "_0_0_0_...." with a unique number. Works for file rules (allow, deny and fileattribute) as well as signers (AllowedSigner, denied signer, cisigner, update signer, supplemental signer). 

Examples/tests: 

ID_SIGNER_S_48_54_0_0_0_0_0_0 --> ID_SIGNER_S_48_54_1
ID_DENY_CBD_1_7_0_0_0_0 --> ID_DENY_CBD_1_7_89
ID_FILEATTRIB_SYSINFO_123_dfds_2132 --> stays as is

The threshold for the ID 'undesrcore limit' is 3 or "_0_0_0". Replaces the first instance of this string. 

Closing #247 

From: 
![image](https://github.com/MicrosoftDocs/WDAC-Toolkit/assets/23045608/fdc85aec-f1bc-4338-a60a-a6369dcb960f)


To: 
![image](https://github.com/MicrosoftDocs/WDAC-Toolkit/assets/23045608/c1d20f64-c62e-4885-864d-a7b14352d34a)
