### PR TITLE
DarkMode: Lower contrast of mouseover highlights

### DIFF
--- a/WDAC-Policy-Wizard/app/src/BuildPage.cs
+++ b/WDAC-Policy-Wizard/app/src/BuildPage.cs
@@ -249,7 +249,7 @@ namespace WDAC_Wizard
                     if (label.Tag == null || label.Tag.ToString() != Properties.Resources.IgnoreDarkModeTag)
                     {
                         label.ForeColor = Color.White;
-                        label.BackColor = Color.Black;
+                        label.BackColor = Color.FromArgb(15, 15, 15);
                     }
                 }
             }

--- a/WDAC-Policy-Wizard/app/src/EditWorkflow.Designer.cs
+++ b/WDAC-Policy-Wizard/app/src/EditWorkflow.Designer.cs
@@ -124,6 +124,7 @@ namespace WDAC_Wizard
             this.textBoxPolicyPath.Location = new System.Drawing.Point(17, 22);
             this.textBoxPolicyPath.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.textBoxPolicyPath.Name = "textBoxPolicyPath";
+            this.textBoxPolicyPath.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.textBoxPolicyPath.ReadOnly = true;
             this.textBoxPolicyPath.Size = new System.Drawing.Size(462, 26);
             this.textBoxPolicyPath.TabIndex = 1;
@@ -188,6 +189,7 @@ namespace WDAC_Wizard
             this.textBox_PolicyName.Location = new System.Drawing.Point(126, 42);
             this.textBox_PolicyName.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.textBox_PolicyName.Name = "textBox_PolicyName";
+            this.textBox_PolicyName.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.textBox_PolicyName.Size = new System.Drawing.Size(351, 26);
             this.textBox_PolicyName.TabIndex = 2;
             this.textBox_PolicyName.TextChanged += new System.EventHandler(this.TextBox_PolicyName_TextChanged);
@@ -198,6 +200,7 @@ namespace WDAC_Wizard
             this.textBoxSaveLocation.Location = new System.Drawing.Point(20, 154);
             this.textBoxSaveLocation.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.textBoxSaveLocation.Name = "textBoxSaveLocation";
+            this.textBoxSaveLocation.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.textBoxSaveLocation.ReadOnly = true;
             this.textBoxSaveLocation.Size = new System.Drawing.Size(462, 26);
             this.textBoxSaveLocation.TabIndex = 112;
@@ -220,6 +223,7 @@ namespace WDAC_Wizard
             this.textBox_PolicyID.Location = new System.Drawing.Point(126, 77);
             this.textBox_PolicyID.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.textBox_PolicyID.Name = "textBox_PolicyID";
+            this.textBox_PolicyID.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.textBox_PolicyID.Size = new System.Drawing.Size(351, 26);
             this.textBox_PolicyID.TabIndex = 3;
             this.textBox_PolicyID.TextChanged += new System.EventHandler(this.TextBox_PolicyID_TextChanged);
@@ -408,6 +412,7 @@ namespace WDAC_Wizard
             this.textBox_AdvancedHuntingPaths.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.textBox_AdvancedHuntingPaths.Multiline = true;
             this.textBox_AdvancedHuntingPaths.Name = "textBox_AdvancedHuntingPaths";
+            this.textBox_AdvancedHuntingPaths.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.textBox_AdvancedHuntingPaths.ReadOnly = true;
             this.textBox_AdvancedHuntingPaths.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
             this.textBox_AdvancedHuntingPaths.Size = new System.Drawing.Size(453, 37);
@@ -432,6 +437,7 @@ namespace WDAC_Wizard
             this.textBox_EventLog.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.textBox_EventLog.Multiline = true;
             this.textBox_EventLog.Name = "textBox_EventLog";
+            this.textBox_EventLog.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.textBox_EventLog.ReadOnly = true;
             this.textBox_EventLog.Size = new System.Drawing.Size(453, 43);
             this.textBox_EventLog.TabIndex = 123;
@@ -498,6 +504,7 @@ namespace WDAC_Wizard
             this.textBox_EventLogFilePath.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.textBox_EventLogFilePath.Multiline = true;
             this.textBox_EventLogFilePath.Name = "textBox_EventLogFilePath";
