### PR TITLE
CustomRules: Standard Button Design

### DIFF
--- a/WDAC-Policy-Wizard/app/src/CustomRuleConditionsPanel.Designer.cs
+++ b/WDAC-Policy-Wizard/app/src/CustomRuleConditionsPanel.Designer.cs
@@ -231,11 +231,7 @@
             // 
             // buttonSearch
             // 
-            this.buttonSearch.BackColor = System.Drawing.Color.Transparent;
-            this.buttonSearch.FlatAppearance.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(16)))), ((int)(((byte)(110)))), ((int)(((byte)(190)))));
-            this.buttonSearch.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.buttonSearch.Font = new System.Drawing.Font("Tahoma", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.buttonSearch.ForeColor = System.Drawing.Color.DodgerBlue;
             this.buttonSearch.Location = new System.Drawing.Point(358, 12);
             this.buttonSearch.Margin = new System.Windows.Forms.Padding(2);
             this.buttonSearch.Name = "buttonSearch";
@@ -946,11 +942,7 @@
             // 
             // button_Browse
             // 
-            this.button_Browse.BackColor = System.Drawing.Color.Transparent;
-            this.button_Browse.FlatAppearance.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(16)))), ((int)(((byte)(110)))), ((int)(((byte)(190)))));
-            this.button_Browse.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.button_Browse.Font = new System.Drawing.Font("Tahoma", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.button_Browse.ForeColor = System.Drawing.Color.DodgerBlue;
             this.button_Browse.Location = new System.Drawing.Point(464, 333);
             this.button_Browse.Margin = new System.Windows.Forms.Padding(2);
             this.button_Browse.Name = "button_Browse";
@@ -999,11 +991,7 @@
             // 
             // button_CreateRule
             // 
-            this.button_CreateRule.BackColor = System.Drawing.Color.White;
-            this.button_CreateRule.FlatAppearance.BorderColor = System.Drawing.Color.Black;
-            this.button_CreateRule.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.button_CreateRule.Font = new System.Drawing.Font("Tahoma", 8.5F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.button_CreateRule.ForeColor = System.Drawing.Color.Black;
             this.button_CreateRule.Location = new System.Drawing.Point(532, 786);
             this.button_CreateRule.Margin = new System.Windows.Forms.Padding(2);
             this.button_CreateRule.Name = "button_CreateRule";
@@ -1015,11 +1003,7 @@
             // 
             // button_Next
             // 
-            this.button_Next.BackColor = System.Drawing.Color.White;
-            this.button_Next.FlatAppearance.BorderColor = System.Drawing.Color.Black;
-            this.button_Next.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.button_Next.Font = new System.Drawing.Font("Tahoma", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.button_Next.ForeColor = System.Drawing.Color.Black;
             this.button_Next.Location = new System.Drawing.Point(648, 786);
             this.button_Next.Margin = new System.Windows.Forms.Padding(2);
             this.button_Next.Name = "button_Next";
@@ -1130,12 +1114,8 @@
             // 
             // button_AddException
             // 
-            this.button_AddException.BackColor = System.Drawing.Color.White;
             this.button_AddException.Enabled = false;
-            this.button_AddException.FlatAppearance.BorderColor = System.Drawing.Color.Gray;
-            this.button_AddException.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.button_AddException.Font = new System.Drawing.Font("Tahoma", 8.5F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.button_AddException.ForeColor = System.Drawing.Color.Gray;
             this.button_AddException.Location = new System.Drawing.Point(419, 786);
             this.button_AddException.Margin = new System.Windows.Forms.Padding(2);
             this.button_AddException.Name = "button_AddException";
@@ -1148,12 +1128,8 @@
             // 
             // button_Back
             // 
-            this.button_Back.BackColor = System.Drawing.Color.White;
             this.button_Back.Enabled = false;
-            this.button_Back.FlatAppearance.BorderColor = System.Drawing.Color.Gray;
-            this.button_Back.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.button_Back.Font = new System.Drawing.Font("Tahoma", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.button_Back.ForeColor = System.Drawing.Color.Gray;
             this.button_Back.Location = new System.Drawing.Point(316, 786);
             this.button_Back.Margin = new System.Windows.Forms.Padding(2);
             this.button_Back.Name = "button_Back";
@@ -1161,7 +1137,6 @@
             this.button_Back.TabIndex = 110;
             this.button_Back.Text = "< Back";
             this.button_Back.UseVisualStyleBackColor = false;
-            this.button_Back.EnabledChanged += new System.EventHandler(this.Button_Back_EnabledChanged);
             this.button_Back.Click += new System.EventHandler(this.Button_Back_Click);
             // 
             // backgroundWorker

--- a/WDAC-Policy-Wizard/app/src/CustomRuleConditionsPanel.cs
+++ b/WDAC-Policy-Wizard/app/src/CustomRuleConditionsPanel.cs
@@ -207,8 +207,9 @@ namespace WDAC_Wizard
 
             // Packaged family name apps
             // Set the list of apps at button create time
+
             if (this.PolicyCustomRule.Level == PolicyCustomRules.RuleLevel.PackagedFamilyName)
-            {
+            {             
                 // Assert >=1 packaged apps must be selected
                 if (this.checkedListBoxPackagedApps.CheckedItems.Count < 1)
                 {
@@ -1883,12 +1884,31 @@ namespace WDAC_Wizard
             {
                 if (this.checkBox_CustomPath.Checked)
                 {
+                    // Dark Mode
+                    if (Properties.Settings.Default.useDarkMode)
+                    {
                     this.richTextBox_CustomHashes.Visible = true;
                     this.richTextBox_CustomHashes.Location = this.panel_Publisher_Scroll.Location;
                     this.richTextBox_CustomHashes.Tag = "Title";
+                    this.richTextBox_CustomHashes.BackColor = Color.FromArgb(15, 15, 15);
+                    this.richTextBox_CustomHashes.ForeColor = Color.White;
 
                     this.PolicyCustomRule.UsingCustomValues = true;
                     this.textBox_ReferenceFile.Text = String.Empty;
+                    }
+
+                    // Light Mode
+                    else
+                    {
+                    this.richTextBox_CustomHashes.Visible = true;
+                    this.richTextBox_CustomHashes.Location = this.panel_Publisher_Scroll.Location;
+                    this.richTextBox_CustomHashes.Tag = "Title";
+                    this.richTextBox_CustomHashes.BackColor = Color.White;
+                    this.richTextBox_CustomHashes.ForeColor = Color.Black;
+
+                    this.PolicyCustomRule.UsingCustomValues = true;
+                    this.textBox_ReferenceFile.Text = String.Empty;
+                    }
                 }
                 else
                 {
@@ -1900,17 +1920,43 @@ namespace WDAC_Wizard
             {
                 if (this.checkBox_CustomPath.Checked)
                 {
+                    // Dark Mode
+                    if (Properties.Settings.Default.useDarkMode)
+                    {
                     this.PolicyCustomRule.UsingCustomValues = true;
                     this.textBox_ReferenceFile.ReadOnly = false;
                     this.textBox_ReferenceFile.Enabled = true; 
-                    this.textBox_ReferenceFile.BackColor = Color.White; 
+                    this.textBox_ReferenceFile.BackColor = Color.FromArgb(15, 15, 15);
+                    }
+
+                    // Light Mode
+                    else
+                    {
+                    this.PolicyCustomRule.UsingCustomValues = true;
+                    this.textBox_ReferenceFile.ReadOnly = false;
+                    this.textBox_ReferenceFile.Enabled = true; 
+                    this.textBox_ReferenceFile.BackColor = Color.White;
+                    }
                 }
                 else
                 {
+                    // Dark Mode
+                    if (Properties.Settings.Default.useDarkMode)
+                    {
                     this.PolicyCustomRule.UsingCustomValues = false;
                     this.textBox_ReferenceFile.ReadOnly = true;
                     this.textBox_ReferenceFile.Enabled = false;
-                    this.textBox_ReferenceFile.BackColor = SystemColors.Control;
+                    this.textBox_ReferenceFile.BackColor = Color.FromArgb(15, 15, 15);
+                    }
+
+                    // Light Mode
+                    else
+                    {
+                    this.PolicyCustomRule.UsingCustomValues = false;
+                    this.textBox_ReferenceFile.ReadOnly = true;
+                    this.textBox_ReferenceFile.Enabled = false;
+                    this.textBox_ReferenceFile.BackColor = Color.White;
+                    }
 
                     // Set back to the reference file path
                     if(this.DefaultValues[4] != null && this.DefaultValues[4].Length > 0)
@@ -1960,6 +2006,7 @@ namespace WDAC_Wizard
         /// <param name="e"></param>
         private void ButtonSearch_Click(object sender, EventArgs e)
         {
+            
             if (String.IsNullOrEmpty(this.textBox_Packaged_App.Text))
             {
                 label_Error.Visible = true;
@@ -2076,6 +2123,7 @@ namespace WDAC_Wizard
         {
             // If checked, update text on the 'Search' button
             // Hide the PFN search UI
+
             if(this.checkBox_CustomPFN.Checked)
             {
                 this.buttonSearch.Text = "Create";
@@ -2555,6 +2603,11 @@ namespace WDAC_Wizard
             GetTextBoxesRecursive(this, textBoxes);
             SetTextBoxesColor(textBoxes);
 
+            // Set checkedListBoxes Color
+            List<CheckedListBox> checkedListBoxes = new List<CheckedListBox>();
+            GetCheckedListBoxesRecursive(this, checkedListBoxes);
+            SetCheckedListBoxesColor(checkedListBoxes);
+
             // Set Comboboxes Color
             List<ComboBox> comboBoxes = new List<ComboBox>();
             GetComboBoxesRecursive(this, comboBoxes);
@@ -2762,6 +2815,39 @@ namespace WDAC_Wizard
                         textBox.ForeColor = Color.Black;
                         textBox.BackColor = Color.White;
                         textBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Sets the color of the checkedListBoxes defined in the provided List
+        /// </summary>
+        /// <param name="labels"></param>
+        private void SetCheckedListBoxesColor(List<CheckedListBox> checkedListBoxes)
+        {
+            // Dark Mode
+            if (Properties.Settings.Default.useDarkMode)
+            {
+                foreach (CheckedListBox checkedListBox in checkedListBoxes)
+                {
+                    if (checkedListBox.Tag == null || checkedListBox.Tag.ToString() != Properties.Resources.IgnoreDarkModeTag)
+                    {
+                        checkedListBox.ForeColor = Color.White;
+                        checkedListBox.BackColor = Color.FromArgb(15, 15, 15);
+                    }
+                }
+            }
+
+            // Light Mode
+            else
+            {
+                foreach (CheckedListBox checkedListBox in checkedListBoxes)
+                {
+                    if (checkedListBox.Tag == null || checkedListBox.Tag.ToString() != Properties.Resources.IgnoreDarkModeTag)
+                    {
+                        checkedListBox.ForeColor = Color.Black;
+                        checkedListBox.BackColor = Color.White;
                     }
                 }
             }
@@ -3041,6 +3127,26 @@ namespace WDAC_Wizard
                 else
                 {
                     GetTextBoxesRecursive(control, textBoxes);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets all of the labels on the form recursively
+        /// </summary>
+        /// <param name="parent"></param>
+        /// <param name="labels"></param>
+        private void GetCheckedListBoxesRecursive(Control parent, List<CheckedListBox> checkedListBoxes)
+        {
+            foreach (Control control in parent.Controls)
+            {
+                if (control is CheckedListBox checkedListBox)
+                {
+                    checkedListBoxes.Add(checkedListBox);
+                }
+                else
+                {
+                    GetCheckedListBoxesRecursive(control, checkedListBoxes);
                 }
             }
         }

--- a/WDAC-Policy-Wizard/app/src/CustomRuleConditionsPanel.cs
+++ b/WDAC-Policy-Wizard/app/src/CustomRuleConditionsPanel.cs
@@ -1291,19 +1291,52 @@ namespace WDAC_Wizard
                 this.state = UIState.RuleExceptions; 
                 SetUIState();
 
-                // Disable next button 
-                //this.button_Next.ForeColor = Color.Gray;
-                //this.button_Back.FlatAppearance.BorderColor = Color.Gray;
-                this.button_Next.Enabled = false;
-
                 // Enable Back & exception button
-                this.button_Back.ForeColor = Color.Black;
-                this.button_Back.FlatAppearance.BorderColor = Color.Black;
-                this.button_Back.Enabled = true;
+                
+                // Dark Mode
+                if (Properties.Settings.Default.useDarkMode)
+                {
+                    button_Back.FlatAppearance.BorderColor = System.Drawing.Color.DodgerBlue;
+                    button_Back.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+                    button_Back.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+                    button_Back.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+                    button_Back.ForeColor = System.Drawing.Color.DodgerBlue;
+                    button_Back.BackColor = System.Drawing.Color.Transparent;
+                    button_Back.Enabled = true;
+                    button_AddException.FlatAppearance.BorderColor = System.Drawing.Color.DodgerBlue;
+                    button_AddException.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+                    button_AddException.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+                    button_AddException.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+                    button_AddException.ForeColor = System.Drawing.Color.DodgerBlue;
+                    button_AddException.BackColor = System.Drawing.Color.Transparent;
+                    button_AddException.Enabled = true;
+                    // Disable next button 
+                    button_Next.FlatAppearance.BorderColor = Color.Gray;
+                    button_Next.Enabled = false;
+                }
 
-                this.button_AddException.ForeColor = Color.Black;
-                this.button_AddException.FlatAppearance.BorderColor = Color.Black;
-                this.button_AddException.Enabled = true;
+                // Light Mode
+                else
+                {
+                    button_Back.FlatAppearance.BorderColor = System.Drawing.Color.Black;
+                    button_Back.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+                    button_Back.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+                    button_Back.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+                    button_Back.ForeColor = System.Drawing.Color.Black;
+                    button_Back.BackColor = System.Drawing.Color.WhiteSmoke;
+                    button_Back.Enabled = true;
+                    button_AddException.FlatAppearance.BorderColor = System.Drawing.Color.Black;
+                    button_AddException.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+                    button_AddException.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+                    button_AddException.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+                    button_AddException.ForeColor = System.Drawing.Color.Black;
+                    button_AddException.BackColor = System.Drawing.Color.WhiteSmoke;
+                    button_AddException.Enabled = true;
+                    // Disable next button 
+                    button_Next.FlatAppearance.BorderColor = Color.LightGray;
+                    button_Next.Enabled = false;
+                }
+                
             }
             else
             {
@@ -1322,14 +1355,37 @@ namespace WDAC_Wizard
             SetUIState();
 
             // Enable next button 
-            this.button_Next.ForeColor = Color.Black;
-            this.button_Back.FlatAppearance.BorderColor = Color.Black;
-            this.button_Next.Enabled = true;
+            
+            // Dark Mode
+            if (Properties.Settings.Default.useDarkMode)
+            {
+                button_Next.FlatAppearance.BorderColor = System.Drawing.Color.DodgerBlue;
+                button_Next.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+                button_Next.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+                button_Next.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+                button_Next.ForeColor = System.Drawing.Color.DodgerBlue;
+                button_Next.BackColor = System.Drawing.Color.Transparent;
+                button_Next.Enabled = true;
+                // Disable Back button
+                button_Back.FlatAppearance.BorderColor = Color.Gray;
+                button_Back.Enabled = false;
+            }
 
-            // Disable Back button
-            //this.button_Back.ForeColor = Color.Gray;
-            //this.button_Back.FlatAppearance.BorderColor = Color.Gray;
-            this.button_Back.Enabled = false;
+            // Light Mode
+            else
+            {
+                button_Next.FlatAppearance.BorderColor = System.Drawing.Color.Black;
+                button_Next.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+                button_Next.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+                button_Next.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+                button_Next.ForeColor = System.Drawing.Color.Black;
+                button_Next.BackColor = System.Drawing.Color.WhiteSmoke;
+                button_Next.Enabled = true;
+                // Disable Back button
+                //this.button_Back.ForeColor = Color.Gray;
+                button_Back.FlatAppearance.BorderColor = Color.LightGray;
+                button_Back.Enabled = false;
+            }
         }
 
         /// <summary>
@@ -2488,6 +2544,12 @@ namespace WDAC_Wizard
             // Set Controls Color (e.g. Panels, buttons)
             SetControlsColor();
 
+            // Set UI for the 'button_Browse' Button
+            Setbutton_BrowseUI();
+
+            // Set UI for the 'buttonSearch' Button
+            SetbuttonSearchUI();
+
             // Set Textboxes Color
             List<TextBox> textBoxes = new List<TextBox>();
             GetTextBoxesRecursive(this, textBoxes);
@@ -2613,6 +2675,64 @@ namespace WDAC_Wizard
         }
 
         /// <summary>
+        /// Sets the colors for the button_Browse Button which depends on the 
+        /// state of Light and Dark Mode
+        /// </summary>
+        public void Setbutton_BrowseUI()
+        {
+            // Dark Mode
+            if (Properties.Settings.Default.useDarkMode)
+            {
+                button_Browse.FlatAppearance.BorderColor = System.Drawing.Color.DodgerBlue;
+                button_Browse.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+                button_Browse.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+                button_Browse.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+                button_Browse.ForeColor = System.Drawing.Color.DodgerBlue;
+                button_Browse.BackColor = System.Drawing.Color.Transparent;
+            }
+
+            // Light Mode
+            else
+            {
+                button_Browse.FlatAppearance.BorderColor = System.Drawing.Color.Black;
+                button_Browse.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+                button_Browse.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+                button_Browse.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+                button_Browse.ForeColor = System.Drawing.Color.Black;
+                button_Browse.BackColor = System.Drawing.Color.WhiteSmoke;
+            }
+        }
+
+        /// <summary>
+        /// Sets the colors for the buttonSearch Button which depends on the 
+        /// state of Light and Dark Mode
+        /// </summary>
+        public void SetbuttonSearchUI()
+        {
+            // Dark Mode
+            if (Properties.Settings.Default.useDarkMode)
+            {
+                buttonSearch.FlatAppearance.BorderColor = System.Drawing.Color.DodgerBlue;
+                buttonSearch.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+                buttonSearch.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+                buttonSearch.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+                buttonSearch.ForeColor = System.Drawing.Color.DodgerBlue;
+                buttonSearch.BackColor = System.Drawing.Color.Transparent;
+            }
+
+            // Light Mode
+            else
+            {
+                buttonSearch.FlatAppearance.BorderColor = System.Drawing.Color.Black;
+                buttonSearch.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+                buttonSearch.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+                buttonSearch.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+                buttonSearch.ForeColor = System.Drawing.Color.Black;
+                buttonSearch.BackColor = System.Drawing.Color.WhiteSmoke;
+            }
+        }
+        
+        /// <summary>
         /// Sets the color of the textBoxes defined in the provided List
         /// </summary>
         /// <param name="labels"></param>
@@ -2677,7 +2797,7 @@ namespace WDAC_Wizard
                     {
                         comboBox.ForeColor = Color.Black;
                         comboBox.BackColor = Color.White;
-                        comboBox.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+                        comboBox.FlatStyle = System.Windows.Forms.FlatStyle.Standard;
                         comboBox.Text = "--Select--";
                     }
                 }
@@ -2826,18 +2946,30 @@ namespace WDAC_Wizard
                 BackColor = Color.FromArgb(15, 15, 15);
 
                 // Buttons
-                button_Back.ForeColor = Color.Pink;
-                button_Back.BackColor = Color.FromArgb(15, 15, 15);
-                button_Back.FlatAppearance.BorderColor = Color.White;
-                button_AddException.ForeColor = Color.White;
-                button_AddException.BackColor = Color.FromArgb(15, 15, 15);
-                button_AddException.FlatAppearance.BorderColor = Color.White;
-                button_CreateRule.ForeColor = Color.White;
-                button_CreateRule.BackColor = Color.FromArgb(15, 15, 15);
-                button_CreateRule.FlatAppearance.BorderColor = Color.White;
-                button_Next.ForeColor = Color.White;
-                button_Next.BackColor = Color.FromArgb(15, 15, 15);
-                button_Next.FlatAppearance.BorderColor = Color.White;
+                button_Back.FlatAppearance.BorderColor = System.Drawing.Color.Gray;
+                button_Back.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+                button_Back.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+                button_Back.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+                button_Back.ForeColor = System.Drawing.Color.DodgerBlue;
+                button_Back.BackColor = System.Drawing.Color.Transparent;
+                button_AddException.FlatAppearance.BorderColor = System.Drawing.Color.Gray;
+                button_AddException.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+                button_AddException.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+                button_AddException.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+                button_AddException.ForeColor = System.Drawing.Color.DodgerBlue;
+                button_AddException.BackColor = System.Drawing.Color.Transparent;
+                button_CreateRule.FlatAppearance.BorderColor = System.Drawing.Color.DodgerBlue;
+                button_CreateRule.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+                button_CreateRule.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+                button_CreateRule.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+                button_CreateRule.ForeColor = System.Drawing.Color.DodgerBlue;
+                button_CreateRule.BackColor = System.Drawing.Color.Transparent;
+                button_Next.FlatAppearance.BorderColor = System.Drawing.Color.DodgerBlue;
+                button_Next.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+                button_Next.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+                button_Next.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+                button_Next.ForeColor = System.Drawing.Color.DodgerBlue;
+                button_Next.BackColor = System.Drawing.Color.Transparent;
             }
 
             // Light Mode
@@ -2846,18 +2978,30 @@ namespace WDAC_Wizard
                 BackColor = Color.White;
 
                 // Buttons
-                button_Back.ForeColor = Color.Gray;
-                button_Back.BackColor = Color.White;
-                button_Back.FlatAppearance.BorderColor = Color.Black;
-                button_AddException.ForeColor = Color.Gray;
-                button_AddException.BackColor = Color.White;
-                button_AddException.FlatAppearance.BorderColor = Color.Black;
-                button_CreateRule.ForeColor = Color.Black;
-                button_CreateRule.BackColor = Color.White;
-                button_CreateRule.FlatAppearance.BorderColor = Color.Black;
-                button_Next.ForeColor = Color.Black;
-                button_Next.BackColor = Color.White;
-                button_Next.FlatAppearance.BorderColor = Color.Black;
+                button_Back.FlatAppearance.BorderColor = System.Drawing.Color.LightGray;
+                button_Back.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+                button_Back.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+                button_Back.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+                button_Back.ForeColor = System.Drawing.Color.Black;
+                button_Back.BackColor = System.Drawing.Color.WhiteSmoke;
+                button_AddException.FlatAppearance.BorderColor = System.Drawing.Color.LightGray;
+                button_AddException.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+                button_AddException.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+                button_AddException.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+                button_AddException.ForeColor = System.Drawing.Color.Black;
+                button_AddException.BackColor = System.Drawing.Color.WhiteSmoke;
+                button_CreateRule.FlatAppearance.BorderColor = System.Drawing.Color.Black;
+                button_CreateRule.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+                button_CreateRule.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+                button_CreateRule.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+                button_CreateRule.ForeColor = System.Drawing.Color.Black;
+                button_CreateRule.BackColor = System.Drawing.Color.WhiteSmoke;
+                button_Next.FlatAppearance.BorderColor = System.Drawing.Color.Black;
+                button_Next.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+                button_Next.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+                button_Next.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+                button_Next.ForeColor = System.Drawing.Color.Black;
+                button_Next.BackColor = System.Drawing.Color.WhiteSmoke;
             }
         }
 
@@ -2931,22 +3075,28 @@ namespace WDAC_Wizard
             // Dark Mode
             if (Properties.Settings.Default.useDarkMode)
             {
-                button_AddException.ForeColor = Color.White;
-                button_AddException.BackColor = Color.FromArgb(15, 15, 15);
-                button_AddException.FlatAppearance.BorderColor = Color.White;
+                button_AddException.FlatAppearance.BorderColor = System.Drawing.Color.DodgerBlue;
+                button_AddException.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+                button_AddException.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+                button_AddException.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+                button_AddException.ForeColor = System.Drawing.Color.DodgerBlue;
+                button_AddException.BackColor = System.Drawing.Color.Transparent;
             }
 
             // Light Mode
             else
             {
-                button_AddException.ForeColor = Color.Black;
-                button_AddException.BackColor = Color.White; 
-                button_AddException.FlatAppearance.BorderColor = Color.Black;
+                button_AddException.FlatAppearance.BorderColor = System.Drawing.Color.Black;
+                button_AddException.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+                button_AddException.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+                button_AddException.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+                button_AddException.ForeColor = System.Drawing.Color.Black;
+                button_AddException.BackColor = System.Drawing.Color.WhiteSmoke;
             }
         }
 
         /// <summary>
-        /// Sets the color of the Button_AddException when enablement changes
+        /// Sets the color of the button_Back when enablement changes
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
@@ -2955,17 +3105,23 @@ namespace WDAC_Wizard
             // Dark Mode
             if (Properties.Settings.Default.useDarkMode)
             {
-                button_Back.ForeColor = Color.White;
-                button_Back.BackColor = Color.FromArgb(15, 15, 15);
-                button_Back.FlatAppearance.BorderColor = Color.White;
+                button_Back.FlatAppearance.BorderColor = System.Drawing.Color.DodgerBlue;
+                button_Back.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+                button_Back.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+                button_Back.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+                button_Back.ForeColor = System.Drawing.Color.DodgerBlue;
+                button_Back.BackColor = System.Drawing.Color.Transparent;
             }
 
             // Light Mode
             else
             {
-                button_Back.ForeColor = Color.Black;
-                button_Back.BackColor = Color.White;
-                button_Back.FlatAppearance.BorderColor = Color.Black;
+                button_Back.FlatAppearance.BorderColor = System.Drawing.Color.Black;
+                button_Back.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+                button_Back.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+                button_Back.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+                button_Back.ForeColor = System.Drawing.Color.Black;
+                button_Back.BackColor = System.Drawing.Color.WhiteSmoke;
             }
         }
     }

--- a/WDAC-Policy-Wizard/app/src/Exceptions_Control.Designer.cs
+++ b/WDAC-Policy-Wizard/app/src/Exceptions_Control.Designer.cs
@@ -394,11 +394,7 @@
             // 
             // button_Browse
             // 
-            this.button_Browse.BackColor = System.Drawing.Color.Transparent;
-            this.button_Browse.FlatAppearance.BorderColor = System.Drawing.Color.DodgerBlue;
-            this.button_Browse.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.button_Browse.Font = new System.Drawing.Font("Tahoma", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.button_Browse.ForeColor = System.Drawing.Color.DodgerBlue;
             this.button_Browse.Location = new System.Drawing.Point(493, 455);
             this.button_Browse.Margin = new System.Windows.Forms.Padding(2);
             this.button_Browse.Name = "button_Browse";

--- a/WDAC-Policy-Wizard/app/src/Exceptions_Control.cs
+++ b/WDAC-Policy-Wizard/app/src/Exceptions_Control.cs
@@ -786,6 +786,9 @@ namespace WDAC_Wizard
             // Set Controls Color (e.g. Panels, buttons)
             SetControlsColor();
 
+            // Set UI for the 'button_Browse' Button
+            Setbutton_BrowseUI();
+
             // Set Textboxes Color
             List<TextBox> textBoxes = new List<TextBox>();
             GetTextBoxesRecursive(this, textBoxes);
@@ -914,6 +917,35 @@ namespace WDAC_Wizard
         }
 
         /// <summary>
+        /// Sets the colors for the button_Browse Button which depends on the 
+        /// state of Light and Dark Mode
+        /// </summary>
+        public void Setbutton_BrowseUI()
+        {
+            // Dark Mode
+            if (Properties.Settings.Default.useDarkMode)
+            {
+                button_Browse.FlatAppearance.BorderColor = System.Drawing.Color.DodgerBlue;
+                button_Browse.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+                button_Browse.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+                button_Browse.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+                button_Browse.ForeColor = System.Drawing.Color.DodgerBlue;
+                button_Browse.BackColor = System.Drawing.Color.Transparent;
+            }
+
+            // Light Mode
+            else
+            {
+                button_Browse.FlatAppearance.BorderColor = System.Drawing.Color.Black;
+                button_Browse.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+                button_Browse.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+                button_Browse.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+                button_Browse.ForeColor = System.Drawing.Color.Black;
+                button_Browse.BackColor = System.Drawing.Color.WhiteSmoke;
+            }
+        }
+        
+        /// <summary>
         /// Sets the color of the textBoxes defined in the provided List
         /// </summary>
         /// <param name="labels"></param>
@@ -978,7 +1010,7 @@ namespace WDAC_Wizard
                     {
                         comboBox.ForeColor = Color.Black;
                         comboBox.BackColor = Color.White;
-                        comboBox.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+                        comboBox.FlatStyle = System.Windows.Forms.FlatStyle.Standard;
                         comboBox.Text = "--Select--";
                     }
                 }


### PR DESCRIPTION
Ensure Dark/Light Modes follow standard button design.

- CustomRuleConditionsPanel page and Exceptions_Control page (all buttons)
- adds Dark/Light modes control over enabled and disabled buttons
- fixed a few bugs/inconsistencies with Back and Next buttons
- included Light Mode comboBox fix from (https://github.com/MicrosoftDocs/WDAC-Toolkit/pull/323)

This follows up on WIP (https://github.com/MicrosoftDocs/WDAC-Toolkit/issues/313).

Screenshots:

![wdac-custompanel1](https://github.com/MicrosoftDocs/WDAC-Toolkit/assets/26308319/fc89fd33-9635-4e29-aea1-88fbf303b071)

![wdac-custompanel2](https://github.com/MicrosoftDocs/WDAC-Toolkit/assets/26308319/af95afac-5059-4652-bbec-0b355a3fcc95)

![wdac-custompanel3](https://github.com/MicrosoftDocs/WDAC-Toolkit/assets/26308319/df9f3c9d-fe31-4ab0-8f98-449edce88f9e)

![wdac-custompanel4](https://github.com/MicrosoftDocs/WDAC-Toolkit/assets/26308319/015c6636-35be-4c23-ab91-482d18390d56)
