### PR TITLE
Set a standard design for Next and Reset buttons

### DIFF
--- a/WDAC-Policy-Wizard/app/src/MainForm.cs
+++ b/WDAC-Policy-Wizard/app/src/MainForm.cs
@@ -2200,15 +2200,23 @@ namespace WDAC_Wizard
             // Dark Mode
             if (Properties.Settings.Default.useDarkMode)
             {
-                button_Next.ForeColor = Color.DodgerBlue;
-                button_Next.BackColor = Color.Black;
+                button_Next.FlatAppearance.BorderColor = System.Drawing.Color.DodgerBlue;
+                button_Next.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+                button_Next.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+                button_Next.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+                button_Next.ForeColor = System.Drawing.Color.DodgerBlue;
+                button_Next.BackColor = System.Drawing.Color.Transparent;
             }
 
             // Light Mode
             else
             {
-                button_Next.ForeColor = Color.Black;
-                button_Next.BackColor = Color.WhiteSmoke;
+                button_Next.FlatAppearance.BorderColor = System.Drawing.Color.Black;
+                button_Next.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+                button_Next.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+                button_Next.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+                button_Next.ForeColor = System.Drawing.Color.Black;
+                button_Next.BackColor = System.Drawing.Color.WhiteSmoke;
             }
         }
 

--- a/WDAC-Policy-Wizard/app/src/SettingsPage.Designer.cs
+++ b/WDAC-Policy-Wizard/app/src/SettingsPage.Designer.cs
@@ -401,7 +401,6 @@ namespace WDAC_Wizard
             // 
             // resetButton
             // 
-            this.resetButton.BackColor = System.Drawing.Color.WhiteSmoke;
             this.resetButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 9F);
             this.resetButton.Location = new System.Drawing.Point(785, 624);
             this.resetButton.Margin = new System.Windows.Forms.Padding(2);

--- a/WDAC-Policy-Wizard/app/src/SettingsPage.cs
+++ b/WDAC-Policy-Wizard/app/src/SettingsPage.cs
@@ -649,15 +649,23 @@ namespace WDAC_Wizard
             // Dark Mode
             if (Properties.Settings.Default.useDarkMode)
             {
-                resetButton.ForeColor = Color.DodgerBlue;
-                resetButton.BackColor = Color.Black; 
+                resetButton.FlatAppearance.BorderColor = System.Drawing.Color.DodgerBlue;
+                resetButton.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+                resetButton.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+                resetButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+                resetButton.ForeColor = System.Drawing.Color.DodgerBlue;
+                resetButton.BackColor = System.Drawing.Color.Transparent;
             }
 
             // Light Mode
             else
             {
-                resetButton.ForeColor = Color.Black;
-                resetButton.BackColor = Color.WhiteSmoke;
+                resetButton.FlatAppearance.BorderColor = System.Drawing.Color.Black;
+                resetButton.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+                resetButton.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+                resetButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+                resetButton.ForeColor = System.Drawing.Color.Black;
+                resetButton.BackColor = System.Drawing.Color.WhiteSmoke;
             }
         }
 


### PR DESCRIPTION
This commit sets a standard design for Dark Mode and Light Mode for the Next button on the MainForm and also the Reset button on the Settings page. There is also a standard MouseOverBackColor that fits the colors from the rest of the app.

Once some of other issues with Dark/Light Button Controls (https://github.com/MicrosoftDocs/WDAC-Toolkit/issues/313) are fixed, I would like to expand so that this button color standard is applied to all other buttons throughout the app.

**Examples:**

_These are animated gifs but don't seem to be animating unless you click on them._

![wdac-nextbutton-dark](https://github.com/MicrosoftDocs/WDAC-Toolkit/assets/26308319/3e935415-e3a7-4397-827e-ec2a6adc79ac)
![wdac-nextbutton-light](https://github.com/MicrosoftDocs/WDAC-Toolkit/assets/26308319/7c00c27a-d95e-41cb-ba52-46abc88e1544)
![wdac-resetbutton-dark](https://github.com/MicrosoftDocs/WDAC-Toolkit/assets/26308319/158d4a72-7692-48ff-8395-e2ec2878ed7b)
![wdac-resetbutton-light](https://github.com/MicrosoftDocs/WDAC-Toolkit/assets/26308319/5618a4de-8dc3-40d9-8f73-e1152eb34dde)
