### PR TITLE
Fixed supplemental policy inheriting rules from base policy issue

### DIFF
--- a/WDAC-Policy-Wizard/app/Properties/Resources.Designer.cs
+++ b/WDAC-Policy-Wizard/app/Properties/Resources.Designer.cs
@@ -350,6 +350,15 @@ namespace WDAC_Wizard.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Empty_Supplemental.xml.
+        /// </summary>
+        internal static string EmptyWdacSupplementalXml {
+            get {
+                return ResourceManager.GetString("EmptyWdacSupplementalXml", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to EmptyWDAC.xml.
         /// </summary>
         internal static string EmptyWdacXml {

--- a/WDAC-Policy-Wizard/app/Properties/Resources.resx
+++ b/WDAC-Policy-Wizard/app/Properties/Resources.resx
@@ -560,4 +560,7 @@ Do you want the Wizard to warn you about these types of path rules in the future
   <data name="TruncatedPathDenyFriendlyName" xml:space="preserve">
     <value>Deny by path: </value>
   </data>
+  <data name="EmptyWdacSupplementalXml" xml:space="preserve">
+    <value>Empty_Supplemental.xml</value>
+  </data>
 </root>

--- a/WDAC-Policy-Wizard/app/src/ConfigTemplate_Control.cs
+++ b/WDAC-Policy-Wizard/app/src/ConfigTemplate_Control.cs
@@ -560,23 +560,22 @@ namespace WDAC_Wizard
             // Copy template to temp folder for reading and writing unless template already in temp folder (event log conversion)
             if(!xmlPathToRead.Contains(this._MainWindow.TempFolderPath))
             {
-                // Set template path to the xmlPathToRead except for the suppplemental policy case
-                if (this.Policy._PolicyType != WDAC_Policy.PolicyType.SupplementalPolicy)
-                {
-                    string xmlTemplateToWrite = Path.Combine(this._MainWindow.TempFolderPath, Path.GetFileName(xmlPathToRead));
-                    File.Copy(xmlPathToRead, xmlTemplateToWrite, true);
-                    this._MainWindow.Policy.TemplatePath = xmlTemplateToWrite;
-                }
+                string xmlTemplateToWrite = Path.Combine(this._MainWindow.TempFolderPath, Path.GetFileName(xmlPathToRead));
+                File.Copy(xmlPathToRead, xmlTemplateToWrite, true);
+                this._MainWindow.Policy.TemplatePath = xmlTemplateToWrite;
             }
             else
             {
-                // Set template path to the xmlPathToRead except for the suppplemental policy case
-                if(this.Policy._PolicyType != WDAC_Policy.PolicyType.SupplementalPolicy)
-                {
-                    this._MainWindow.Policy.TemplatePath = xmlPathToRead;
-                }
+                this._MainWindow.Policy.TemplatePath = xmlPathToRead;
             }
-            
+
+            // Set TemplatePath to none for NEW Supplemental policy flow
+            if (this.Policy.PolicyWorkflow == WDAC_Policy.Workflow.New
+                && this.Policy._PolicyType == WDAC_Policy.PolicyType.SupplementalPolicy)
+            {
+                this._MainWindow.Policy.TemplatePath = null; 
+            }
+
             return true; 
         }
 

--- a/WDAC-Policy-Wizard/app/src/ConfigTemplate_Control.cs
+++ b/WDAC-Policy-Wizard/app/src/ConfigTemplate_Control.cs
@@ -560,13 +560,21 @@ namespace WDAC_Wizard
             // Copy template to temp folder for reading and writing unless template already in temp folder (event log conversion)
             if(!xmlPathToRead.Contains(this._MainWindow.TempFolderPath))
             {
-                string xmlTemplateToWrite = Path.Combine(this._MainWindow.TempFolderPath, Path.GetFileName(xmlPathToRead));
-                File.Copy(xmlPathToRead, xmlTemplateToWrite, true);
-                this._MainWindow.Policy.TemplatePath = xmlTemplateToWrite;
+                // Set template path to the xmlPathToRead except for the suppplemental policy case
+                if (this.Policy._PolicyType != WDAC_Policy.PolicyType.SupplementalPolicy)
+                {
+                    string xmlTemplateToWrite = Path.Combine(this._MainWindow.TempFolderPath, Path.GetFileName(xmlPathToRead));
+                    File.Copy(xmlPathToRead, xmlTemplateToWrite, true);
+                    this._MainWindow.Policy.TemplatePath = xmlTemplateToWrite;
+                }
             }
             else
             {
-                this._MainWindow.Policy.TemplatePath = xmlPathToRead; 
+                // Set template path to the xmlPathToRead except for the suppplemental policy case
+                if(this.Policy._PolicyType != WDAC_Policy.PolicyType.SupplementalPolicy)
+                {
+                    this._MainWindow.Policy.TemplatePath = xmlPathToRead;
+                }
             }
             
             return true; 

--- a/WDAC-Policy-Wizard/app/src/SigningRules_Control.cs
+++ b/WDAC-Policy-Wizard/app/src/SigningRules_Control.cs
@@ -436,18 +436,32 @@ namespace WDAC_Wizard
         /// </summary>
         private bool ReadSetRules(object sender, EventArgs e)
         {
-            // Always going to have to parse an XML file - either going to be pre-exisiting policy (edit mode, supplmental policy)
-            // or template policy (new base)
+            // Always going to have to parse an XML file 
+            // Edit Policies - Read from the EditPolicy Path
+            // New Policies
+            //     - Read from Template path if Base Policy
+            //     - Read from Empty Supplemental if Supplemental Policy i.e. no rules to show
             if (this._MainWindow.Policy.PolicyWorkflow == WDAC_Policy.Workflow.Edit)
             {
                 this.XmlPath = this._MainWindow.Policy.EditPolicyPath; // existing policy - read from policy under edit path
             }
-            else
+            else // New Policy
             {
-                this.XmlPath = this._MainWindow.Policy.TemplatePath; // New policy - read from template
+                // Base Policy - Read from Template Path
+                if(this._MainWindow.Policy._PolicyType == WDAC_Policy.PolicyType.BasePolicy)
+                {
+                    this.XmlPath = this._MainWindow.Policy.TemplatePath; 
+                }
+                
+                // Supplemental Policy - Read from Empty_Supplemental.xml
+                else
+                {
+                    this.XmlPath = System.IO.Path.Combine(this._MainWindow.ExeFolderPath, Properties.Resources.EmptyWdacSupplementalXml);
+                }
             }
                 
             this.Log.AddInfoMsg("--- Reading Set Signing Rules Beginning ---");
+            this.Log.AddInfoMsg("Reading file rules from path: " + this.XmlPath); 
 
             try
             {
@@ -464,7 +478,9 @@ namespace WDAC_Wizard
                                                     MessageBoxIcon.Error);
 
                 if (res == DialogResult.OK)
+                {
                     this._MainWindow.ResetWorkflow(sender, e);
+                }
                 return false; 
             }
             


### PR DESCRIPTION
The Issue:

Version 2.3.1.1 introduced a bug where new supplemental policies would inherit the entire set of file and signature rules from the base policy it is extending in the UI and the resulting XML. 

The Fix: 

This changes ensures the new policy - supplemental flow sets the Template Path attribute to none to prevent merging. The UI table parsing code is now forced to read the Empty_Supplemental.xml file as well. 

Tested: 
1. New Base policy creation
2. New supplemental policy creation flow
3. Editing base and supplemental policy flow

Closes #270 