### PR TITLE
DarkMode: Fix radioButtons Dark/Light Color

### DIFF
--- a/WDAC-Policy-Wizard/app/src/Exceptions_Control.Designer.cs
+++ b/WDAC-Policy-Wizard/app/src/Exceptions_Control.Designer.cs
@@ -122,7 +122,6 @@
             // 
             this.radioButton_Folder.AutoSize = true;
             this.radioButton_Folder.Font = new System.Drawing.Font("Tahoma", 9F);
-            this.radioButton_Folder.ForeColor = System.Drawing.Color.Black;
             this.radioButton_Folder.Location = new System.Drawing.Point(61, 7);
             this.radioButton_Folder.Margin = new System.Windows.Forms.Padding(2);
             this.radioButton_Folder.Name = "radioButton_Folder";
@@ -137,7 +136,6 @@
             // 
             this.radioButton_File.AutoSize = true;
             this.radioButton_File.Font = new System.Drawing.Font("Tahoma", 9F);
-            this.radioButton_File.ForeColor = System.Drawing.Color.Black;
             this.radioButton_File.Location = new System.Drawing.Point(2, 7);
             this.radioButton_File.Margin = new System.Windows.Forms.Padding(2);
             this.radioButton_File.Name = "radioButton_File";


### PR DESCRIPTION
The radiobuttons for File and Folder on the Exceptions page were hardcoded with a Black ForeColor. So the ForeColor was showing Black whether it was Dark or Light mode.

This fixes it by removing the hardcoded ForeColor, therefore allowing the already in place Dark/Light color control to work as expected.