### PR TITLE
Added ability to create supplemental policies from only a base ID

### DIFF
--- a/WDAC-Policy-Wizard/app/MSIX/EmptyWDAC.xml
+++ b/WDAC-Policy-Wizard/app/MSIX/EmptyWDAC.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<SiPolicy xmlns="urn:schemas-microsoft-com:sipolicy" PolicyType="Base Policy">
+  <VersionEx>10.0.0.0</VersionEx>
+  <PlatformID>{2E07F7E4-194C-4D20-B7C9-6F44A6C5A234}</PlatformID>
+  <Rules>
+    <Rule>
+      <Option>Enabled:Unsigned System Integrity Policy</Option>
+    </Rule>
+    <Rule>
+      <Option>Enabled:Audit Mode</Option>
+    </Rule>
+    <Rule>
+      <Option>Enabled:Advanced Boot Options Menu</Option>
+    </Rule>
+    <Rule>
+      <Option>Required:Enforce Store Applications</Option>
+    </Rule>
+  </Rules>
+  <!--EKUS-->
+  <EKUs />
+  <!--File Rules-->
+  <FileRules />
+  <!--Signers-->
+  <Signers />
+  <!--Driver Signing Scenarios-->
+  <SigningScenarios>
+    <SigningScenario Value="131" ID="ID_SIGNINGSCENARIO_DRIVERS_1" FriendlyName="Auto generated policy on 05-12-2022">
+      <ProductSigners />
+    </SigningScenario>
+    <SigningScenario Value="12" ID="ID_SIGNINGSCENARIO_WINDOWS" FriendlyName="Auto generated policy on 05-12-2022">
+      <ProductSigners />
+    </SigningScenario>
+  </SigningScenarios>
+  <UpdatePolicySigners />
+  <CiSigners />
+  <HvciOptions>0</HvciOptions>
+  <BasePolicyID>{784C4414-79F4-4C32-A6A5-F0FB42A51D0D}</BasePolicyID>
+  <PolicyID>{784C4414-79F4-4C32-A6A5-F0FB42A51D0D}</PolicyID>
+</SiPolicy>

--- a/WDAC-Policy-Wizard/app/MSIX/EmptyWDAC.xml
+++ b/WDAC-Policy-Wizard/app/MSIX/EmptyWDAC.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <SiPolicy xmlns="urn:schemas-microsoft-com:sipolicy" PolicyType="Base Policy">
   <VersionEx>10.0.0.0</VersionEx>
   <PlatformID>{2E07F7E4-194C-4D20-B7C9-6F44A6C5A234}</PlatformID>
@@ -14,6 +14,9 @@
     </Rule>
     <Rule>
       <Option>Required:Enforce Store Applications</Option>
+    </Rule>
+    <Rule>
+      <Option>Enabled:Inherit Default Policy</Option>
     </Rule>
   </Rules>
   <!--EKUS-->

