### PR TITLE
PolicyType: Standard Button Design

### DIFF
--- a/WDAC-Policy-Wizard/app/src/PolicyType.Designer.cs
+++ b/WDAC-Policy-Wizard/app/src/PolicyType.Designer.cs
@@ -228,10 +228,7 @@ namespace WDAC_Wizard
             // 
             // button_Browse
             // 
-            this.button_Browse.FlatAppearance.BorderColor = System.Drawing.Color.DodgerBlue;
-            this.button_Browse.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.button_Browse.Font = new System.Drawing.Font("Tahoma", 9F);
-            this.button_Browse.ForeColor = System.Drawing.Color.DodgerBlue;
             this.button_Browse.Location = new System.Drawing.Point(560, 105);
             this.button_Browse.Margin = new System.Windows.Forms.Padding(2);
             this.button_Browse.Name = "button_Browse";
@@ -267,10 +264,7 @@ namespace WDAC_Wizard
             // 
             // button_Browse_Supp
             // 
-            this.button_Browse_Supp.FlatAppearance.BorderColor = System.Drawing.Color.DodgerBlue;
-            this.button_Browse_Supp.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.button_Browse_Supp.Font = new System.Drawing.Font("Tahoma", 9F);
-            this.button_Browse_Supp.ForeColor = System.Drawing.Color.DodgerBlue;
             this.button_Browse_Supp.Location = new System.Drawing.Point(563, 53);
             this.button_Browse_Supp.Margin = new System.Windows.Forms.Padding(2);
             this.button_Browse_Supp.Name = "button_Browse_Supp";

--- a/WDAC-Policy-Wizard/app/src/PolicyType.cs
+++ b/WDAC-Policy-Wizard/app/src/PolicyType.cs
@@ -617,6 +617,12 @@ namespace WDAC_Wizard
             // Set Controls Color (e.g. Radio Buttons)
             SetControlsColor();
 
+            // Set UI for the 'button_Browse' Button
+            Setbutton_BrowseUI();
+
+            // Set UI for the 'button_Browse_Supp' Button
+            Setbutton_Browse_SuppUI();
+
             // Set Labels Color
             List<Label> labels = new List<Label>();
             GetLabelsRecursive(this, labels);
@@ -666,6 +672,64 @@ namespace WDAC_Wizard
             }
         }
 
+        /// <summary>
+        /// Sets the colors for the button_Browse Button which depends on the 
+        /// state of Light and Dark Mode
+        /// </summary>
+        public void Setbutton_BrowseUI()
+        {
+            // Dark Mode
+            if (Properties.Settings.Default.useDarkMode)
+            {
+                button_Browse.FlatAppearance.BorderColor = System.Drawing.Color.DodgerBlue;
+                button_Browse.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+                button_Browse.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+                button_Browse.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+                button_Browse.ForeColor = System.Drawing.Color.DodgerBlue;
+                button_Browse.BackColor = System.Drawing.Color.Transparent;
+            }
+
+            // Light Mode
+            else
+            {
+                button_Browse.FlatAppearance.BorderColor = System.Drawing.Color.Black;
+                button_Browse.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+                button_Browse.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+                button_Browse.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+                button_Browse.ForeColor = System.Drawing.Color.Black;
+                button_Browse.BackColor = System.Drawing.Color.WhiteSmoke;
+            }
+        }
+
+        /// <summary>
+        /// Sets the colors for the button_Browse_Supp Button which depends on the 
+        /// state of Light and Dark Mode
+        /// </summary>
+        public void Setbutton_Browse_SuppUI()
+        {
+            // Dark Mode
+            if (Properties.Settings.Default.useDarkMode)
+            {
+                button_Browse_Supp.FlatAppearance.BorderColor = System.Drawing.Color.DodgerBlue;
+                button_Browse_Supp.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+                button_Browse_Supp.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+                button_Browse_Supp.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+                button_Browse_Supp.ForeColor = System.Drawing.Color.DodgerBlue;
+                button_Browse_Supp.BackColor = System.Drawing.Color.Transparent;
+            }
+
+            // Light Mode
+            else
+            {
+                button_Browse_Supp.FlatAppearance.BorderColor = System.Drawing.Color.Black;
+                button_Browse_Supp.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+                button_Browse_Supp.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+                button_Browse_Supp.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+                button_Browse_Supp.ForeColor = System.Drawing.Color.Black;
+                button_Browse_Supp.BackColor = System.Drawing.Color.WhiteSmoke;
+            }
+        }
+        
         /// <summary>
         /// Gets all of the labels on the form recursively
         /// </summary>
@@ -753,7 +817,7 @@ namespace WDAC_Wizard
                     if (textBox.Tag == null || textBox.Tag.ToString() != Properties.Resources.IgnoreDarkModeTag)
                     {
                         textBox.ForeColor = Color.White;
-                        textBox.BackColor = Color.Black;
+                        textBox.BackColor = Color.FromArgb(15, 15, 15);
                     }
                 }
             }


### PR DESCRIPTION
Ensure Dark/Light Modes follow standard button design.

This follows up on WIP (https://github.com/MicrosoftDocs/WDAC-Toolkit/issues/313).

Also fixed backColor of textBoxes.