### PR TITLE
Fix null exception in settings page in event log workflow

### DIFF
--- a/WDAC-Policy-Wizard/app/src/EditWorkflow.Designer.cs
+++ b/WDAC-Policy-Wizard/app/src/EditWorkflow.Designer.cs
@@ -283,16 +283,16 @@ namespace WDAC_Wizard
             this.label_Progress.AutoSize = true;
             this.label_Progress.Location = new System.Drawing.Point(15, 18);
             this.label_Progress.Name = "label_Progress";
-            this.label_Progress.Size = new System.Drawing.Size(254, 17);
+            this.label_Progress.Size = new System.Drawing.Size(250, 17);
             this.label_Progress.TabIndex = 1;
-            this.label_Progress.Text = "23 / 137 Rules from Event Log Created";
+            this.label_Progress.Text = "Parsing Rules from Event Log Created";
             this.label_Progress.TextAlign = System.Drawing.ContentAlignment.TopCenter;
             // 
             // pictureBox_Progress
             // 
             this.pictureBox_Progress.Image = global::WDAC_Wizard.Properties.Resources.loading;
             this.pictureBox_Progress.InitialImage = global::WDAC_Wizard.Properties.Resources.loading;
-            this.pictureBox_Progress.Location = new System.Drawing.Point(78, 48);
+            this.pictureBox_Progress.Location = new System.Drawing.Point(76, 48);
             this.pictureBox_Progress.Name = "pictureBox_Progress";
             this.pictureBox_Progress.Size = new System.Drawing.Size(128, 128);
             this.pictureBox_Progress.SizeMode = System.Windows.Forms.PictureBoxSizeMode.AutoSize;

--- a/WDAC-Policy-Wizard/app/src/MainForm.cs
+++ b/WDAC-Policy-Wizard/app/src/MainForm.cs
@@ -1865,7 +1865,7 @@ namespace WDAC_Wizard
                     this.page1_Button.Text = "Policy Type";
                     this.page2_Button.Text = "Policy Template";
                     this.page3_Button.Text = "Policy Rules";
-                    this.page4_Button.Text = "Signing Rules";
+                    this.page4_Button.Text = "File Rules";
                     this.page5_Button.Text = "Creating Policy";
                 }
 
@@ -1881,25 +1881,45 @@ namespace WDAC_Wizard
                     this.workflow_Label.Text = "Policy Creator";
                     this.page1_Button.Text = "Policy Type";
                     this.page2_Button.Text = "Policy Rules";
-                    this.page3_Button.Text = "Signing Rules";
+                    this.page3_Button.Text = "File Rules";
                     this.page4_Button.Text = "Creating Policy";
                 }
             }
             // Policy Editor
             else if (this.Policy.PolicyWorkflow == WDAC_Policy.Workflow.Edit)
             {
-                this.workflow_Label.Visible = true;
-                this.page1_Button.Visible = true;
-                this.page2_Button.Visible = true;
-                this.page3_Button.Visible = true;
-                this.page4_Button.Visible = true;
-                this.page5_Button.Visible = false;
+                // Editing a policy but not creating one from event logs
+                if(this.EditWorkflow == EditWorkflowType.Edit)
+                {
+                    this.workflow_Label.Visible = true;
+                    this.page1_Button.Visible = true;
+                    this.page2_Button.Visible = true;
+                    this.page3_Button.Visible = true;
+                    this.page4_Button.Visible = true;
+                    this.page5_Button.Visible = false;
 
-                this.workflow_Label.Text = "Policy Editor";
-                this.page1_Button.Text = "Select Policy";
-                this.page2_Button.Text = "Policy Rules";
-                this.page3_Button.Text = "Signing Rules";
-                this.page4_Button.Text = "Creating Policy";
+                    this.workflow_Label.Text = "Policy Editor";
+                    this.page1_Button.Text = "Select Policy";
+                    this.page2_Button.Text = "Policy Rules";
+                    this.page3_Button.Text = "File Rules";
+
+                    this.page4_Button.Text = "Creating Policy";
+                }
+                // Creating a policy from event log or advanced hunting
+                else if(this.EditWorkflow == EditWorkflowType.EventLog)
+                {
+                    this.workflow_Label.Visible = true;
+                    this.page1_Button.Visible = true;
+                    this.page2_Button.Visible = true;
+                    this.page3_Button.Visible = true;
+                    this.page4_Button.Visible = false;
+                    this.page5_Button.Visible = false;
+
+                    this.workflow_Label.Text = "Policy Editor";
+                    this.page1_Button.Text = "Select Policy";
+                    this.page2_Button.Text = "File Rules";
+                    this.page3_Button.Text = "Creating Policy";
+                }
             }
             
             // Policy Merger
@@ -1938,7 +1958,7 @@ namespace WDAC_Wizard
                 break;
 
             case 2:
