### PR TITLE
Fixed PFN deny bug by setting min version to 65535...

### DIFF
--- a/WDAC-Policy-Wizard/app/Properties/Resources.Designer.cs
+++ b/WDAC-Policy-Wizard/app/Properties/Resources.Designer.cs
@@ -290,15 +290,6 @@ namespace WDAC_Wizard.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to 1.0.0.0.
-        /// </summary>
-        internal static string DefaultPFNVersion {
-            get {
-                return ResourceManager.GetString("DefaultPFNVersion", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to 0.0.0.0.
         /// </summary>
         internal static string DefaultVersionString {
@@ -713,6 +704,15 @@ namespace WDAC_Wizard.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to 65535.65535.65535.65535.
+        /// </summary>
+        internal static string MaxVersion {
+            get {
+                return ResourceManager.GetString("MaxVersion", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>
         internal static System.Drawing.Bitmap merge {
@@ -1077,7 +1077,7 @@ namespace WDAC_Wizard.Properties {
         /// <summary>
         ///   Looks up a localized string similar to &lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;
         ///&lt;SiPolicy xmlns=&quot;urn:schemas-microsoft-com:sipolicy&quot; PolicyType=&quot;Base Policy&quot;&gt;
-        ///  &lt;VersionEx&gt;10.0.1.0&lt;/VersionEx&gt;
+        ///  &lt;VersionEx&gt;10.2.2.0&lt;/VersionEx&gt;
         ///  &lt;PlatformID&gt;{2E07F7E4-194C-4D20-B7C9-6F44A6C5A234}&lt;/PlatformID&gt;
         ///  &lt;Rules&gt;
         ///    &lt;Rule&gt;

--- a/WDAC-Policy-Wizard/app/Properties/Resources.resx
+++ b/WDAC-Policy-Wizard/app/Properties/Resources.resx
@@ -378,9 +378,6 @@ with a version at or above this specified file version number.</value>
   <data name="RevokedAsUnsigned_Info" xml:space="preserve">
     <value>When enabled, WDAC will treat revoked and expired binaries as unsigned. </value>
   </data>
-  <data name="DefaultPFNVersion" xml:space="preserve">
-    <value>1.0.0.0</value>
-  </data>
   <data name="HashEmptyList_Error" xml:space="preserve">
     <value>Invalid custom hashes specified. The WDAC Wizard was unable to detect at least 1 hash.</value>
   </data>
@@ -562,5 +559,8 @@ Do you want the Wizard to warn you about these types of path rules in the future
   </data>
   <data name="EmptyWdacSupplementalXml" xml:space="preserve">
     <value>Empty_Supplemental.xml</value>
+  </data>
+  <data name="MaxVersion" xml:space="preserve">
+    <value>65535.65535.65535.65535</value>
   </data>
 </root>

--- a/WDAC-Policy-Wizard/app/src/Helper.cs
+++ b/WDAC-Policy-Wizard/app/src/Helper.cs
@@ -1475,7 +1475,7 @@ namespace WDAC_Wizard
                 {
                     Allow allowRule = new Allow();
                     allowRule.PackageFamilyName = pfn;
-                    allowRule.MinimumFileVersion = Properties.Resources.DefaultPFNVersion;
+                    allowRule.MinimumFileVersion = Properties.Resources.DefaultVersionString;
                     allowRule.FriendlyName = String.Format("Allow packaged app by Package Family Name (PFN): {0}", pfn);
                     allowRule.ID = String.Format("ID_ALLOW_PFN_{0}", cFileAllowRules);
                     cFileAllowRules++;
@@ -1490,7 +1490,7 @@ namespace WDAC_Wizard
                 {
                     Deny denyRule = new Deny();
                     denyRule.PackageFamilyName = pfn;
-                    denyRule.MinimumFileVersion = Properties.Resources.DefaultPFNVersion;
+                    denyRule.PackageVersion = Properties.Resources.MaxVersion;
                     denyRule.FriendlyName = String.Format("Deny packaged app by Package Family Name (PFN): {0}", pfn);
                     denyRule.ID = String.Format("ID_DENY_PFN_{0}", cFileDenyRules);
                     cFileDenyRules++;


### PR DESCRIPTION
**Issue:**
Deny PFN rules were ineffective when created by the Wizard. They deny rules were not setting the proper MinFileVersion

**Fix:**
The Wizard now sets 65535.65535.65535.65535 as the MinFileVersion for all deny PFN rules. Allow rules now have 0.0.0.0 as the MinFileVersion - 

![image](https://github.com/MicrosoftDocs/WDAC-Toolkit/assets/23045608/17ac844d-5944-4fe4-913a-9b4a55e35087)

Closing #288 