+            this.textBox_EventLogFilePath.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.textBox_EventLogFilePath.ReadOnly = true;
             this.textBox_EventLogFilePath.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
             this.textBox_EventLogFilePath.Size = new System.Drawing.Size(453, 37);

--- a/WDAC-Policy-Wizard/app/src/MainForm.Designer.cs
+++ b/WDAC-Policy-Wizard/app/src/MainForm.Designer.cs
@@ -73,8 +73,8 @@ namespace WDAC_Wizard
             // 
             this.button_New.BackColor = System.Drawing.Color.Transparent;
             this.button_New.FlatAppearance.BorderSize = 0;
-            this.button_New.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(190)))), ((int)(((byte)(230)))), ((int)(((byte)(253)))));
-            this.button_New.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(190)))), ((int)(((byte)(230)))), ((int)(((byte)(253)))));
+            this.button_New.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+            this.button_New.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
             this.button_New.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.button_New.Font = new System.Drawing.Font("Tahoma", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.button_New.Image = Properties.Resources.newPolicy;
@@ -113,8 +113,8 @@ namespace WDAC_Wizard
             // 
             this.button_Edit.BackColor = System.Drawing.Color.Transparent;
             this.button_Edit.FlatAppearance.BorderSize = 0;
-            this.button_Edit.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(190)))), ((int)(((byte)(230)))), ((int)(((byte)(253)))));
-            this.button_Edit.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(190)))), ((int)(((byte)(230)))), ((int)(((byte)(253)))));
+            this.button_Edit.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+            this.button_Edit.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
             this.button_Edit.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.button_Edit.Font = new System.Drawing.Font("Tahoma", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.button_Edit.Image = global::WDAC_Wizard.Properties.Resources.tools;
@@ -132,8 +132,8 @@ namespace WDAC_Wizard
             // 
             this.button_Merge.BackColor = System.Drawing.Color.Transparent;
             this.button_Merge.FlatAppearance.BorderSize = 0;
-            this.button_Merge.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(190)))), ((int)(((byte)(230)))), ((int)(((byte)(253)))));
-            this.button_Merge.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(190)))), ((int)(((byte)(230)))), ((int)(((byte)(253)))));
+            this.button_Merge.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+            this.button_Merge.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
             this.button_Merge.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.button_Merge.Font = new System.Drawing.Font("Tahoma", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.button_Merge.Image = global::WDAC_Wizard.Properties.Resources.merge;
@@ -184,8 +184,8 @@ namespace WDAC_Wizard
             this.page5_Button.BackColor = System.Drawing.Color.Transparent;
             this.page5_Button.Enabled = false;
             this.page5_Button.FlatAppearance.BorderSize = 0;
-            this.page5_Button.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(149)))), ((int)(((byte)(149)))), ((int)(((byte)(149)))));
-            this.page5_Button.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(149)))), ((int)(((byte)(149)))), ((int)(((byte)(149)))));
+            this.page5_Button.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+            this.page5_Button.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
             this.page5_Button.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.page5_Button.Font = new System.Drawing.Font("Tahoma", 9.5F);
             this.page5_Button.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -206,8 +206,8 @@ namespace WDAC_Wizard
             this.page4_Button.BackColor = System.Drawing.Color.Transparent;
             this.page4_Button.Enabled = false;
             this.page4_Button.FlatAppearance.BorderSize = 0;
-            this.page4_Button.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(149)))), ((int)(((byte)(149)))), ((int)(((byte)(149)))));
-            this.page4_Button.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(149)))), ((int)(((byte)(149)))), ((int)(((byte)(149)))));
+            this.page4_Button.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+            this.page4_Button.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
             this.page4_Button.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.page4_Button.Font = new System.Drawing.Font("Tahoma", 9.5F);
             this.page4_Button.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -228,8 +228,8 @@ namespace WDAC_Wizard
             this.page3_Button.BackColor = System.Drawing.Color.Transparent;
             this.page3_Button.Enabled = false;
             this.page3_Button.FlatAppearance.BorderSize = 0;
