### PR TITLE
DarkMode: Labels background color fix

### DIFF
--- a/WDAC-Policy-Wizard/app/src/EditWorkflow.cs
+++ b/WDAC-Policy-Wizard/app/src/EditWorkflow.cs
@@ -647,7 +647,7 @@ namespace WDAC_Wizard
                     if (label.Tag == null || label.Tag.ToString() != Properties.Resources.IgnoreDarkModeTag)
                     {
                         label.ForeColor = Color.White;
-                        label.BackColor = Color.Black;
+                        label.BackColor = Color.FromArgb(15, 15, 15);
                     }
                 }
             }

--- a/WDAC-Policy-Wizard/app/src/PolicyType.cs
+++ b/WDAC-Policy-Wizard/app/src/PolicyType.cs
@@ -646,7 +646,7 @@ namespace WDAC_Wizard
                         && (radioButton.Tag == null || radioButton.Tag.ToString() != Properties.Resources.IgnoreDarkModeTag))
                     {
                         radioButton.ForeColor = Color.White;
-                        radioButton.BackColor = Color.Black;
+                        radioButton.BackColor = Color.FromArgb(15, 15, 15);
                     }
                 }
             }
@@ -700,7 +700,7 @@ namespace WDAC_Wizard
                     if (label.Tag == null || label.Tag.ToString() != Properties.Resources.IgnoreDarkModeTag)
                     {
                         label.ForeColor = Color.White;
-                        label.BackColor = Color.Black;
+                        label.BackColor = Color.FromArgb(15, 15, 15);
                     }
                 }
             }

--- a/WDAC-Policy-Wizard/app/src/SettingsPage.cs
+++ b/WDAC-Policy-Wizard/app/src/SettingsPage.cs
@@ -543,7 +543,7 @@ namespace WDAC_Wizard
                     if(label.Tag == null || label.Tag.ToString() != Properties.Resources.IgnoreDarkModeTag)
                     {
                         label.ForeColor = Color.White;
-                        label.BackColor = Color.Black; 
+                        label.BackColor = Color.FromArgb(15, 15, 15); 
                     }
                 }
             }


### PR DESCRIPTION
All of the background colors were recently changed to `Color.FromArgb(15, 15, 15)`. However, the labels/radioboxes on a few pages were still left as Black. This commit fixes the remaining labels/radioboxes background colors.

Example:
![wdac-darkmode-labels](https://github.com/MicrosoftDocs/WDAC-Toolkit/assets/26308319/3ab687ec-5879-4cab-bba0-12aa7eca64c7)
