### PR TITLE
WDAC Wizard policy rule option clean up

### DIFF
--- a/WDAC-Policy-Wizard/app/src/ConfigTemplate_Control.cs
+++ b/WDAC-Policy-Wizard/app/src/ConfigTemplate_Control.cs
@@ -128,6 +128,7 @@ namespace WDAC_Wizard
             Dictionary<string, Dictionary<string, string>>.KeyCollection keys = this.Policy.ConfigRules.Keys;
             foreach (string key in keys)
             {
+                // Found button name and rule-option mapping
                 if (this.Policy.ConfigRules[key]["ButtonMapping"] == buttonName) // button name match
                 {
                     if (this.Controls.Find(buttonName, true).FirstOrDefault().Tag.ToString() == "untoggle")
@@ -357,10 +358,11 @@ namespace WDAC_Wizard
         /// </summary>
         private void Toggle_Button_Click(object sender, EventArgs e)
         {
+            // Get button name from sender and set UI state
             string buttonName = ((Button)sender).Name;
             SetButtonVal(buttonName);
 
-
+            // Update the policy Rule-Options object
             this._MainWindow.Policy.ConfigRules = this.Policy.ConfigRules;
             this.Policy.EnableHVCI = this.Policy.ConfigRules["HVCI"]["CurrentValue"] == "Enabled";
             this._MainWindow.Policy.EnableHVCI = this.Policy.EnableHVCI; 

--- a/WDAC-Policy-Wizard/app/src/Helper.cs
+++ b/WDAC-Policy-Wizard/app/src/Helper.cs
@@ -2487,6 +2487,45 @@ namespace WDAC_Wizard
             return false;
         }
 
+        /// <summary>
+        /// Removes duplicate Rule-Option values and returns only unique Rule-Option instances
+        /// </summary>
+        /// <param name="duplicateRuleTypes"></param>
+        /// <returns></returns>
+        public static List<RuleType> DeDuplicateRuleOptions(List<RuleType> duplicateRuleTypes)
+        {
+            // Trivial case where null or only 1 rule-option
+            if(duplicateRuleTypes == null || duplicateRuleTypes.Count < 2)
+            {
+                return duplicateRuleTypes; 
+            }
+
+            List<RuleType> deduplicatedRuleOptions = new List<RuleType>();
+            Dictionary<OptionType, int> keyValuePairs = new Dictionary<OptionType, int>(); 
+
+            // Dedupe using Dictionary keys
+            foreach(var ruleOption in duplicateRuleTypes)
+            {
+                if (keyValuePairs.ContainsKey(ruleOption.Item))
+                {
+                    continue; 
+                }
+                keyValuePairs[ruleOption.Item] = 1; 
+            }
+
+            // Set deduplicated rule-options to the dictionary keys to guarantee unique entries
+            foreach(OptionType item in keyValuePairs.Keys)
+            {
+                RuleType ruleOption = new RuleType();
+                ruleOption.Item = item;
+
+                deduplicatedRuleOptions.Add(ruleOption);
+            }
+
+            return deduplicatedRuleOptions; 
+
+        }
+
 
         /// <summary>
         /// Formats the Rule IDs in cases of long runs of "_0"s

--- a/WDAC-Policy-Wizard/app/src/MainForm.cs
+++ b/WDAC-Policy-Wizard/app/src/MainForm.cs
@@ -215,7 +215,15 @@ namespace WDAC_Wizard
                     // Close the CustomRuleConditionsPanel
                     this._SigningRulesControl.CloseCustomRulesPanel(); 
                 }
+                else
+                {
+                    // Do not return home
+                    return; 
+                }
             }
+
+            // Re-initialize SiPolicy object
+            this.Policy = new WDAC_Policy();
 
             // Reset flags
             this.ConfigInProcess = false;
@@ -226,7 +234,6 @@ namespace WDAC_Wizard
 
             RemoveControls(); 
             ShowControlPanel(sender, e);
-            
         }
         /// <summary>
         /// Settings button on the left hand navigation panel. Loads the Settings UserControl. 
@@ -949,7 +956,7 @@ namespace WDAC_Wizard
                 this.Log.AddErrorMsg("Create Policy Rule Options -- parsing OutputSchema.xml encountered the following error ", e); 
             }
 
-            // Iterate through all the ruleoptions to remove each one
+            // Policy Rule Options derived from the final state of the rules page
             List<RuleType> ruleOptionsList = this.Policy.PolicyRuleOptions;
 
             // Assert supplemental policies and legacy policies cannot have the Supplemental (rule #17) option

--- a/WDAC-Policy-Wizard/app/src/MainForm.cs
+++ b/WDAC-Policy-Wizard/app/src/MainForm.cs
@@ -979,12 +979,15 @@ namespace WDAC_Wizard
                 this.Log.AddInfoMsg("Asserting EnabledUnsignedSystemIntegrityPolicy (rule-option 6)");
             }
 
+            // De-duplicate the Rule Options list
+            List<RuleType> dedupedRuleOptions = Helper.DeDuplicateRuleOptions(ruleOptionsList);
+
             // Convert from List<RuleType> to RuleType[]
-            RuleType[] ruleOptions = new RuleType[ruleOptionsList.Count];
+            RuleType[] ruleOptions = new RuleType[dedupedRuleOptions.Count];
             for(int i = 0; i< ruleOptions.Length; i++)
             {
-                ruleOptions[i] = ruleOptionsList[i];
-                this.Log.AddInfoMsg("Adding " + ruleOptionsList[i].Item); 
+                ruleOptions[i] = dedupedRuleOptions[i];
+                this.Log.AddInfoMsg("Adding " + dedupedRuleOptions[i].Item); 
             }
 
             try


### PR DESCRIPTION
Closes #253 and fixes 2 issues: 

1. Multiple duplicates of the same rule-option values e.g. 50 UMCI instances --> 1
2. Returning Home will overwrite the current value of the rule option state