### PR TITLE
TemplatePage: Temporarily Disable MouseHover

### DIFF
--- a/WDAC-Policy-Wizard/app/src/TemplatePage.cs
+++ b/WDAC-Policy-Wizard/app/src/TemplatePage.cs
@@ -279,7 +279,9 @@ namespace WDAC_Wizard
         private void MouseHover_Button(object sender, EventArgs e)
         {
             PictureBox checkBox = ((PictureBox)sender);
-            checkBox.BackColor = Color.FromArgb(190, 230, 253);
+        /// Temporarily disable MouseHover effect by changing FromArgb(190, 230, 253) to Transparent.
+        /// Disabled until issue (https://github.com/MicrosoftDocs/WDAC-Toolkit/issues/307) is fixed.
+            checkBox.BackColor = Color.Transparent;
         }
 
         /// <summary>


### PR DESCRIPTION
Related to issue (https://github.com/MicrosoftDocs/WDAC-Toolkit/issues/307).

I think that the PictureBox MouseHover on the TemplatePage should be disabled for now until it can be fixed properly. Also, none of the other circular PictureBoxes throughout the app have the MouseHover effect anyway.

Temporarily disable MouseHover effect by changing FromArgb(190, 230, 253) to Transparent.