### PR TITLE
Fixed build break and bug where unsign supp would not compile

### DIFF
--- a/WDAC-Policy-Wizard/app/Properties/Resources.Designer.cs
+++ b/WDAC-Policy-Wizard/app/Properties/Resources.Designer.cs
@@ -800,16 +800,6 @@ namespace WDAC_Wizard.Properties {
         /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>
-        internal static System.Drawing.Bitmap newPolicy1 {
-            get {
-                object obj = ResourceManager.GetObject("newPolicy1", resourceCulture);
-                return ((System.Drawing.Bitmap)(obj));
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized resource of type System.Drawing.Bitmap.
-        /// </summary>
         internal static System.Drawing.Bitmap next {
             get {
                 object obj = ResourceManager.GetObject("next", resourceCulture);

--- a/WDAC-Policy-Wizard/app/Properties/Resources.resx
+++ b/WDAC-Policy-Wizard/app/Properties/Resources.resx
@@ -276,9 +276,6 @@ with a version at or above this specified file version number.</value>
   <data name="WHQL_Info" xml:space="preserve">
     <value>When enabled, kernel-mode drivers must be WHQL-signed. Legacy cross-signed drivers will not be trusted.</value>
   </data>
-  <data name="newPolicy1" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\imgs\newPolicy.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
   <data name="gear" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\imgs\gear.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
@@ -586,6 +583,7 @@ Do you want the Wizard to warn you about these types of path rules in the future
   </data>
   <data name="white_minus_button" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\imgs\white-minus-button.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
   <data name="MaxVersion" xml:space="preserve">
     <value>65535.65535.65535.65535</value>
   </data>

--- a/WDAC-Policy-Wizard/app/src/BuildPage.Designer.cs
+++ b/WDAC-Policy-Wizard/app/src/BuildPage.Designer.cs
@@ -176,7 +176,7 @@ namespace WDAC_Wizard
             this.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.Name = "BuildPage";
             this.Size = new System.Drawing.Size(1443, 833);
-            this.Paint += new System.Windows.Forms.PaintEventHandler(this.BuildPage_Paint);
+            this.Validated += new System.EventHandler(this.BuildPage_Validated);
             this.finishPanel.ResumeLayout(false);
             this.finishPanel.PerformLayout();
             this.ResumeLayout(false);

--- a/WDAC-Policy-Wizard/app/src/BuildPage.cs
+++ b/WDAC-Policy-Wizard/app/src/BuildPage.cs
@@ -201,7 +201,7 @@ namespace WDAC_Wizard
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void BuildPage_Paint(object sender, PaintEventArgs e)
+        private void BuildPage_Validated(object sender, EventArgs e)
         {
             // Set Controls Color (e.g. Panels)
             SetControlsColor();

--- a/WDAC-Policy-Wizard/app/src/ConfigTemplate_Control.Designer.cs
+++ b/WDAC-Policy-Wizard/app/src/ConfigTemplate_Control.Designer.cs
@@ -817,8 +817,8 @@ namespace WDAC_Wizard
             this.Name = "ConfigTemplate_Control";
             this.Size = new System.Drawing.Size(1208, 782);
             this.Load += new System.EventHandler(this.SetDefaultButtonVals);
-            this.Paint += new System.Windows.Forms.PaintEventHandler(this.ConfigTemplate_Control_Paint);
             this.MouseHover += new System.EventHandler(this.RuleLabel_Hover);
+            this.Validated += new System.EventHandler(this.ConfigTemplate_Control_Validated);
             this.panel_AdvancedOptions.ResumeLayout(false);
             this.panel_AdvancedOptions.PerformLayout();
             this.ResumeLayout(false);

--- a/WDAC-Policy-Wizard/app/src/ConfigTemplate_Control.cs
+++ b/WDAC-Policy-Wizard/app/src/ConfigTemplate_Control.cs
@@ -814,7 +814,7 @@ namespace WDAC_Wizard
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void ConfigTemplate_Control_Paint(object sender, PaintEventArgs e)
+        private void ConfigTemplate_Control_Validated(object sender, EventArgs e)
         {
             // Set Controls Color (e.g. Panels)
             SetControlsColor();
@@ -828,9 +828,9 @@ namespace WDAC_Wizard
             SetFormBackColor();
 
             // Set toggle colors
-            List<Button> toggles = new List<Button>(); 
+            List<Button> toggles = new List<Button>();
             GetTogglesRecursive(this, toggles);
-            SetToggleColors(toggles); 
+            SetToggleColors(toggles);
         }
 
         /// <summary>

--- a/WDAC-Policy-Wizard/app/src/ConfigTemplate_Control.cs
+++ b/WDAC-Policy-Wizard/app/src/ConfigTemplate_Control.cs
@@ -554,6 +554,14 @@ namespace WDAC_Wizard
                         {
                             this.Policy.ConfigRules[name]["CurrentValue"] = value;
                         }
+
+                        // Mirror the value for signed policy based on the value in the base policy
+                        // This will allow for the resulting xml to compile to bin
+                        if(name == "UnsignedSystemIntegrityPolicy")
+                        {
+                            SetRuleOptionState(name);
+                        }
+
                     }
                     else
                     {
@@ -611,7 +619,8 @@ namespace WDAC_Wizard
                 // User only provided a base policy ID to expand
                 if(this._MainWindow.Policy.BasePolicyId != Guid.Empty)
                 {
-                    xmlPathToRead = System.IO.Path.Combine(this._MainWindow.ExeFolderPath, Properties.Resources.EmptyWdacXml);
+                    xmlPathToRead = System.IO.Path.Combine(this._MainWindow.ExeFolderPath, 
+                                                            Properties.Resources.EmptyWdacSupplementalXml);
                 }
                 // User provided a path to the base policy
                 else

--- a/WDAC-Policy-Wizard/app/src/CustomRuleConditionsPanel.Designer.cs
+++ b/WDAC-Policy-Wizard/app/src/CustomRuleConditionsPanel.Designer.cs
@@ -96,9 +96,9 @@
             this.button_CreateRule = new System.Windows.Forms.Button();
             this.button_Next = new System.Windows.Forms.Button();
             this.control_Panel = new System.Windows.Forms.Panel();
-            this.workflow_Label = new System.Windows.Forms.Label();
             this.page2_Button = new System.Windows.Forms.Button();
             this.page1_Button = new System.Windows.Forms.Button();
+            this.workflow_Label = new System.Windows.Forms.Label();
             this.controlHighlight_Panel = new System.Windows.Forms.Panel();
             this.headerLabel = new System.Windows.Forms.Label();
             this.headerPanel = new System.Windows.Forms.Panel();
@@ -1043,17 +1043,6 @@
             this.control_Panel.TabIndex = 108;
             this.control_Panel.Tag = "IgnoreDarkMode";
             // 
-            // workflow_Label
-            // 
-            this.workflow_Label.AutoSize = true;
-            this.workflow_Label.Font = new System.Drawing.Font("Tahoma", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.workflow_Label.Location = new System.Drawing.Point(11, 9);
-            this.workflow_Label.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
-            this.workflow_Label.Name = "workflow_Label";
-            this.workflow_Label.Size = new System.Drawing.Size(82, 21);
-            this.workflow_Label.TabIndex = 40;
-            this.workflow_Label.Text = "File Rules";
-            // 
             // page2_Button
             // 
             this.page2_Button.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
@@ -1094,6 +1083,17 @@
             this.page1_Button.Text = "Rule Conditions";
             this.page1_Button.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this.page1_Button.UseVisualStyleBackColor = false;
+            // 
+            // workflow_Label
+            // 
+            this.workflow_Label.AutoSize = true;
+            this.workflow_Label.Font = new System.Drawing.Font("Tahoma", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.workflow_Label.Location = new System.Drawing.Point(11, 9);
+            this.workflow_Label.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.workflow_Label.Name = "workflow_Label";
+            this.workflow_Label.Size = new System.Drawing.Size(82, 21);
+            this.workflow_Label.TabIndex = 40;
+            this.workflow_Label.Text = "File Rules";
             // 
             // controlHighlight_Panel
             // 
@@ -1191,7 +1191,7 @@
             this.Text = "Custom Rules ";
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.CustomRulesPanel_FormClosing);
             this.Load += new System.EventHandler(this.OnLoad);
-            this.Paint += new System.Windows.Forms.PaintEventHandler(this.CustomRuleConditionsPanel_Paint);
+            this.Validated += new System.EventHandler(this.CustomRuleConditionsPanel_Validated);
             this.panel_CustomRules.ResumeLayout(false);
             this.panel_CustomRules.PerformLayout();
             this.panelPackagedApps.ResumeLayout(false);

--- a/WDAC-Policy-Wizard/app/src/CustomRuleConditionsPanel.cs
+++ b/WDAC-Policy-Wizard/app/src/CustomRuleConditionsPanel.cs
@@ -2476,13 +2476,14 @@ namespace WDAC_Wizard
             e.Effect = DragDropEffects.Move;
         }
 
+
         /// <summary>
         /// Fires on Load, Paint, Refresh. 
         /// Sets the colors on the UI elements for Dark and Light mode
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void CustomRuleConditionsPanel_Paint(object sender, PaintEventArgs e)
+        private void CustomRuleConditionsPanel_Validated(object sender, EventArgs e)
         {
             // Set Controls Color (e.g. Panels, buttons)
             SetControlsColor();
@@ -2495,7 +2496,7 @@ namespace WDAC_Wizard
             // Set Radio Buttons Color
             List<RadioButton> radioButtons = new List<RadioButton>();
             GetRadioButtonsRecursive(this, radioButtons);
-            SetRadioButtonsColor(radioButtons); 
+            SetRadioButtonsColor(radioButtons);
 
             // Set Side Panel
             SetSidePanelColor();
@@ -2509,7 +2510,7 @@ namespace WDAC_Wizard
         /// </summary>
         public void ForceRepaint()
         {
-            CustomRuleConditionsPanel_Paint(null, null); 
+            CustomRuleConditionsPanel_Validated(null, null); 
         }
 
         /// <summary>

--- a/WDAC-Policy-Wizard/app/src/EditWorkflow.Designer.cs
+++ b/WDAC-Policy-Wizard/app/src/EditWorkflow.Designer.cs
@@ -49,8 +49,8 @@ namespace WDAC_Wizard
             this.button_Parse_LogFile = new System.Windows.Forms.Button();
             this.backgroundWorker = new System.ComponentModel.BackgroundWorker();
             this.panel_Progress = new System.Windows.Forms.Panel();
-            this.label_Progress = new System.Windows.Forms.Label();
             this.pictureBox_Progress = new System.Windows.Forms.PictureBox();
+            this.label_Progress = new System.Windows.Forms.Label();
             this.label_LearnMore = new System.Windows.Forms.Label();
             this.radioButton_EventConversion = new System.Windows.Forms.RadioButton();
             this.radioButton_EditXML = new System.Windows.Forms.RadioButton();
@@ -278,18 +278,6 @@ namespace WDAC_Wizard
             this.panel_Progress.TabIndex = 114;
             this.panel_Progress.Visible = false;
             // 
-            // label_Progress
-            // 
-            this.label_Progress.AutoSize = true;
-            this.label_Progress.BackColor = System.Drawing.Color.Transparent;
-            this.label_Progress.Location = new System.Drawing.Point(15, 18);
-            this.label_Progress.Name = "label_Progress";
-            this.label_Progress.Size = new System.Drawing.Size(250, 17);
-            this.label_Progress.TabIndex = 1;
-            this.label_Progress.Tag = "IgnoreDarkMode";
-            this.label_Progress.Text = "Parsing Rules from Event Log Created";
-            this.label_Progress.TextAlign = System.Drawing.ContentAlignment.TopCenter;
-            // 
             // pictureBox_Progress
             // 
             this.pictureBox_Progress.BackColor = System.Drawing.Color.Transparent;
@@ -302,6 +290,18 @@ namespace WDAC_Wizard
             this.pictureBox_Progress.TabIndex = 0;
             this.pictureBox_Progress.TabStop = false;
             this.pictureBox_Progress.Tag = "IgnoreDarkMode";
+            // 
+            // label_Progress
+            // 
+            this.label_Progress.AutoSize = true;
+            this.label_Progress.BackColor = System.Drawing.Color.Transparent;
+            this.label_Progress.Location = new System.Drawing.Point(15, 18);
+            this.label_Progress.Name = "label_Progress";
+            this.label_Progress.Size = new System.Drawing.Size(250, 17);
+            this.label_Progress.TabIndex = 1;
+            this.label_Progress.Tag = "IgnoreDarkMode";
+            this.label_Progress.Text = "Parsing Rules from Event Log Created";
+            this.label_Progress.TextAlign = System.Drawing.ContentAlignment.TopCenter;
             // 
             // label_LearnMore
             // 
@@ -578,7 +578,7 @@ namespace WDAC_Wizard
             this.Margin = new System.Windows.Forms.Padding(2);
             this.Name = "EditWorkflow";
             this.Size = new System.Drawing.Size(1208, 894);
-            this.Paint += new System.Windows.Forms.PaintEventHandler(this.EditWorkflow_Paint);
+            this.Validated += new System.EventHandler(this.EditWorkflow_Validated);
             this.policyInfoPanel.ResumeLayout(false);
             this.policyInfoPanel.PerformLayout();
             this.panel_Progress.ResumeLayout(false);

--- a/WDAC-Policy-Wizard/app/src/EditWorkflow.cs
+++ b/WDAC-Policy-Wizard/app/src/EditWorkflow.cs
@@ -503,7 +503,7 @@ namespace WDAC_Wizard
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void EditWorkflow_Paint(object sender, PaintEventArgs e)
+        private void EditWorkflow_Validated(object sender, EventArgs e)
         {
             // Set Controls Color (e.g. Panels, Textboxes, Buttons)
             SetControlsColor();

--- a/WDAC-Policy-Wizard/app/src/EventLogRuleConfiguration.Designer.cs
+++ b/WDAC-Policy-Wizard/app/src/EventLogRuleConfiguration.Designer.cs
@@ -598,7 +598,7 @@ namespace WDAC_Wizard
             this.Name = "EventLogRuleConfiguration";
             this.Size = new System.Drawing.Size(1208, 782);
             this.Load += new System.EventHandler(this.EventLogRuleConfiguration_Load);
-            this.Paint += new System.Windows.Forms.PaintEventHandler(this.EventLogRuleConfiguration_Paint);
+            this.Validated += new System.EventHandler(this.EventLogRuleConfiguration_Validated);
             this.publisherRulePanel.ResumeLayout(false);
             this.publisherRulePanel.PerformLayout();
             this.fileAttributeRulePanel.ResumeLayout(false);

--- a/WDAC-Policy-Wizard/app/src/EventLogRuleConfiguration.cs
+++ b/WDAC-Policy-Wizard/app/src/EventLogRuleConfiguration.cs
@@ -342,10 +342,13 @@ namespace WDAC_Wizard
                 || this.issuerTextBox.Text == Properties.Resources.BadEventPubValue)
             {
                 // Log exception error and throw error to user
-                MessageBox.Show(String.Format("The Issuer is invalid for rule creation. The issuer cannot be empty or '{0}'", Properties.Resources.BadEventPubValue), 
-                    "New Rule Creation Error", 
-                    MessageBoxButtons.OK, 
-                    MessageBoxIcon.Error);
+                MessageBox.Show(this,String.Format("The Issuer is invalid for rule creation. The issuer cannot be empty or '{0}'", Properties.Resources.BadEventPubValue), 
+                                                   "New Rule Creation Error", 
+                                                   MessageBoxButtons.OK, 
+                                                   MessageBoxIcon.Error);
+
+                this.Invalidate();
+
                 this.Log.AddWarningMsg("Event Log Config - Invalid publisher rule with Issuer = Unknown");
                 return false; 
             }
@@ -353,40 +356,40 @@ namespace WDAC_Wizard
             if (PublisherUIState[1] == 1 && (String.IsNullOrEmpty(this.publisherTextBox.Text) 
                 || this.publisherTextBox.Text == Properties.Resources.BadEventPubValue))
             {
-                MessageBox.Show(String.Format("The Publisher is invalid for rule creation. The Publisher cannot be empty '{0}'", Properties.Resources.BadEventPubValue),
-                    "New Rule Creation Error",
-                    MessageBoxButtons.OK,
-                    MessageBoxIcon.Error);
+                DialogResult res = MessageBox.Show(String.Format("The Publisher is invalid for rule creation. The Publisher cannot be empty '{0}'", Properties.Resources.BadEventPubValue),
+                                                   "New Rule Creation Error",
+                                                   MessageBoxButtons.OK,
+                                                   MessageBoxIcon.Error);
                 this.Log.AddWarningMsg("Event Log Config - Invalid publisher rule with Publisher = Unknown");
                 return false;
             }
 
             if (PublisherUIState[2] == 1 && String.IsNullOrEmpty(this.filenameTextBox.Text))
             {
-                MessageBox.Show(String.Format("The Filename is invalid for rule creation. The Filename cannot be empty if its checkbox is selected."),
-                    "New Rule Creation Error",
-                    MessageBoxButtons.OK,
-                    MessageBoxIcon.Error);
+                DialogResult res = MessageBox.Show(String.Format("The Filename is invalid for rule creation. The Filename cannot be empty if its checkbox is selected."),
+                                                   "New Rule Creation Error",
+                                                   MessageBoxButtons.OK,
+                                                   MessageBoxIcon.Error);
                 this.Log.AddWarningMsg("Event Log Config - Empty Filename");
                 return false;
             }
 
             if (PublisherUIState[3] == 1 && String.IsNullOrEmpty(this.versionCheckBox.Text))
             {
-                MessageBox.Show(String.Format("The Version field is invalid for rule creation. The Version field cannot be empty if its checkbox is selected."),
-                    "New Rule Creation Error",
-                    MessageBoxButtons.OK,
-                    MessageBoxIcon.Error);
+                DialogResult res = MessageBox.Show(String.Format("The Version field is invalid for rule creation. The Version field cannot be empty if its checkbox is selected."),
+                                                   "New Rule Creation Error",
+                                                   MessageBoxButtons.OK,
+                                                   MessageBoxIcon.Error);
                 this.Log.AddWarningMsg("Event Log Config - Empty Version field");
                 return false;
             }
 
             if (PublisherUIState[4] == 1 && String.IsNullOrEmpty(this.productTextBox.Text))
             {
-                MessageBox.Show(String.Format("The Product name is invalid for rule creation. The Product name cannot be empty if its checkbox is selected."),
-                    "New Rule Creation Error",
-                    MessageBoxButtons.OK,
-                    MessageBoxIcon.Error);
+                DialogResult res = MessageBox.Show(String.Format("The Product name is invalid for rule creation. The Product name cannot be empty if its checkbox is selected."),
+                                                   "New Rule Creation Error",
+                                                   MessageBoxButtons.OK,
+                                                   MessageBoxIcon.Error);
                 this.Log.AddWarningMsg("Event Log Config - Empty Product name");
                 return false;
             }
@@ -800,7 +803,7 @@ namespace WDAC_Wizard
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void EventLogRuleConfiguration_Paint(object sender, PaintEventArgs e)
+        private void EventLogRuleConfiguration_Validated(object sender, EventArgs e)
         {
             // Set Controls Color (e.g. Panels, Textboxes, Buttons)
             SetControlsColor();
@@ -821,14 +824,15 @@ namespace WDAC_Wizard
             SetCheckBoxesColor(checkBoxes);
 
             this.CheckBoxes = checkBoxes;
-            SetDisabledCheckBoxesColor(); 
+            SetDisabledCheckBoxesColor();
 
             // Set PolicyType Form back color
             SetFormBackColor();
 
             // Set the Rules Grid colors
-            SetGridColors(); 
+            SetGridColors();
         }
+
 
         /// <summary>
         /// Gets all of the labels on the form recursively
@@ -1153,7 +1157,7 @@ namespace WDAC_Wizard
                 // Set checkbox text to a lighter color for better Dark Mode contrast
                 if (!checkBox.AutoCheck)
                 {
-                    checkBox.ForeColor = Color.Red;
+                    checkBox.ForeColor = Color.Silver;
                 }
             } 
         }

--- a/WDAC-Policy-Wizard/app/src/Exceptions_Control.Designer.cs
+++ b/WDAC-Policy-Wizard/app/src/Exceptions_Control.Designer.cs
@@ -431,7 +431,7 @@
             this.Name = "Exceptions_Control";
             this.Size = new System.Drawing.Size(1001, 988);
             this.Load += new System.EventHandler(this.Exceptions_Control_Load);
-            this.Paint += new System.Windows.Forms.PaintEventHandler(this.Exceptions_Control_Paint);
+            this.Validated += new System.EventHandler(this.Exceptions_Control_Validated);
             this.panel_ExceptionRule.ResumeLayout(false);
             this.panel_ExceptionRule.PerformLayout();
             this.panel_FileFolder.ResumeLayout(false);

--- a/WDAC-Policy-Wizard/app/src/Exceptions_Control.cs
+++ b/WDAC-Policy-Wizard/app/src/Exceptions_Control.cs
@@ -781,7 +781,7 @@ namespace WDAC_Wizard
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void Exceptions_Control_Paint(object sender, PaintEventArgs e)
+        private void Exceptions_Control_Validated(object sender, EventArgs e)
         {
             // Set Controls Color (e.g. Panels, buttons)
             SetControlsColor();
@@ -795,7 +795,7 @@ namespace WDAC_Wizard
             SetFormBackColor();
 
             // Set color of the Grid
-            SetGridColors(); 
+            SetGridColors();
         }
 
         /// <summary>

--- a/WDAC-Policy-Wizard/app/src/Exceptions_Control.resx
+++ b/WDAC-Policy-Wizard/app/src/Exceptions_Control.resx
@@ -123,4 +123,10 @@
   <metadata name="column_Name.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <metadata name="column_Level.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="column_Name.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
 </root>

--- a/WDAC-Policy-Wizard/app/src/MainForm.Designer.cs
+++ b/WDAC-Policy-Wizard/app/src/MainForm.Designer.cs
@@ -77,7 +77,7 @@ namespace WDAC_Wizard
             this.button_New.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(190)))), ((int)(((byte)(230)))), ((int)(((byte)(253)))));
             this.button_New.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.button_New.Font = new System.Drawing.Font("Tahoma", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.button_New.Image = global::WDAC_Wizard.Properties.Resources.newPolicy;
+            this.button_New.Image = Properties.Resources.newPolicy;
             this.button_New.Location = new System.Drawing.Point(328, 225);
             this.button_New.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.button_New.Name = "button_New";

--- a/WDAC-Policy-Wizard/app/src/MainForm.cs
+++ b/WDAC-Policy-Wizard/app/src/MainForm.cs
@@ -965,33 +965,27 @@ namespace WDAC_Wizard
 
             // Assert supplemental policies and legacy policies cannot have the Supplemental (rule #17) option
             if (Policy.HasRuleOption(OptionType.EnabledAllowSupplementalPolicies)
-                && (this.Policy._Format == WDAC_Policy.Format.Legacy || this.Policy._PolicyType == WDAC_Policy.PolicyType.SupplementalPolicy))
+                && (this.Policy._Format == WDAC_Policy.Format.Legacy 
+                    || this.Policy._PolicyType == WDAC_Policy.PolicyType.SupplementalPolicy))
             {
-                for(int i=0; i < ruleOptionsList.Count; i++)
-                {
-                    if(ruleOptionsList[i].Item == OptionType.EnabledAllowSupplementalPolicies)
-                    {
-                        this.Log.AddInfoMsg("Removing EnabledAllowSupplementalPolicies (rule-option 17)"); 
-                        ruleOptionsList.RemoveAt(i);
-                        break;
-                    }
-                }
+                Policy.RemoveRuleOption(OptionType.EnabledAllowSupplementalPolicies);
+                this.Log.AddInfoMsg("Removing EnabledAllowSupplementalPolicies (rule-option 17)");
             }
 
             // Updated logic for Issue #262 - instead of forcing rule-option 6, skip binary conversion
             // if the policy has the signed CI policy option (rule #6) and lacks policy signers
-            if (Properties.Settings.Default.convertPolicyToBinary 
+            if (Properties.Settings.Default.convertPolicyToBinary
                 && !Policy.HasRuleOption(OptionType.EnabledUnsignedSystemIntegrityPolicy))
             {
-                if(finalPolicy.UpdatePolicySigners == null 
+                if (finalPolicy.UpdatePolicySigners == null
                     || finalPolicy.UpdatePolicySigners.Length < 1)
                 {
-                    skipPolicyConversion = true; 
+                    skipPolicyConversion = true;
                 }
 
                 // Handle Supplemental Signers issue - must have supplemental signers if signed policy && policy
                 // allows supplemental policies
-                if(Policy.HasRuleOption(OptionType.EnabledAllowSupplementalPolicies))
+                if (Policy.HasRuleOption(OptionType.EnabledAllowSupplementalPolicies))
                 {
                     if (finalPolicy.SupplementalPolicySigners == null
                     || finalPolicy.SupplementalPolicySigners.Length < 1)

--- a/WDAC-Policy-Wizard/app/src/Policy.cs
+++ b/WDAC-Policy-Wizard/app/src/Policy.cs
@@ -215,6 +215,25 @@ namespace WDAC_Wizard
         }
 
         /// <summary>
+        /// Removes a given rule option if it exists in the Policy
+        /// </summary>
+        /// <param name="targetRuleOption"></param>
+        public void RemoveRuleOption(OptionType targetRuleOption)
+        {
+            List<RuleType> tempRuleOptions = this.PolicyRuleOptions; 
+            for (int i = 0; i < tempRuleOptions.Count; i++)
+            {
+                if (tempRuleOptions[i].Item == OptionType.EnabledAllowSupplementalPolicies)
+                {
+                    tempRuleOptions.RemoveAt(i);
+                    break;
+                }
+            }
+
+            this.PolicyRuleOptions = tempRuleOptions; 
+        }
+
+        /// <summary>
         /// Checks if a given rule option is already specified in the Policy
         /// </summary>
         /// <param name="targetRuleOption">Rule OptionType to query the Policy object for</param>

--- a/WDAC-Policy-Wizard/app/src/PolicyMerge_Control.Designer.cs
+++ b/WDAC-Policy-Wizard/app/src/PolicyMerge_Control.Designer.cs
@@ -105,19 +105,18 @@
             // policiesDataGrid
             // 
             this.policiesDataGrid.AllowUserToDeleteRows = false;
+            this.policiesDataGrid.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
+            this.policiesDataGrid.ColumnHeadersBorderStyle = System.Windows.Forms.DataGridViewHeaderBorderStyle.Single;
             this.policiesDataGrid.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
             this.policiesDataGrid.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
             this.Column_Number,
             this.Column_Path});
+            this.policiesDataGrid.EnableHeadersVisualStyles = false;
             this.policiesDataGrid.Location = new System.Drawing.Point(165, 139);
             this.policiesDataGrid.Name = "policiesDataGrid";
+            this.policiesDataGrid.RowHeadersBorderStyle = System.Windows.Forms.DataGridViewHeaderBorderStyle.Single;
             this.policiesDataGrid.RowHeadersWidth = 51;
             this.policiesDataGrid.RowTemplate.Height = 24;
-            this.policiesDataGrid.EnableHeadersVisualStyles = false;
-            this.policiesDataGrid.CellBorderStyle = System.Windows.Forms.DataGridViewCellBorderStyle.Single;
-            this.policiesDataGrid.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
-            this.policiesDataGrid.ColumnHeadersBorderStyle = System.Windows.Forms.DataGridViewHeaderBorderStyle.Single;
-            this.policiesDataGrid.RowHeadersBorderStyle = System.Windows.Forms.DataGridViewHeaderBorderStyle.Single;
             this.policiesDataGrid.Size = new System.Drawing.Size(678, 150);
             this.policiesDataGrid.TabIndex = 95;
             this.policiesDataGrid.VirtualMode = true;
@@ -194,7 +193,7 @@
             this.Controls.Add(this.label1);
             this.Name = "PolicyMerge_Control";
             this.Size = new System.Drawing.Size(1172, 782);
-            this.Paint += new System.Windows.Forms.PaintEventHandler(this.PolicyMerge_Control_Paint);
+            this.Validated += new System.EventHandler(this.PolicyMerge_Control_Validated);
             ((System.ComponentModel.ISupportInitialize)(this.policiesDataGrid)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();

--- a/WDAC-Policy-Wizard/app/src/PolicyMerge_Control.cs
+++ b/WDAC-Policy-Wizard/app/src/PolicyMerge_Control.cs
@@ -272,11 +272,6 @@ namespace WDAC_Wizard.src
         {
             this.label_Error.Visible = false;
         }
-        
-        private void PolicyMerge_Control_Paint(object sender, PaintEventArgs e)
-        {
-            
-        }
 
         /// <summary>
         /// Form painting. Occurs on Form.Refresh, Load and Focus. 

--- a/WDAC-Policy-Wizard/app/src/PolicyMerge_Control.cs
+++ b/WDAC-Policy-Wizard/app/src/PolicyMerge_Control.cs
@@ -272,13 +272,19 @@ namespace WDAC_Wizard.src
         {
             this.label_Error.Visible = false;
         }
+        
+        private void PolicyMerge_Control_Paint(object sender, PaintEventArgs e)
+        {
+            
+        }
+
         /// <summary>
         /// Form painting. Occurs on Form.Refresh, Load and Focus. 
         /// Used for UI element changes for Dark and Light Mode
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void PolicyMerge_Control_Paint(object sender, PaintEventArgs e)
+        private void PolicyMerge_Control_Validated(object sender, EventArgs e)
         {
             // Set Controls Color (e.g. Labels Panels, Textboxes, Buttons)
             SetControlsColor();

--- a/WDAC-Policy-Wizard/app/src/PolicyType.Designer.cs
+++ b/WDAC-Policy-Wizard/app/src/PolicyType.Designer.cs
@@ -477,7 +477,7 @@ namespace WDAC_Wizard
             this.Name = "PolicyType";
             this.Size = new System.Drawing.Size(1172, 782);
             this.Load += new System.EventHandler(this.PolicyType_Load);
-            this.Paint += new System.Windows.Forms.PaintEventHandler(this.PolicyType_Paint);
+            this.Validated += new System.EventHandler(this.PolicyType_Validated);
             this.panelSupplName.ResumeLayout(false);
             this.panelSupplName.PerformLayout();
             this.panelSuppl_Base.ResumeLayout(false);

--- a/WDAC-Policy-Wizard/app/src/PolicyType.cs
+++ b/WDAC-Policy-Wizard/app/src/PolicyType.cs
@@ -605,16 +605,17 @@ namespace WDAC_Wizard
             }
         }
 
+
         /// <summary>
         /// Form painting. Occurs on Form.Refresh, Load and Focus. 
         /// Used for UI element changes for Dark and Light Mode
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void PolicyType_Paint(object sender, PaintEventArgs e)
+        private void PolicyType_Validated(object sender, EventArgs e)
         {
             // Set Controls Color (e.g. Radio Buttons)
-            SetControlsColor(); 
+            SetControlsColor();
 
             // Set Labels Color
             List<Label> labels = new List<Label>();
@@ -624,10 +625,10 @@ namespace WDAC_Wizard
             // Set Textboxes Color
             List<TextBox> textBoxes = new List<TextBox>();
             GetTextBoxesRecursive(this, textBoxes);
-            SetTextBoxesColor(textBoxes); 
+            SetTextBoxesColor(textBoxes);
 
             // Set PolicyType Form back color
-            SetFormBackColor(); 
+            SetFormBackColor();
         }
 
         /// <summary>

--- a/WDAC-Policy-Wizard/app/src/SigningRules_Control.Designer.cs
+++ b/WDAC-Policy-Wizard/app/src/SigningRules_Control.Designer.cs
@@ -32,7 +32,7 @@ namespace WDAC_Wizard
         /// </summary>
         private void InitializeComponent()
         {
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle2 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle1 = new System.Windows.Forms.DataGridViewCellStyle();
             this.label7 = new System.Windows.Forms.Label();
             this.label1 = new System.Windows.Forms.Label();
             this.rulesDataGrid = new System.Windows.Forms.DataGridView();
@@ -86,14 +86,14 @@ namespace WDAC_Wizard
             this.rulesDataGrid.BackgroundColor = System.Drawing.Color.LightGray;
             this.rulesDataGrid.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
             this.rulesDataGrid.ColumnHeadersBorderStyle = System.Windows.Forms.DataGridViewHeaderBorderStyle.Single;
-            dataGridViewCellStyle2.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
-            dataGridViewCellStyle2.BackColor = System.Drawing.Color.LightGray;
-            dataGridViewCellStyle2.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            dataGridViewCellStyle2.ForeColor = System.Drawing.Color.Black;
-            dataGridViewCellStyle2.SelectionBackColor = System.Drawing.SystemColors.Highlight;
-            dataGridViewCellStyle2.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
-            dataGridViewCellStyle2.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
-            this.rulesDataGrid.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle2;
+            dataGridViewCellStyle1.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle1.BackColor = System.Drawing.Color.LightGray;
+            dataGridViewCellStyle1.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            dataGridViewCellStyle1.ForeColor = System.Drawing.Color.Black;
+            dataGridViewCellStyle1.SelectionBackColor = System.Drawing.SystemColors.Highlight;
+            dataGridViewCellStyle1.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
+            dataGridViewCellStyle1.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
+            this.rulesDataGrid.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle1;
             this.rulesDataGrid.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
             this.rulesDataGrid.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
             this.column_Action,
@@ -327,7 +327,7 @@ namespace WDAC_Wizard
             this.Name = "SigningRules_Control";
             this.Size = new System.Drawing.Size(1203, 725);
             this.Load += new System.EventHandler(this.SigningRules_Control_Load);
-            this.Paint += new System.Windows.Forms.PaintEventHandler(this.SigningRules_Control_Paint);
+            this.Validated += new System.EventHandler(this.SigningRules_Control_Validated);
             ((System.ComponentModel.ISupportInitialize)(this.rulesDataGrid)).EndInit();
             this.panel_Progress.ResumeLayout(false);
             this.panel_Progress.PerformLayout();

--- a/WDAC-Policy-Wizard/app/src/SigningRules_Control.cs
+++ b/WDAC-Policy-Wizard/app/src/SigningRules_Control.cs
@@ -98,6 +98,7 @@ namespace WDAC_Wizard
                 this.customRuleConditionsPanel.Show();
                 this.customRuleConditionsPanel.BringToFront();
                 this.customRuleConditionsPanel.Focus();
+                this.customRuleConditionsPanel.ForceRepaint();
 
                 // this.label_AddCustomRules.Text = "- Custom Rules"; 
                 this.isCustomPanelOpen = true; 
@@ -1203,7 +1204,7 @@ namespace WDAC_Wizard
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void SigningRules_Control_Paint(object sender, PaintEventArgs e)
+        private void SigningRules_Control_Validated(object sender, EventArgs e)
         {
             // Set Controls Color (e.g. Panels)
             SetControlsColor();
@@ -1220,7 +1221,7 @@ namespace WDAC_Wizard
             SetGridColors();
 
             // Repaint the Custom Rules Condition Panel, if applicable
-            if(customRuleConditionsPanel != null)
+            if (customRuleConditionsPanel != null)
             {
                 customRuleConditionsPanel.ForceRepaint();
             }

--- a/WDAC-Policy-Wizard/app/src/TemplatePage.Designer.cs
+++ b/WDAC-Policy-Wizard/app/src/TemplatePage.Designer.cs
@@ -478,7 +478,7 @@ namespace WDAC_Wizard
             this.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.Name = "TemplatePage";
             this.Size = new System.Drawing.Size(1172, 782);
-            this.Paint += new System.Windows.Forms.PaintEventHandler(this.TemplatePage_Paint);
+            this.Validated += new System.EventHandler(this.TemplatePage_Validated);
             this.panel2.ResumeLayout(false);
             this.panel2.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.allowMsft_Button)).EndInit();

--- a/WDAC-Policy-Wizard/app/src/TemplatePage.cs
+++ b/WDAC-Policy-Wizard/app/src/TemplatePage.cs
@@ -316,7 +316,7 @@ namespace WDAC_Wizard
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void TemplatePage_Paint(object sender, PaintEventArgs e)
+        private void TemplatePage_Validated(object sender, EventArgs e)
         {
             // Set Controls Color (e.g. Panels)
             SetControlsColor();
@@ -329,13 +329,13 @@ namespace WDAC_Wizard
             // Set TextBoxes Color
             List<TextBox> textBoxes = new List<TextBox>();
             GetTextBoxesRecursive(this, textBoxes);
-            SetTextBoxesColor(textBoxes); 
+            SetTextBoxesColor(textBoxes);
 
             // Set PolicyType Form back color
             SetFormBackColor();
 
             // Set Template Policy Icons
-            SetTemplateIconImages(); 
+            SetTemplateIconImages();
         }
 
         /// <summary>


### PR DESCRIPTION
Fixed a few issues found during testing:

- Build break
- Unsigned supplemental policies would not convert to binary
- Moved all the dark/light mode into the validated event handler as opposed to paint to prevent infinite loops