-            this.page3_Button.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(149)))), ((int)(((byte)(149)))), ((int)(((byte)(149)))));
-            this.page3_Button.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(149)))), ((int)(((byte)(149)))), ((int)(((byte)(149)))));
+            this.page3_Button.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+            this.page3_Button.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
             this.page3_Button.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.page3_Button.Font = new System.Drawing.Font("Tahoma", 9.5F);
             this.page3_Button.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -250,8 +250,8 @@ namespace WDAC_Wizard
             this.page2_Button.BackColor = System.Drawing.Color.Transparent;
             this.page2_Button.Enabled = false;
             this.page2_Button.FlatAppearance.BorderSize = 0;
-            this.page2_Button.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(149)))), ((int)(((byte)(149)))), ((int)(((byte)(149)))));
-            this.page2_Button.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(149)))), ((int)(((byte)(149)))), ((int)(((byte)(149)))));
+            this.page2_Button.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+            this.page2_Button.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
             this.page2_Button.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.page2_Button.Font = new System.Drawing.Font("Tahoma", 9.5F);
             this.page2_Button.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -272,8 +272,8 @@ namespace WDAC_Wizard
             this.page1_Button.BackColor = System.Drawing.Color.Transparent;
             this.page1_Button.Enabled = false;
             this.page1_Button.FlatAppearance.BorderSize = 0;
-            this.page1_Button.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(149)))), ((int)(((byte)(149)))), ((int)(((byte)(149)))));
-            this.page1_Button.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(149)))), ((int)(((byte)(149)))), ((int)(((byte)(149)))));
+            this.page1_Button.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+            this.page1_Button.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
             this.page1_Button.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.page1_Button.Font = new System.Drawing.Font("Tahoma", 9.5F);
             this.page1_Button.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -302,8 +302,8 @@ namespace WDAC_Wizard
             this.home_Button.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.home_Button.BackColor = System.Drawing.Color.Transparent;
             this.home_Button.FlatAppearance.BorderSize = 0;
