### PR TITLE
Fixed bug in version 2.3.1.0 where supplemental polices under edit do not show any rules

### DIFF
--- a/WDAC-Policy-Wizard/app/src/ConfigTemplate_Control.cs
+++ b/WDAC-Policy-Wizard/app/src/ConfigTemplate_Control.cs
@@ -558,12 +558,7 @@ namespace WDAC_Wizard
             this._MainWindow.Policy.siPolicy = this.Policy.siPolicy;
 
             // Copy template to temp folder for reading and writing unless template already in temp folder (event log conversion)
-            if(this.Policy._PolicyType == WDAC_Policy.PolicyType.SupplementalPolicy)
-            {
-                string xmlTemplateToWrite = Path.Combine(this._MainWindow.ExeFolderPath, "Empty_Supplemental.xml");
-                this._MainWindow.Policy.TemplatePath = xmlTemplateToWrite;
-            }
-            else if(!xmlPathToRead.Contains(this._MainWindow.TempFolderPath))
+            if(!xmlPathToRead.Contains(this._MainWindow.TempFolderPath))
             {
                 string xmlTemplateToWrite = Path.Combine(this._MainWindow.TempFolderPath, Path.GetFileName(xmlPathToRead));
                 File.Copy(xmlPathToRead, xmlTemplateToWrite, true);

--- a/WDAC-Policy-Wizard/app/src/MainForm.cs
+++ b/WDAC-Policy-Wizard/app/src/MainForm.cs
@@ -1061,8 +1061,6 @@ namespace WDAC_Wizard
             // 5. Format IDs in the case of Issue #247
 
             this.Log.AddInfoMsg("-- Set Additional Parameters --");
-
-            
             SiPolicy siPolicy = Helper.DeserializeXMLtoPolicy(this.Policy.SchemaPath); 
 
             if(siPolicy == null)

--- a/WDAC-Policy-Wizard/app/src/SigningRules_Control.cs
+++ b/WDAC-Policy-Wizard/app/src/SigningRules_Control.cs
@@ -436,14 +436,15 @@ namespace WDAC_Wizard
         /// </summary>
         private bool ReadSetRules(object sender, EventArgs e)
         {
-            // Always going to have to parse an XML file - either going to be pre-exisiting policy (edit mode, supplmental policy) or template policy (new base)
-            if (this._MainWindow.Policy.TemplatePath != null)
+            // Always going to have to parse an XML file - either going to be pre-exisiting policy (edit mode, supplmental policy)
+            // or template policy (new base)
+            if (this._MainWindow.Policy.PolicyWorkflow == WDAC_Policy.Workflow.Edit)
             {
-                this.XmlPath = this._MainWindow.Policy.TemplatePath;
+                this.XmlPath = this._MainWindow.Policy.EditPolicyPath; // existing policy - read from policy under edit path
             }
             else
             {
-                this.XmlPath = this._MainWindow.Policy.EditPolicyPath;
+                this.XmlPath = this._MainWindow.Policy.TemplatePath; // New policy - read from template
             }
                 
             this.Log.AddInfoMsg("--- Reading Set Signing Rules Beginning ---");


### PR DESCRIPTION
This issue was reported this morning by a customer who was attempting to edit their WDAC supplemental policy. The issue is that the Wizard is reading from the empty supplemental policy instead of their existing policy. Confirmed that this does not affect base policies under edit, just supplemental policies. 

The fix is pointing the Wizard at the template path, which is just a copy of the supplemental policy file in the temp folder of the AppData Local folder. 



![image](https://github.com/MicrosoftDocs/WDAC-Toolkit/assets/23045608/09d2d90f-9112-46d6-95df-f2e4f042673e)
