### PR TITLE
Fixed policy rule removal bug during edit flow

### DIFF
--- a/WDAC-Policy-Wizard/app/src/MainForm.cs
+++ b/WDAC-Policy-Wizard/app/src/MainForm.cs
@@ -1630,7 +1630,7 @@ namespace WDAC_Wizard
                 if(String.IsNullOrEmpty(this.Policy.SchemaPath))
                 {
                     // Since we don't have a new save location, copy the TemplatePath
-                    // and append '_Edit' to the file path.
+                    // and append '_version' to the file path.
                     // Check if _v10.0.x.y is already in string ie. editing the output of an editing workflow
                     int versionNumPos = this.Policy.EditPathContainsVersionInfo(); 
                     if (versionNumPos > 0)
@@ -1726,7 +1726,7 @@ namespace WDAC_Wizard
                 this.Log.AddErrorMsg("MergeTemplatesPolicy() encountered the following error: Unable to locate any policies to merge");
             }
                 
-
+            // Logging
             foreach (var policyPath in policyPaths)
             {
                 mergeScript += String.Format("\"{0}\",", policyPath);

--- a/WDAC-Policy-Wizard/app/src/SigningRules_Control.cs
+++ b/WDAC-Policy-Wizard/app/src/SigningRules_Control.cs
@@ -437,14 +437,15 @@ namespace WDAC_Wizard
         /// </summary>
         private bool ReadSetRules(object sender, EventArgs e)
         {
-            // Always going to have to parse an XML file 
-            // Edit Policies - Read from the EditPolicy Path
+            // Always going to have to parse an XML file:
+            // Edit Policies - Read from the copy of the policy under edit (stored under /Temp/ as Policy.TemplatePath)
             // New Policies
             //     - Read from Template path if Base Policy
             //     - Read from Empty Supplemental if Supplemental Policy i.e. no rules to show
+
             if (this._MainWindow.Policy.PolicyWorkflow == WDAC_Policy.Workflow.Edit)
             {
-                this.XmlPath = this._MainWindow.Policy.EditPolicyPath; // existing policy - read from policy under edit path
+                this.XmlPath = this._MainWindow.Policy.TemplatePath; // existing policy - read from temp dir path
             }
             else // New Policy
             {


### PR DESCRIPTION
**Issue**
Rules that were being removed in the edit workflow were only being removed from the UI, the old policy but NOT the policy the Wizard outputs. 

**Root Cause**
The Wizard was modifying the XML on disk from the old policy rather than the OutputPath. 

**Fix**
Updating the signing rules workflow to modify the "TemplatePath" which in turn gets converted to "OutputPath".