-            this.home_Button.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(149)))), ((int)(((byte)(149)))), ((int)(((byte)(149)))));
-            this.home_Button.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(149)))), ((int)(((byte)(149)))), ((int)(((byte)(149)))));
+            this.home_Button.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+            this.home_Button.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
             this.home_Button.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.home_Button.Font = new System.Drawing.Font("Tahoma", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.home_Button.Image = ((System.Drawing.Image)(resources.GetObject("home_Button.Image")));
@@ -323,8 +323,8 @@ namespace WDAC_Wizard
             this.settings_Button.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.settings_Button.BackColor = System.Drawing.Color.Transparent;
             this.settings_Button.FlatAppearance.BorderSize = 0;
-            this.settings_Button.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(149)))), ((int)(((byte)(149)))), ((int)(((byte)(149)))));
-            this.settings_Button.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(149)))), ((int)(((byte)(149)))), ((int)(((byte)(149)))));
+            this.settings_Button.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+            this.settings_Button.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
             this.settings_Button.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.settings_Button.Font = new System.Drawing.Font("Tahoma", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.settings_Button.Image = global::WDAC_Wizard.Properties.Resources.gear;

--- a/WDAC-Policy-Wizard/app/src/PolicyMerge_Control.Designer.cs
+++ b/WDAC-Policy-Wizard/app/src/PolicyMerge_Control.Designer.cs
@@ -83,6 +83,7 @@
             this.finalPolicyTextBox.Font = new System.Drawing.Font("Tahoma", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.finalPolicyTextBox.Location = new System.Drawing.Point(165, 409);
             this.finalPolicyTextBox.Name = "finalPolicyTextBox";
+            this.finalPolicyTextBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.finalPolicyTextBox.Size = new System.Drawing.Size(448, 26);
             this.finalPolicyTextBox.TabIndex = 4;
             this.finalPolicyTextBox.Click += new System.EventHandler(this.Button_Browse_Click);

--- a/WDAC-Policy-Wizard/app/src/PolicyType.Designer.cs
+++ b/WDAC-Policy-Wizard/app/src/PolicyType.Designer.cs
@@ -167,6 +167,7 @@ namespace WDAC_Wizard
             // 
             this.textBoxBasePolicyID.Font = new System.Drawing.Font("Tahoma", 8.5F);
             this.textBoxBasePolicyID.ForeColor = System.Drawing.SystemColors.WindowFrame;
+            this.textBoxBasePolicyID.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.textBoxBasePolicyID.Location = new System.Drawing.Point(169, 43);
             this.textBoxBasePolicyID.Margin = new System.Windows.Forms.Padding(2);
             this.textBoxBasePolicyID.Name = "textBoxBasePolicyID";
@@ -246,6 +247,7 @@ namespace WDAC_Wizard
             this.textBoxBasePolicyPath.Location = new System.Drawing.Point(169, 107);
             this.textBoxBasePolicyPath.Margin = new System.Windows.Forms.Padding(2);
             this.textBoxBasePolicyPath.Name = "textBoxBasePolicyPath";
+            this.textBoxBasePolicyPath.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.textBoxBasePolicyPath.Size = new System.Drawing.Size(381, 25);
             this.textBoxBasePolicyPath.TabIndex = 14;
             this.textBoxBasePolicyPath.Click += new System.EventHandler(this.Button_Browse_Click);
@@ -282,6 +284,7 @@ namespace WDAC_Wizard
             // 
             this.textBox_PolicyName.Font = new System.Drawing.Font("Tahoma", 8.5F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.textBox_PolicyName.ForeColor = System.Drawing.Color.Black;
+            this.textBox_PolicyName.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.textBox_PolicyName.Location = new System.Drawing.Point(172, 11);
             this.textBox_PolicyName.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.textBox_PolicyName.Name = "textBox_PolicyName";
@@ -304,6 +307,7 @@ namespace WDAC_Wizard
             // 
             this.textBoxSuppPath.Font = new System.Drawing.Font("Tahoma", 8.5F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.textBoxSuppPath.ForeColor = System.Drawing.Color.Black;
+            this.textBoxSuppPath.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.textBoxSuppPath.Location = new System.Drawing.Point(172, 55);
             this.textBoxSuppPath.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.textBoxSuppPath.Name = "textBoxSuppPath";

--- a/WDAC-Policy-Wizard/app/src/TemplatePage.Designer.cs
+++ b/WDAC-Policy-Wizard/app/src/TemplatePage.Designer.cs
@@ -364,6 +364,7 @@ namespace WDAC_Wizard
             // 
             this.textBoxPolicyPath.Font = new System.Drawing.Font("Tahoma", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.textBoxPolicyPath.ForeColor = System.Drawing.Color.Black;
+            this.textBoxPolicyPath.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.textBoxPolicyPath.Location = new System.Drawing.Point(185, 87);
             this.textBoxPolicyPath.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.textBoxPolicyPath.Name = "textBoxPolicyPath";
@@ -387,6 +388,7 @@ namespace WDAC_Wizard
             // 
             this.textBox_PolicyName.Font = new System.Drawing.Font("Tahoma", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.textBox_PolicyName.ForeColor = System.Drawing.Color.Black;
+            this.textBox_PolicyName.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.textBox_PolicyName.Location = new System.Drawing.Point(185, 46);
             this.textBox_PolicyName.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.textBox_PolicyName.Name = "textBox_PolicyName";


### PR DESCRIPTION
The mouseover highlights of the 3 main options as well as the menu options are geared more toward light mode. The contrast was too much for dark mode.

I kept the same DodgerBlue color and simply added a good amount of transparency so that it works well in both dark and light modes.

Also added a minor fix for Build page label background.

Screenshots:
![wdac-hover-color](https://github.com/MicrosoftDocs/WDAC-Toolkit/assets/26308319/10f0d513-1b03-459b-abac-30700211039e)
![wdac-hover-color-menu](https://github.com/MicrosoftDocs/WDAC-Toolkit/assets/26308319/6b8cd540-91e8-4a4d-8820-7da3d14a51b8)