-                if(this.view == 3)
+                if(this.view == 3) // Merge
                 {
                     // Building page
                     this.page1_Button.Enabled = false;
@@ -1947,8 +1967,8 @@ namespace WDAC_Wizard
                     this.page4_Button.Enabled = false;
                     this.page5_Button.Enabled = false;
 
-                    this.settings_Button.Enabled = false; 
-                }
+                    this.settings_Button.Enabled = false; // disable settings button to prevent writing to flushed/closed logger
+                    }
                 else
                 {
                     this.page1_Button.Enabled = true;
@@ -1961,32 +1981,61 @@ namespace WDAC_Wizard
                 break;
 
             case 3:
-                this.page1_Button.Enabled = true;
-                this.page2_Button.Enabled = true;
-                this.page3_Button.Enabled = true;
-                this.page4_Button.Enabled = false;
-                this.page5_Button.Enabled = false;
-                controlHighlight_Panel.Location = new System.Drawing.Point(this.page3_Button.Location.X - X_OFFSET, this.page3_Button.Location.Y + Y_OFFSET);
-                break;
 
-            case 4:
-                if(this.view == 2)
+                if(this.view ==2 && this.EditWorkflow == EditWorkflowType.EventLog) // event log or AH building page
                 {
-                    // Building page
                     this.page1_Button.Enabled = false;
                     this.page2_Button.Enabled = false;
                     this.page3_Button.Enabled = false;
                     this.page4_Button.Enabled = false;
+                    this.page5_Button.Enabled = false;
 
-                    this.settings_Button.Enabled = false;
+                    this.settings_Button.Enabled = false; // disable settings button to prevent writing to flushed/closed logger
                 }
                 else
                 {
                     this.page1_Button.Enabled = true;
                     this.page2_Button.Enabled = true;
                     this.page3_Button.Enabled = true;
-                    this.page4_Button.Enabled = true;
+                    this.page4_Button.Enabled = false;
                     this.page5_Button.Enabled = false;
+                }
+                controlHighlight_Panel.Location = new System.Drawing.Point(this.page3_Button.Location.X - X_OFFSET, this.page3_Button.Location.Y + Y_OFFSET);
+                break;
+
+            case 4:
+                if(this.view == 2) // Edit
+                {
+                    // Building page
+                    this.page1_Button.Enabled = false;
+                    this.page2_Button.Enabled = false;
+                    this.page3_Button.Enabled = false;
+                    this.page4_Button.Enabled = false;
+                    this.page5_Button.Enabled = false;
+
+                    this.settings_Button.Enabled = false; // disable settings button to prevent writing to flushed/closed logger
+                }
+                else
+                {
+                    if(this.Policy._PolicyType == WDAC_Policy.PolicyType.SupplementalPolicy) // build page for supplemental policies
+                    {
+                        this.page1_Button.Enabled = false;
+                        this.page2_Button.Enabled = false;
+                        this.page3_Button.Enabled = false;
+                        this.page4_Button.Enabled = false;
+                        this.page5_Button.Enabled = false;
+
+                        this.settings_Button.Enabled = false; // disable settings button to prevent writing to flushed/closed logger
+                    }
+
+                    else
+                    {
+                        this.page1_Button.Enabled = true;
+                        this.page2_Button.Enabled = true;
+                        this.page3_Button.Enabled = true;
+                        this.page4_Button.Enabled = true;
+                        this.page5_Button.Enabled = false;
+                    }
                 }
                     
                 controlHighlight_Panel.Location = new System.Drawing.Point(this.page4_Button.Location.X - X_OFFSET, this.page4_Button.Location.Y + Y_OFFSET);

--- a/WDAC-Policy-Wizard/app/src/SettingsPage.Designer.cs
+++ b/WDAC-Policy-Wizard/app/src/SettingsPage.Designer.cs
@@ -95,7 +95,7 @@ namespace WDAC_Wizard
             this.label3.Name = "label3";
             this.label3.Size = new System.Drawing.Size(243, 42);
             this.label3.TabIndex = 3;
-            this.label3.Text = "2022 Microsoft Corporation ©\r\nJordan.Geurten@microsoft.com";
+            this.label3.Text = "2019 Microsoft Corporation ©\r\nJordan.Geurten@microsoft.com";
             // 
             // terms_Label
             // 

--- a/WDAC-Policy-Wizard/app/src/SettingsPage.cs
+++ b/WDAC-Policy-Wizard/app/src/SettingsPage.cs
@@ -44,7 +44,7 @@ namespace WDAC_Wizard
             System.Reflection.Assembly assembly = System.Reflection.Assembly.GetExecutingAssembly();
             FileVersionInfo versionInfo = FileVersionInfo.GetVersionInfo(assembly.Location);
 
-            this.appVersion_Label.Text = String.Format("App Version {0}.22", versionInfo.FileVersion);
+            this.appVersion_Label.Text = "App Version: " + versionInfo.FileVersion;
         }
 
         //


### PR DESCRIPTION
Fixed an issue where selecting the "Settings" button after building policy from AH or evtx could result in a crash writing to a closed  logger instance