### PR TITLE
displays correct friendly name if the FN is missing the path

### DIFF
--- a/WDAC-Policy-Wizard/app/Properties/Resources.Designer.cs
+++ b/WDAC-Policy-Wizard/app/Properties/Resources.Designer.cs
@@ -1166,6 +1166,24 @@ namespace WDAC_Wizard.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Allow by path: .
+        /// </summary>
+        internal static string TruncatedPathAllowFriendlyName {
+            get {
+                return ResourceManager.GetString("TruncatedPathAllowFriendlyName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Deny by path: .
+        /// </summary>
+        internal static string TruncatedPathDenyFriendlyName {
+            get {
+                return ResourceManager.GetString("TruncatedPathDenyFriendlyName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to When enabled, user-mode executables and scripts are validated, in addition to kernel-mode binaries..
         /// </summary>
         internal static string UMCI_Info {

--- a/WDAC-Policy-Wizard/app/Properties/Resources.resx
+++ b/WDAC-Policy-Wizard/app/Properties/Resources.resx
@@ -554,4 +554,10 @@ Do you want the Wizard to warn you about these types of path rules in the future
   <data name="InvalidBasePolicyId" xml:space="preserve">
     <value>The Base Policy Id entered does not match the format expected. E.g. {fd756ea8-ad7f-4e30-96bd-8778288212f6}</value>
   </data>
+  <data name="TruncatedPathAllowFriendlyName" xml:space="preserve">
+    <value>Allow by path: </value>
+  </data>
+  <data name="TruncatedPathDenyFriendlyName" xml:space="preserve">
+    <value>Deny by path: </value>
+  </data>
 </root>

--- a/WDAC-Policy-Wizard/app/src/SigningRules_Control.cs
+++ b/WDAC-Policy-Wizard/app/src/SigningRules_Control.cs
@@ -348,6 +348,15 @@ namespace WDAC_Wizard
                     {
                         level = "FilePath";
                         fileAttrList = "Filepath: " + filePath;
+
+                        // Fix issue where file path not in friendly name introduced in version 2.2 of the Wizard by appending filepath
+                        // FriendlyName="Allow by path: "
+                        // FriendlyName = "Deny by path: "
+                        if(friendlyName == Properties.Resources.TruncatedPathAllowFriendlyName
+                            || friendlyName == Properties.Resources.TruncatedPathDenyFriendlyName)
+                        {
+                            friendlyName += filePath; 
+                        }
                     }
 
                     // Packaged App Rule


### PR DESCRIPTION
Version 2.2 had a bug where friendly names for path rules were missing the path. That means that there are policies in the wild created by Wizard v2.2 that have 'bad' friendly names. Updated the rule table parsing logic to add in the path where it was otherwise omitted. The net is a rule like this goes from : 

![image](https://github.com/MicrosoftDocs/WDAC-Toolkit/assets/23045608/bbdc8a56-d301-4237-9c32-c1bae377b93b)


to this: 

![image](https://github.com/MicrosoftDocs/WDAC-Toolkit/assets/23045608/b59378ba-54d1-4e91-8c10-63553fcc5068)