--- a/WDAC-Policy-Wizard/app/Properties/Resources.Designer.cs
+++ b/WDAC-Policy-Wizard/app/Properties/Resources.Designer.cs
@@ -350,6 +350,15 @@ namespace WDAC_Wizard.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to EmptyWDAC.xml.
+        /// </summary>
+        internal static string EmptyWdacXml {
+            get {
+                return ResourceManager.GetString("EmptyWdacXml", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Microsoft-Windows-Applocker/MSI and Script.
         /// </summary>
         internal static string EventLogAppLocker {
@@ -382,6 +391,15 @@ namespace WDAC_Wizard.Properties {
         internal static string EVSigners_Info {
             get {
                 return ResourceManager.GetString("EVSigners_Info", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to e.g. {fd756ea8-ad7f-4e30-96bd-8778288212f6}.
+        /// </summary>
+        internal static string ExampleBasePolicyId {
+            get {
+                return ResourceManager.GetString("ExampleBasePolicyId", resourceCulture);
             }
         }
         
@@ -497,6 +515,15 @@ namespace WDAC_Wizard.Properties {
         internal static string InvalidAttributeSelection_Error {
             get {
                 return ResourceManager.GetString("InvalidAttributeSelection_Error", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The Base Policy Id entered does not match the format expected. E.g. {fd756ea8-ad7f-4e30-96bd-8778288212f6}.
+        /// </summary>
+        internal static string InvalidBasePolicyId {
+            get {
+                return ResourceManager.GetString("InvalidBasePolicyId", resourceCulture);
             }
         }
         

--- a/WDAC-Policy-Wizard/app/Properties/Resources.resx
+++ b/WDAC-Policy-Wizard/app/Properties/Resources.resx
@@ -545,4 +545,13 @@ Do you want the Wizard to warn you about these types of path rules in the future
   <data name="InvalidEventRulesCreated" xml:space="preserve">
     <value>At least one rule must be created before building the policy file. </value>
   </data>
+  <data name="EmptyWdacXml" xml:space="preserve">
+    <value>EmptyWDAC.xml</value>
+  </data>
+  <data name="ExampleBasePolicyId" xml:space="preserve">
+    <value>e.g. {fd756ea8-ad7f-4e30-96bd-8778288212f6}</value>
+  </data>
+  <data name="InvalidBasePolicyId" xml:space="preserve">
+    <value>The Base Policy Id entered does not match the format expected. E.g. {fd756ea8-ad7f-4e30-96bd-8778288212f6}</value>
+  </data>
 </root>

--- a/WDAC-Policy-Wizard/app/Resources/EmptyWDAC.xml
+++ b/WDAC-Policy-Wizard/app/Resources/EmptyWDAC.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <SiPolicy xmlns="urn:schemas-microsoft-com:sipolicy" PolicyType="Base Policy">
   <VersionEx>10.0.0.0</VersionEx>
   <PlatformID>{2E07F7E4-194C-4D20-B7C9-6F44A6C5A234}</PlatformID>
@@ -14,6 +14,9 @@
     </Rule>
     <Rule>
       <Option>Required:Enforce Store Applications</Option>
+    </Rule>
+    <Rule>
+      <Option>Enabled:Inherit Default Policy</Option>
     </Rule>
   </Rules>
   <!--EKUS-->

--- a/WDAC-Policy-Wizard/app/Resources/policyTemplates/EmptyWDAC.xml
+++ b/WDAC-Policy-Wizard/app/Resources/policyTemplates/EmptyWDAC.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<SiPolicy xmlns="urn:schemas-microsoft-com:sipolicy" PolicyType="Base Policy">
+  <VersionEx>10.0.0.0</VersionEx>
+  <PlatformID>{2E07F7E4-194C-4D20-B7C9-6F44A6C5A234}</PlatformID>
+  <Rules>
+    <Rule>
+      <Option>Enabled:Unsigned System Integrity Policy</Option>
+    </Rule>
+    <Rule>
+      <Option>Enabled:Audit Mode</Option>
+    </Rule>
+    <Rule>
+      <Option>Enabled:Advanced Boot Options Menu</Option>
+    </Rule>
+    <Rule>
+      <Option>Required:Enforce Store Applications</Option>
+    </Rule>
+  </Rules>
+  <!--EKUS-->
+  <EKUs />
+  <!--File Rules-->
+  <FileRules />
+  <!--Signers-->
+  <Signers />
+  <!--Driver Signing Scenarios-->
+  <SigningScenarios>
+    <SigningScenario Value="131" ID="ID_SIGNINGSCENARIO_DRIVERS_1" FriendlyName="Auto generated policy on 05-12-2022">
+      <ProductSigners />
+    </SigningScenario>
+    <SigningScenario Value="12" ID="ID_SIGNINGSCENARIO_WINDOWS" FriendlyName="Auto generated policy on 05-12-2022">
+      <ProductSigners />
+    </SigningScenario>
+  </SigningScenarios>
+  <UpdatePolicySigners />
+  <CiSigners />
+  <HvciOptions>0</HvciOptions>
+  <BasePolicyID>{784C4414-79F4-4C32-A6A5-F0FB42A51D0D}</BasePolicyID>
+  <PolicyID>{784C4414-79F4-4C32-A6A5-F0FB42A51D0D}</PolicyID>
+</SiPolicy>

--- a/WDAC-Policy-Wizard/app/src/ConfigTemplate_Control.cs
+++ b/WDAC-Policy-Wizard/app/src/ConfigTemplate_Control.cs
@@ -593,7 +593,16 @@ namespace WDAC_Wizard
             // If we are supplementing a policy, we need to mirror the rule options of the base so they do not conflict
             else if (this.Policy._PolicyType == WDAC_Policy.PolicyType.SupplementalPolicy)
             {
-                xmlPathToRead = this._MainWindow.Policy.BaseToSupplementPath;
+                // User only provided a base policy ID to expand
+                if(this._MainWindow.Policy.BasePolicyId != Guid.Empty)
+                {
+                    xmlPathToRead = System.IO.Path.Combine(this._MainWindow.ExeFolderPath, Properties.Resources.EmptyWdacXml);
+                }
+                // User provided a path to the base policy
+                else
+                {
+                    xmlPathToRead = this._MainWindow.Policy.BaseToSupplementPath;
+                }
             }
             else
             {

--- a/WDAC-Policy-Wizard/app/src/MainForm.cs
+++ b/WDAC-Policy-Wizard/app/src/MainForm.cs
@@ -1095,8 +1095,28 @@ namespace WDAC_Wizard
                 // If supplemental policy, set the Base policy guid; reset the policy ID and set the policy name
                 else if (this.Policy._PolicyType == WDAC_Policy.PolicyType.SupplementalPolicy)
                 {
-                    // Set BasePolicyID to match the Id of the linked base policy
-                    siPolicy.BasePolicyID = Helper.DeserializeXMLtoPolicy(this.Policy.BaseToSupplementPath).BasePolicyID;
+                    // User provided path to base policy XML
+                    if(this.Policy.BasePolicyId == Guid.Empty)
+                    {
+                        // Set BasePolicyID to match the Id of the linked base policy
+                        siPolicy.BasePolicyID = Helper.DeserializeXMLtoPolicy(this.Policy.BaseToSupplementPath).BasePolicyID;
+                    }
+
+                    // User provided the GUID of the base policy only
+                    else
+                    {
+                        string baseId = this.Policy.BasePolicyId.ToString().ToUpper();
+
+                        // Set BasePolicyID to match the Id provided base policy ID
+                        if (baseId.Contains("{"))
+                        {
+                            siPolicy.BasePolicyID = baseId; 
+                        }
+                        else
+                        {
+                            siPolicy.BasePolicyID = "{" + baseId + "}";
+                        }
+                    }
 
                     // Reset the PolicyID guid so it is unique
                     siPolicy.PolicyID = "{" + Guid.NewGuid().ToString().ToUpper() + "}";

--- a/WDAC-Policy-Wizard/app/src/Policy.cs
+++ b/WDAC-Policy-Wizard/app/src/Policy.cs
@@ -76,12 +76,14 @@ namespace WDAC_Wizard
         // Paths:
         public string SchemaPath { get; set; }          // Path to final xml file on disk
         public string TemplatePath { get; set; }        // ReadOnly Path to template policy - TODO: make const
-        public string BaseToSupplementPath { get; set; } // Path to base policy to supplement, if applicable
         public string EditPolicyPath { get; set; }      // Path to the policy we are editing. Used for parsing.
         public string BinPath { get; set;  }
 
         public List<string> PoliciesToMerge { get; set; }
 
+        // Supplemental policy objs:
+        public string BaseToSupplementPath { get; set; } // Path to base policy to supplement, if applicable
+        public Guid BasePolicyId { get; set; }           // Id of the base policy the supplemental policy will expand
 
         // Datastructs for signing rules (and exceptions)
         public List<PolicyEKUs> EKUs { get; set; }

--- a/WDAC-Policy-Wizard/app/src/PolicyType.Designer.cs
+++ b/WDAC-Policy-Wizard/app/src/PolicyType.Designer.cs
@@ -146,7 +146,7 @@ namespace WDAC_Wizard
             this.label10.AutoSize = true;
             this.label10.Font = new System.Drawing.Font("Tahoma", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label10.ForeColor = System.Drawing.Color.Black;
-            this.label10.Location = new System.Drawing.Point(79, 78);
+            this.label10.Location = new System.Drawing.Point(75, 78);
             this.label10.Name = "label10";
             this.label10.Size = new System.Drawing.Size(28, 18);
             this.label10.TabIndex = 102;
@@ -157,7 +157,7 @@ namespace WDAC_Wizard
             this.label7.AutoSize = true;
             this.label7.Font = new System.Drawing.Font("Tahoma", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label7.ForeColor = System.Drawing.Color.Black;
-            this.label7.Location = new System.Drawing.Point(38, 46);
+            this.label7.Location = new System.Drawing.Point(34, 46);
             this.label7.Name = "label7";
             this.label7.Size = new System.Drawing.Size(106, 18);
             this.label7.TabIndex = 101;
@@ -167,7 +167,7 @@ namespace WDAC_Wizard
             // 
             this.textBoxBasePolicyID.Font = new System.Drawing.Font("Tahoma", 8.5F);
             this.textBoxBasePolicyID.ForeColor = System.Drawing.SystemColors.WindowFrame;
-            this.textBoxBasePolicyID.Location = new System.Drawing.Point(173, 43);
+            this.textBoxBasePolicyID.Location = new System.Drawing.Point(169, 43);
             this.textBoxBasePolicyID.Margin = new System.Windows.Forms.Padding(2);
             this.textBoxBasePolicyID.Name = "textBoxBasePolicyID";
             this.textBoxBasePolicyID.Size = new System.Drawing.Size(381, 25);
@@ -219,7 +219,7 @@ namespace WDAC_Wizard
             this.label5.AutoSize = true;
             this.label5.Font = new System.Drawing.Font("Tahoma", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label5.ForeColor = System.Drawing.Color.Black;
-            this.label5.Location = new System.Drawing.Point(38, 110);
+            this.label5.Location = new System.Drawing.Point(34, 110);
             this.label5.Name = "label5";
             this.label5.Size = new System.Drawing.Size(119, 18);
             this.label5.TabIndex = 97;
@@ -231,7 +231,7 @@ namespace WDAC_Wizard
             this.button_Browse.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.button_Browse.Font = new System.Drawing.Font("Tahoma", 9F);
             this.button_Browse.ForeColor = System.Drawing.Color.DodgerBlue;
-            this.button_Browse.Location = new System.Drawing.Point(564, 105);
+            this.button_Browse.Location = new System.Drawing.Point(560, 105);
             this.button_Browse.Margin = new System.Windows.Forms.Padding(2);
             this.button_Browse.Name = "button_Browse";
             this.button_Browse.Size = new System.Drawing.Size(107, 28);
@@ -243,7 +243,7 @@ namespace WDAC_Wizard
             // textBoxBasePolicyPath
             // 
             this.textBoxBasePolicyPath.Font = new System.Drawing.Font("Tahoma", 8.5F);
-            this.textBoxBasePolicyPath.Location = new System.Drawing.Point(173, 107);
+            this.textBoxBasePolicyPath.Location = new System.Drawing.Point(169, 107);
             this.textBoxBasePolicyPath.Margin = new System.Windows.Forms.Padding(2);
             this.textBoxBasePolicyPath.Name = "textBoxBasePolicyPath";
             this.textBoxBasePolicyPath.Size = new System.Drawing.Size(381, 25);
@@ -255,7 +255,7 @@ namespace WDAC_Wizard
             this.label2.AutoSize = true;
             this.label2.Font = new System.Drawing.Font("Tahoma", 9.5F);
             this.label2.ForeColor = System.Drawing.SystemColors.ActiveCaptionText;
-            this.label2.Location = new System.Drawing.Point(38, 9);
+            this.label2.Location = new System.Drawing.Point(35, 9);
             this.label2.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(621, 19);

--- a/WDAC-Policy-Wizard/app/src/PolicyType.Designer.cs
+++ b/WDAC-Policy-Wizard/app/src/PolicyType.Designer.cs
@@ -37,6 +37,9 @@ namespace WDAC_Wizard
             this.labelSupp = new System.Windows.Forms.Label();
             this.panelSupplName = new System.Windows.Forms.Panel();
             this.panelSuppl_Base = new System.Windows.Forms.Panel();
+            this.label10 = new System.Windows.Forms.Label();
+            this.label7 = new System.Windows.Forms.Label();
+            this.textBoxBasePolicyID = new System.Windows.Forms.TextBox();
             this.basePolicyValidation_Panel = new System.Windows.Forms.Panel();
             this.Verified_PictureBox = new System.Windows.Forms.PictureBox();
             this.Verified_Label = new System.Windows.Forms.Label();
@@ -118,12 +121,15 @@ namespace WDAC_Wizard
             this.panelSupplName.Location = new System.Drawing.Point(6, 165);
             this.panelSupplName.Margin = new System.Windows.Forms.Padding(2);
             this.panelSupplName.Name = "panelSupplName";
-            this.panelSupplName.Size = new System.Drawing.Size(811, 262);
+            this.panelSupplName.Size = new System.Drawing.Size(811, 344);
             this.panelSupplName.TabIndex = 11;
             this.panelSupplName.Visible = false;
             // 
             // panelSuppl_Base
             // 
+            this.panelSuppl_Base.Controls.Add(this.label10);
+            this.panelSuppl_Base.Controls.Add(this.label7);
+            this.panelSuppl_Base.Controls.Add(this.textBoxBasePolicyID);
             this.panelSuppl_Base.Controls.Add(this.basePolicyValidation_Panel);
             this.panelSuppl_Base.Controls.Add(this.label5);
             this.panelSuppl_Base.Controls.Add(this.button_Browse);
@@ -131,15 +137,52 @@ namespace WDAC_Wizard
             this.panelSuppl_Base.Controls.Add(this.label2);
             this.panelSuppl_Base.Location = new System.Drawing.Point(3, 101);
             this.panelSuppl_Base.Name = "panelSuppl_Base";
-            this.panelSuppl_Base.Size = new System.Drawing.Size(805, 143);
+            this.panelSuppl_Base.Size = new System.Drawing.Size(805, 212);
             this.panelSuppl_Base.TabIndex = 96;
             this.panelSuppl_Base.Visible = false;
+            // 
+            // label10
+            // 
+            this.label10.AutoSize = true;
+            this.label10.Font = new System.Drawing.Font("Tahoma", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label10.ForeColor = System.Drawing.Color.Black;
+            this.label10.Location = new System.Drawing.Point(79, 78);
+            this.label10.Name = "label10";
+            this.label10.Size = new System.Drawing.Size(28, 18);
+            this.label10.TabIndex = 102;
+            this.label10.Text = "OR";
+            // 
+            // label7
+            // 
+            this.label7.AutoSize = true;
+            this.label7.Font = new System.Drawing.Font("Tahoma", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label7.ForeColor = System.Drawing.Color.Black;
+            this.label7.Location = new System.Drawing.Point(38, 46);
+            this.label7.Name = "label7";
+            this.label7.Size = new System.Drawing.Size(106, 18);
+            this.label7.TabIndex = 101;
+            this.label7.Text = "Base Policy ID:";
+            // 
+            // textBoxBasePolicyID
+            // 
+            this.textBoxBasePolicyID.Font = new System.Drawing.Font("Tahoma", 8.5F);
+            this.textBoxBasePolicyID.ForeColor = System.Drawing.SystemColors.WindowFrame;
+            this.textBoxBasePolicyID.Location = new System.Drawing.Point(173, 43);
+            this.textBoxBasePolicyID.Margin = new System.Windows.Forms.Padding(2);
+            this.textBoxBasePolicyID.Name = "textBoxBasePolicyID";
+            this.textBoxBasePolicyID.Size = new System.Drawing.Size(381, 25);
+            this.textBoxBasePolicyID.TabIndex = 100;
+            this.textBoxBasePolicyID.Text = "e.g. {fd756ea8-ad7f-4e30-96bd-8778288212f6}";
+            this.textBoxBasePolicyID.Click += new System.EventHandler(this.TextBoxBasePolicyID_Selected);
+            this.textBoxBasePolicyID.TextChanged += new System.EventHandler(this.TextBoxBasePolicyID_TextChanged);
+            this.textBoxBasePolicyID.DoubleClick += new System.EventHandler(this.TextBoxBasePolicyID_Selected);
+            this.textBoxBasePolicyID.Leave += new System.EventHandler(this.TextBoxBasePolicyID_Leave);
             // 
             // basePolicyValidation_Panel
             // 
             this.basePolicyValidation_Panel.Controls.Add(this.Verified_PictureBox);
             this.basePolicyValidation_Panel.Controls.Add(this.Verified_Label);
-            this.basePolicyValidation_Panel.Location = new System.Drawing.Point(10, 87);
+            this.basePolicyValidation_Panel.Location = new System.Drawing.Point(10, 152);
             this.basePolicyValidation_Panel.Margin = new System.Windows.Forms.Padding(2);
             this.basePolicyValidation_Panel.Name = "basePolicyValidation_Panel";
             this.basePolicyValidation_Panel.Size = new System.Drawing.Size(793, 35);
@@ -176,11 +219,11 @@ namespace WDAC_Wizard
             this.label5.AutoSize = true;
             this.label5.Font = new System.Drawing.Font("Tahoma", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label5.ForeColor = System.Drawing.Color.Black;
-            this.label5.Location = new System.Drawing.Point(7, 45);
+            this.label5.Location = new System.Drawing.Point(38, 110);
             this.label5.Name = "label5";
-            this.label5.Size = new System.Drawing.Size(85, 18);
+            this.label5.Size = new System.Drawing.Size(119, 18);
             this.label5.TabIndex = 97;
-            this.label5.Text = "Base Policy:";
+            this.label5.Text = "Base Policy Path:";
             // 
             // button_Browse
             // 
@@ -188,7 +231,7 @@ namespace WDAC_Wizard
             this.button_Browse.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.button_Browse.Font = new System.Drawing.Font("Tahoma", 9F);
             this.button_Browse.ForeColor = System.Drawing.Color.DodgerBlue;
-            this.button_Browse.Location = new System.Drawing.Point(532, 40);
+            this.button_Browse.Location = new System.Drawing.Point(564, 105);
             this.button_Browse.Margin = new System.Windows.Forms.Padding(2);
             this.button_Browse.Name = "button_Browse";
             this.button_Browse.Size = new System.Drawing.Size(107, 28);
@@ -200,7 +243,7 @@ namespace WDAC_Wizard
             // textBoxBasePolicyPath
             // 
             this.textBoxBasePolicyPath.Font = new System.Drawing.Font("Tahoma", 8.5F);
-            this.textBoxBasePolicyPath.Location = new System.Drawing.Point(141, 42);
+            this.textBoxBasePolicyPath.Location = new System.Drawing.Point(173, 107);
             this.textBoxBasePolicyPath.Margin = new System.Windows.Forms.Padding(2);
             this.textBoxBasePolicyPath.Name = "textBoxBasePolicyPath";
             this.textBoxBasePolicyPath.Size = new System.Drawing.Size(381, 25);
@@ -212,12 +255,13 @@ namespace WDAC_Wizard
             this.label2.AutoSize = true;
             this.label2.Font = new System.Drawing.Font("Tahoma", 9.5F);
             this.label2.ForeColor = System.Drawing.SystemColors.ActiveCaptionText;
-            this.label2.Location = new System.Drawing.Point(4, 9);
+            this.label2.Location = new System.Drawing.Point(38, 9);
             this.label2.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(428, 19);
+            this.label2.Size = new System.Drawing.Size(621, 19);
             this.label2.TabIndex = 12;
-            this.label2.Text = "Select the policy that the supplemental policy will apply to. ";
+            this.label2.Text = "Select the policy that the supplemental policy will apply to or enter the base po" +
+    "licy ID. ";
             // 
             // button_Browse_Supp
             // 
@@ -225,7 +269,7 @@ namespace WDAC_Wizard
             this.button_Browse_Supp.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.button_Browse_Supp.Font = new System.Drawing.Font("Tahoma", 9F);
             this.button_Browse_Supp.ForeColor = System.Drawing.Color.DodgerBlue;
-            this.button_Browse_Supp.Location = new System.Drawing.Point(532, 53);
+            this.button_Browse_Supp.Location = new System.Drawing.Point(563, 53);
             this.button_Browse_Supp.Margin = new System.Windows.Forms.Padding(2);
             this.button_Browse_Supp.Name = "button_Browse_Supp";
             this.button_Browse_Supp.Size = new System.Drawing.Size(107, 28);
@@ -238,7 +282,7 @@ namespace WDAC_Wizard
             // 
             this.textBox_PolicyName.Font = new System.Drawing.Font("Tahoma", 8.5F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.textBox_PolicyName.ForeColor = System.Drawing.Color.Black;
-            this.textBox_PolicyName.Location = new System.Drawing.Point(141, 11);
+            this.textBox_PolicyName.Location = new System.Drawing.Point(172, 11);
             this.textBox_PolicyName.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.textBox_PolicyName.Name = "textBox_PolicyName";
             this.textBox_PolicyName.Size = new System.Drawing.Size(381, 25);
@@ -250,7 +294,7 @@ namespace WDAC_Wizard
             this.label6.AutoSize = true;
             this.label6.Font = new System.Drawing.Font("Tahoma", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label6.ForeColor = System.Drawing.Color.Black;
-            this.label6.Location = new System.Drawing.Point(7, 14);
+            this.label6.Location = new System.Drawing.Point(38, 14);
             this.label6.Name = "label6";
             this.label6.Size = new System.Drawing.Size(92, 18);
             this.label6.TabIndex = 8;
@@ -260,7 +304,7 @@ namespace WDAC_Wizard
             // 
             this.textBoxSuppPath.Font = new System.Drawing.Font("Tahoma", 8.5F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.textBoxSuppPath.ForeColor = System.Drawing.Color.Black;
-            this.textBoxSuppPath.Location = new System.Drawing.Point(141, 55);
+            this.textBoxSuppPath.Location = new System.Drawing.Point(172, 55);
             this.textBoxSuppPath.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.textBoxSuppPath.Name = "textBoxSuppPath";
             this.textBoxSuppPath.Size = new System.Drawing.Size(381, 25);
@@ -273,7 +317,7 @@ namespace WDAC_Wizard
             this.label_fileLocation.AutoSize = true;
             this.label_fileLocation.Font = new System.Drawing.Font("Tahoma", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label_fileLocation.ForeColor = System.Drawing.Color.Black;
-            this.label_fileLocation.Location = new System.Drawing.Point(7, 58);
+            this.label_fileLocation.Location = new System.Drawing.Point(38, 58);
             this.label_fileLocation.Name = "label_fileLocation";
             this.label_fileLocation.Size = new System.Drawing.Size(131, 18);
             this.label_fileLocation.TabIndex = 6;
@@ -474,5 +518,8 @@ namespace WDAC_Wizard
         private System.Windows.Forms.Label label9;
         private System.Windows.Forms.RadioButton radioButton_MultiplePolicy;
         private System.Windows.Forms.RadioButton radioButton_SinglePolicy;
+        private System.Windows.Forms.Label label10;
+        private System.Windows.Forms.Label label7;
+        private System.Windows.Forms.TextBox textBoxBasePolicyID;
     }
 }

--- a/WDAC-Policy-Wizard/app/src/PolicyType.cs
+++ b/WDAC-Policy-Wizard/app/src/PolicyType.cs
@@ -95,6 +95,26 @@ namespace WDAC_Wizard
         /// </summary>
         private void Button_Browse_Click(object sender, EventArgs e)
         {
+            // Verify that a Base Policy ID/GUID is not in progress or finished
+            // and confirm the user would rather continue with adding a path instead
+            if (this._Policy.BasePolicyId != Guid.Empty 
+                || !textBoxBasePolicyID.Text.Contains(Properties.Resources.ExampleBasePolicyId))
+            {
+                DialogResult res = MessageBox.Show(
+                    "Adding a Base Policy by path will remove the ID entered.\r\nAre you sure you want to continue?",
+                    "WDAC Wizard",
+                    MessageBoxButtons.YesNoCancel,
+                    MessageBoxIcon.Question);
+
+                if (res != DialogResult.Yes)
+                {
+                    return;
+                }
+
+                this._Policy.BasePolicyId = Guid.Empty; 
+                TextBoxBasePolicyID_Reformat(); 
+            }
+
             // Hide the validation panel
             basePolicyValidation_Panel.Visible = false;
 
@@ -486,6 +506,137 @@ namespace WDAC_Wizard
             catch (Exception exp)
             {
                 this.Log.AddErrorMsg("Launching webpage for multipolicy link encountered the following error", exp);
+            }
+        }
+
+        /// <summary>
+        /// Fires when the base policy ID text entered changes
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void TextBoxBasePolicyID_TextChanged(object sender, EventArgs e)
+        {
+            // Validate the text entered
+            Guid result; 
+            bool isValidGuid = Guid.TryParse(textBoxBasePolicyID.Text, out result); 
+
+            if(isValidGuid)
+            {
+                this._Policy.BasePolicyId = result; 
+                this._MainWindow.ErrorOnPage = false; 
+            }
+            else
+            {
+                this._MainWindow.ErrorOnPage = true;
+                this._MainWindow.ErrorMsg = Properties.Resources.InvalidBasePolicyId; 
+            }
+        }
+
+        /// <summary>
+        /// Textbox selected. Clears the example text, if applicable
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void TextBoxBasePolicyID_Selected(object sender, MouseEventArgs e)
+        {
+            // Check if we already have a base policy path and confirm the user would rather
+            // continue with adding a GUID instead
+            if(!String.IsNullOrEmpty(this._Policy.BaseToSupplementPath))
+            {
+                DialogResult res = MessageBox.Show(
+                    String.Format("Adding a Base Policy ID will remove the following XML path: {0}. " +
+                    "\r\nAre you sure you want to continue?",this._Policy.BaseToSupplementPath),
+                    "WDAC Wizard", 
+                    MessageBoxButtons.YesNoCancel, 
+                    MessageBoxIcon.Question);
+
+                if(res != DialogResult.Yes)
+                {
+                    return; 
+                }
+
+                // Otherwise, clear the base policy path text and objects
+                this.BaseToSupplementPath = String.Empty;
+                this._Policy.BaseToSupplementPath = String.Empty;
+                textBoxBasePolicyPath.Clear();
+
+                // Hide the validation panel
+                basePolicyValidation_Panel.Visible = false;
+            }
+
+            // Clear the example text, if applicable
+            // Set the text color to black for the user
+            if(textBoxBasePolicyID.Text.Contains(Properties.Resources.ExampleBasePolicyId))
+            {
+                textBoxBasePolicyID.Clear();
+                textBoxBasePolicyID.ForeColor = System.Drawing.Color.Black; 
+            }
+        }
+
+        /// <summary>
+        /// Textbox clicked. Clears the example text, if applicable
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void TextBoxBasePolicyID_Selected(object sender, EventArgs e)
+        {
+            // Check if we already have a base policy path and confirm the user would rather
+            // continue with adding a GUID instead
+            if (!String.IsNullOrEmpty(this._Policy.BaseToSupplementPath))
+            {
+                DialogResult res = MessageBox.Show(
+                    String.Format("Adding a Base Policy ID will remove the following XML path: {0}. " +
+                    "\r\nAre you sure you want to continue?", this._Policy.BaseToSupplementPath),
+                    "WDAC Wizard",
+                    MessageBoxButtons.YesNoCancel,
+                    MessageBoxIcon.Question);
+
+                if (res != DialogResult.Yes)
+                {
+                    return;
+                }
+
+                // Otherwise, clear the base policy path text and objects
+                this.BaseToSupplementPath = String.Empty;
+                this._Policy.BaseToSupplementPath = String.Empty;
+                textBoxBasePolicyPath.Clear();
+
+                // Hide the validation panel
+                basePolicyValidation_Panel.Visible = false;
+            }
+
+            // Clear the example text, if applicable
+            // Set the text color to black for the user
+            if (textBoxBasePolicyID.Text.Contains(Properties.Resources.ExampleBasePolicyId))
+            {
+                textBoxBasePolicyID.Clear();
+                textBoxBasePolicyID.ForeColor = System.Drawing.Color.Black;
+            }
+        }
+
+        /// <summary>
+        /// Resets the text to the original eg. {} text and color of the text
+        /// </summary>
+        private void TextBoxBasePolicyID_Reformat()
+        {
+            // Reset the text and font to original
+            textBoxBasePolicyID.Text = Properties.Resources.ExampleBasePolicyId;
+            textBoxBasePolicyID.ForeColor = System.Drawing.SystemColors.WindowFrame; 
+        }
+
+        /// <summary>
+        /// Fires on form leaving event
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void TextBoxBasePolicyID_Leave(object sender, EventArgs e)
+        {
+            // If nothing was input, reformat the text box. 
+            // Otherwise, leave it as is - good Id or in progress
+
+            if(String.IsNullOrEmpty(textBoxBasePolicyID.Text))
+            {
+                TextBoxBasePolicyID_Reformat();
             }
         }
     }

--- a/WDAC-Policy-Wizard/app/src/PolicyType.cs
+++ b/WDAC-Policy-Wizard/app/src/PolicyType.cs
@@ -520,10 +520,7 @@ namespace WDAC_Wizard
         private void TextBoxBasePolicyID_TextChanged(object sender, EventArgs e)
         {
             // Validate the text entered
-            Guid result; 
-            bool isValidGuid = Guid.TryParse(textBoxBasePolicyID.Text, out result); 
-
-            if(isValidGuid)
+            if(Guid.TryParse(textBoxBasePolicyID.Text, out Guid result))
             {
                 this._Policy.BasePolicyId = result; 
                 this._MainWindow.ErrorOnPage = false;
@@ -535,47 +532,6 @@ namespace WDAC_Wizard
             {
                 this._MainWindow.ErrorOnPage = true;
                 this._MainWindow.ErrorMsg = Properties.Resources.InvalidBasePolicyId; 
-            }
-        }
-
-        /// <summary>
-        /// Textbox selected. Clears the example text, if applicable
-        /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="e"></param>
-        private void TextBoxBasePolicyID_Selected(object sender, MouseEventArgs e)
-        {
-            // Check if we already have a base policy path and confirm the user would rather
-            // continue with adding a GUID instead
-            if(!String.IsNullOrEmpty(this._Policy.BaseToSupplementPath))
-            {
-                DialogResult res = MessageBox.Show(
-                    String.Format("Adding a Base Policy ID will remove the following XML path: {0}. " +
-                    "\r\nAre you sure you want to continue?",this._Policy.BaseToSupplementPath),
-                    "WDAC Wizard", 
-                    MessageBoxButtons.YesNoCancel, 
-                    MessageBoxIcon.Question);
-
-                if(res != DialogResult.Yes)
-                {
-                    return; 
-                }
-
-                // Otherwise, clear the base policy path text and objects
-                this.BaseToSupplementPath = String.Empty;
-                this._Policy.BaseToSupplementPath = String.Empty;
-                textBoxBasePolicyPath.Clear();
-
-                // Hide the validation panel
-                basePolicyValidation_Panel.Visible = false;
-            }
-
-            // Clear the example text, if applicable
-            // Set the text color to black for the user
-            if(textBoxBasePolicyID.Text.Contains(Properties.Resources.ExampleBasePolicyId))
-            {
-                textBoxBasePolicyID.Clear();
-                textBoxBasePolicyID.ForeColor = System.Drawing.Color.Black; 
             }
         }
 

--- a/WDAC-Policy-Wizard/app/src/PolicyType.cs
+++ b/WDAC-Policy-Wizard/app/src/PolicyType.cs
@@ -112,7 +112,10 @@ namespace WDAC_Wizard
                 }
 
                 this._Policy.BasePolicyId = Guid.Empty; 
-                TextBoxBasePolicyID_Reformat(); 
+                TextBoxBasePolicyID_Reformat();
+
+                // Log state
+                this._MainWindow.Log.AddInfoMsg("New supplemental policy flow. Clearing Policy ID and electing for base path");
             }
 
             // Hide the validation panel
@@ -523,7 +526,10 @@ namespace WDAC_Wizard
             if(isValidGuid)
             {
                 this._Policy.BasePolicyId = result; 
-                this._MainWindow.ErrorOnPage = false; 
+                this._MainWindow.ErrorOnPage = false;
+
+                // Log state
+                this._MainWindow.Log.AddInfoMsg(String.Format("New supplemental policy flow. Valid policy ID entered: ", result.ToString()));
             }
             else
             {
@@ -603,6 +609,9 @@ namespace WDAC_Wizard
 
                 // Hide the validation panel
                 basePolicyValidation_Panel.Visible = false;
+
+                // Log state
+                this._MainWindow.Log.AddInfoMsg("New supplemental policy flow. Clearing XML path and electing for base policy ID");
             }
 
             // Clear the example text, if applicable


### PR DESCRIPTION
Previously, the Wizard required a base policy XML to generate a corresponding supplemental policy. Closes #249 and adds the ability for a user to provide either the XML path or the base policy ID to generate a supplemental policy. 

The new UI on the supplemental policy creation page:

![image](https://github.com/MicrosoftDocs/WDAC-Toolkit/assets/23045608/b173bc4b-c35b-401c-93e1-3a9cb17af20f)
