### PR TITLE
LightMode: ComboBox Fix

### DIFF
--- a/WDAC-Policy-Wizard/app/src/CustomRuleConditionsPanel.cs
+++ b/WDAC-Policy-Wizard/app/src/CustomRuleConditionsPanel.cs
@@ -2677,7 +2677,7 @@ namespace WDAC_Wizard
                     {
                         comboBox.ForeColor = Color.Black;
                         comboBox.BackColor = Color.White;
-                        comboBox.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+                        comboBox.FlatStyle = System.Windows.Forms.FlatStyle.Standard;
                         comboBox.Text = "--Select--";
                     }
                 }

--- a/WDAC-Policy-Wizard/app/src/Exceptions_Control.cs
+++ b/WDAC-Policy-Wizard/app/src/Exceptions_Control.cs
@@ -978,7 +978,7 @@ namespace WDAC_Wizard
                     {
                         comboBox.ForeColor = Color.Black;
                         comboBox.BackColor = Color.White;
-                        comboBox.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+                        comboBox.FlatStyle = System.Windows.Forms.FlatStyle.Standard;
                         comboBox.Text = "--Select--";
                     }
                 }


### PR DESCRIPTION
ComboBox was more difficult to see in Light Mode. Switching from `FlatStyle.Flat` to `FlatStyle.Standard` displays are define border for the ComboBox, therefore making it display better in Light Mode.

**Before:**

![wdac-combobox-flat](https://github.com/MicrosoftDocs/WDAC-Toolkit/assets/26308319/4a90acf3-4236-4471-ab7d-382af6356b33)

**After:**

![wdac-combobox-standard](https://github.com/MicrosoftDocs/WDAC-Toolkit/assets/26308319/76107e3f-92fb-45c2-8eb2-90f46cb67df8)
