### PR TITLE
DarkMode: Lower contrast of text boxes

### DIFF
--- a/WDAC-Policy-Wizard/app/src/EditWorkflow.Designer.cs
+++ b/WDAC-Policy-Wizard/app/src/EditWorkflow.Designer.cs
@@ -124,6 +124,7 @@ namespace WDAC_Wizard
             this.textBoxPolicyPath.Location = new System.Drawing.Point(17, 22);
             this.textBoxPolicyPath.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.textBoxPolicyPath.Name = "textBoxPolicyPath";
+            this.textBoxPolicyPath.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.textBoxPolicyPath.ReadOnly = true;
             this.textBoxPolicyPath.Size = new System.Drawing.Size(462, 26);
             this.textBoxPolicyPath.TabIndex = 1;
@@ -188,6 +189,7 @@ namespace WDAC_Wizard
             this.textBox_PolicyName.Location = new System.Drawing.Point(126, 42);
             this.textBox_PolicyName.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.textBox_PolicyName.Name = "textBox_PolicyName";
+            this.textBox_PolicyName.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.textBox_PolicyName.Size = new System.Drawing.Size(351, 26);
             this.textBox_PolicyName.TabIndex = 2;
             this.textBox_PolicyName.TextChanged += new System.EventHandler(this.TextBox_PolicyName_TextChanged);
@@ -198,6 +200,7 @@ namespace WDAC_Wizard
             this.textBoxSaveLocation.Location = new System.Drawing.Point(20, 154);
             this.textBoxSaveLocation.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.textBoxSaveLocation.Name = "textBoxSaveLocation";
+            this.textBoxSaveLocation.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.textBoxSaveLocation.ReadOnly = true;
             this.textBoxSaveLocation.Size = new System.Drawing.Size(462, 26);
             this.textBoxSaveLocation.TabIndex = 112;
@@ -220,6 +223,7 @@ namespace WDAC_Wizard
             this.textBox_PolicyID.Location = new System.Drawing.Point(126, 77);
             this.textBox_PolicyID.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.textBox_PolicyID.Name = "textBox_PolicyID";
+            this.textBox_PolicyID.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.textBox_PolicyID.Size = new System.Drawing.Size(351, 26);
             this.textBox_PolicyID.TabIndex = 3;
             this.textBox_PolicyID.TextChanged += new System.EventHandler(this.TextBox_PolicyID_TextChanged);
@@ -408,6 +412,7 @@ namespace WDAC_Wizard
             this.textBox_AdvancedHuntingPaths.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.textBox_AdvancedHuntingPaths.Multiline = true;
             this.textBox_AdvancedHuntingPaths.Name = "textBox_AdvancedHuntingPaths";
+            this.textBox_AdvancedHuntingPaths.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.textBox_AdvancedHuntingPaths.ReadOnly = true;
             this.textBox_AdvancedHuntingPaths.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
             this.textBox_AdvancedHuntingPaths.Size = new System.Drawing.Size(453, 37);
@@ -432,6 +437,7 @@ namespace WDAC_Wizard
             this.textBox_EventLog.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.textBox_EventLog.Multiline = true;
             this.textBox_EventLog.Name = "textBox_EventLog";
+            this.textBox_EventLog.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.textBox_EventLog.ReadOnly = true;
             this.textBox_EventLog.Size = new System.Drawing.Size(453, 43);
             this.textBox_EventLog.TabIndex = 123;
@@ -498,6 +504,7 @@ namespace WDAC_Wizard
             this.textBox_EventLogFilePath.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.textBox_EventLogFilePath.Multiline = true;
             this.textBox_EventLogFilePath.Name = "textBox_EventLogFilePath";
+            this.textBox_EventLogFilePath.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.textBox_EventLogFilePath.ReadOnly = true;
             this.textBox_EventLogFilePath.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
             this.textBox_EventLogFilePath.Size = new System.Drawing.Size(453, 37);

