### PR TITLE
Fixed the reset button color

### DIFF
--- a/WDAC-Policy-Wizard/app/src/SettingsPage.cs
+++ b/WDAC-Policy-Wizard/app/src/SettingsPage.cs
@@ -491,6 +491,9 @@ namespace WDAC_Wizard
 
             // Set Form Back Color
             SetFormBackColor();
+
+            // Set color of Reset button
+            SetResetButtonColor();
         }
 
         /// <summary>


### PR DESCRIPTION
**Issue:**
Switching between Light Mode and Dark Mode on the Settings page, the Reset button does not get the proper color based on the setting for light and dark mode. 

**Fix:**
Call the SetResetButtonColor method to force the painting of the button on 'Reset' as well as Settings Page loading. 