--- a/WDAC-Policy-Wizard/app/src/PolicyMerge_Control.Designer.cs
+++ b/WDAC-Policy-Wizard/app/src/PolicyMerge_Control.Designer.cs
@@ -83,6 +83,7 @@
             this.finalPolicyTextBox.Font = new System.Drawing.Font("Tahoma", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.finalPolicyTextBox.Location = new System.Drawing.Point(165, 409);
             this.finalPolicyTextBox.Name = "finalPolicyTextBox";
+            this.finalPolicyTextBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.finalPolicyTextBox.Size = new System.Drawing.Size(448, 26);
             this.finalPolicyTextBox.TabIndex = 4;
             this.finalPolicyTextBox.Click += new System.EventHandler(this.Button_Browse_Click);

--- a/WDAC-Policy-Wizard/app/src/PolicyType.Designer.cs
+++ b/WDAC-Policy-Wizard/app/src/PolicyType.Designer.cs
@@ -167,6 +167,7 @@ namespace WDAC_Wizard
             // 
             this.textBoxBasePolicyID.Font = new System.Drawing.Font("Tahoma", 8.5F);
             this.textBoxBasePolicyID.ForeColor = System.Drawing.SystemColors.WindowFrame;
+            this.textBoxBasePolicyID.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.textBoxBasePolicyID.Location = new System.Drawing.Point(169, 43);
             this.textBoxBasePolicyID.Margin = new System.Windows.Forms.Padding(2);
             this.textBoxBasePolicyID.Name = "textBoxBasePolicyID";
@@ -246,6 +247,7 @@ namespace WDAC_Wizard
             this.textBoxBasePolicyPath.Location = new System.Drawing.Point(169, 107);
             this.textBoxBasePolicyPath.Margin = new System.Windows.Forms.Padding(2);
             this.textBoxBasePolicyPath.Name = "textBoxBasePolicyPath";
+            this.textBoxBasePolicyPath.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.textBoxBasePolicyPath.Size = new System.Drawing.Size(381, 25);
             this.textBoxBasePolicyPath.TabIndex = 14;
             this.textBoxBasePolicyPath.Click += new System.EventHandler(this.Button_Browse_Click);
@@ -282,6 +284,7 @@ namespace WDAC_Wizard
             // 
             this.textBox_PolicyName.Font = new System.Drawing.Font("Tahoma", 8.5F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.textBox_PolicyName.ForeColor = System.Drawing.Color.Black;
+            this.textBox_PolicyName.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.textBox_PolicyName.Location = new System.Drawing.Point(172, 11);
             this.textBox_PolicyName.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.textBox_PolicyName.Name = "textBox_PolicyName";
@@ -304,6 +307,7 @@ namespace WDAC_Wizard
             // 
             this.textBoxSuppPath.Font = new System.Drawing.Font("Tahoma", 8.5F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.textBoxSuppPath.ForeColor = System.Drawing.Color.Black;
+            this.textBoxSuppPath.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.textBoxSuppPath.Location = new System.Drawing.Point(172, 55);
             this.textBoxSuppPath.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.textBoxSuppPath.Name = "textBoxSuppPath";

--- a/WDAC-Policy-Wizard/app/src/TemplatePage.Designer.cs
+++ b/WDAC-Policy-Wizard/app/src/TemplatePage.Designer.cs
@@ -364,6 +364,7 @@ namespace WDAC_Wizard
             // 
             this.textBoxPolicyPath.Font = new System.Drawing.Font("Tahoma", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.textBoxPolicyPath.ForeColor = System.Drawing.Color.Black;
+            this.textBoxPolicyPath.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.textBoxPolicyPath.Location = new System.Drawing.Point(185, 87);
             this.textBoxPolicyPath.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.textBoxPolicyPath.Name = "textBoxPolicyPath";
@@ -387,6 +388,7 @@ namespace WDAC_Wizard
             // 
             this.textBox_PolicyName.Font = new System.Drawing.Font("Tahoma", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.textBox_PolicyName.ForeColor = System.Drawing.Color.Black;
+            this.textBox_PolicyName.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.textBox_PolicyName.Location = new System.Drawing.Point(185, 46);
             this.textBox_PolicyName.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.textBox_PolicyName.Name = "textBox_PolicyName";


### PR DESCRIPTION
The text boxes were appearing with quite a jarring contrast in dark mode. I switched the text box BorderStyle to FixedSingle for a more visually appealing look with less contrast.

The text boxes in Custom Rule Conditions / Exceptions panel will need to be fixed in another commit.

Quick example:
![wdac-textboxes-fixedsingle](https://github.com/MicrosoftDocs/WDAC-Toolkit/assets/26308319/07aae44d-9d66-4933-806a-dd4d3a3812eb)
