### PR TITLE
SigningRules: Standard Button Design

### DIFF
--- a/WDAC-Policy-Wizard/app/src/SigningRules_Control.Designer.cs
+++ b/WDAC-Policy-Wizard/app/src/SigningRules_Control.Designer.cs
@@ -190,18 +190,14 @@ namespace WDAC_Wizard
             // 
             // deleteButton
             // 
-            this.deleteButton.FlatAppearance.BorderSize = 0;
-            this.deleteButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.deleteButton.Font = new System.Drawing.Font("Tahoma", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.deleteButton.Image = global::WDAC_Wizard.Properties.Resources.minus_button;
-            this.deleteButton.Location = new System.Drawing.Point(903, 607);
+            this.deleteButton.Location = new System.Drawing.Point(905, 607);
             this.deleteButton.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.deleteButton.Name = "deleteButton";
-            this.deleteButton.Size = new System.Drawing.Size(154, 26);
+            this.deleteButton.Size = new System.Drawing.Size(114, 26);
             this.deleteButton.TabIndex = 93;
-            this.deleteButton.Text = "   Remove Rule";
+            this.deleteButton.Text = "- Remove Rule";
             this.deleteButton.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-            this.deleteButton.TextImageRelation = System.Windows.Forms.TextImageRelation.ImageBeforeText;
             this.deleteButton.UseVisualStyleBackColor = true;
             this.deleteButton.Click += new System.EventHandler(this.DeleteButton_Click);
             // 
@@ -223,18 +219,14 @@ namespace WDAC_Wizard
             // 
             // addButton
             // 
-            this.addButton.FlatAppearance.BorderSize = 0;
-            this.addButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.addButton.Font = new System.Drawing.Font("Tahoma", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.addButton.Image = global::WDAC_Wizard.Properties.Resources.add_button;
             this.addButton.Location = new System.Drawing.Point(881, 132);
             this.addButton.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.addButton.Name = "addButton";
-            this.addButton.Size = new System.Drawing.Size(174, 26);
+            this.addButton.Size = new System.Drawing.Size(146, 26);
             this.addButton.TabIndex = 97;
-            this.addButton.Text = "   Add Custom Rule";
+            this.addButton.Text = "+ Add Custom Rule";
             this.addButton.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-            this.addButton.TextImageRelation = System.Windows.Forms.TextImageRelation.ImageBeforeText;
             this.addButton.UseVisualStyleBackColor = true;
             this.addButton.Click += new System.EventHandler(this.Label_AddCustomRules_Click);
             // 

--- a/WDAC-Policy-Wizard/app/src/SigningRules_Control.cs
+++ b/WDAC-Policy-Wizard/app/src/SigningRules_Control.cs
@@ -91,7 +91,7 @@ namespace WDAC_Wizard
         private void Label_AddCustomRules_Click(object sender, EventArgs e)
         {
             // Open the custom rules conditions panel
-
+            
             if (this.customRuleConditionsPanel == null)
             {
                 this.customRuleConditionsPanel = new CustomRuleConditionsPanel(this);
@@ -101,7 +101,7 @@ namespace WDAC_Wizard
                 this.customRuleConditionsPanel.ForceRepaint();
 
                 // this.label_AddCustomRules.Text = "- Custom Rules"; 
-                this.isCustomPanelOpen = true; 
+                this.isCustomPanelOpen = true;
             }
             
             this.Log.AddInfoMsg("--- Create Custom Rules Selected ---"); 
@@ -1262,8 +1262,13 @@ namespace WDAC_Wizard
                     if (control is Button button
                         && (button.Tag == null || button.Tag.ToString() != Properties.Resources.IgnoreDarkModeTag))
                     {
-                        button.ForeColor = Color.White;
-                        button.BackColor = Color.FromArgb(15,15,15);
+                        button.FlatAppearance.BorderColor = System.Drawing.Color.DodgerBlue;
+                        button.FlatAppearance.BorderSize = 0;
+                        button.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+                        button.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+                        button.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+                        button.ForeColor = System.Drawing.Color.DodgerBlue;
+                        button.BackColor = System.Drawing.Color.Transparent;
                     }
 
                     // Panels
@@ -1282,10 +1287,6 @@ namespace WDAC_Wizard
                         checkBox.BackColor = Color.FromArgb(15, 15, 15);
                     }
                 }
-
-                // Button Images
-                addButton.Image = Properties.Resources.white_add_button;
-                deleteButton.Image = Properties.Resources.white_minus_button; 
             }
 
             // Light Mode
@@ -1297,8 +1298,13 @@ namespace WDAC_Wizard
                     if (control is Button button
                         && (button.Tag == null || button.Tag.ToString() != Properties.Resources.IgnoreDarkModeTag))
                     {
-                        button.ForeColor = Color.Black;
-                        button.BackColor = Color.White;
+                        button.FlatAppearance.BorderColor = System.Drawing.Color.Black;
+                        button.FlatAppearance.BorderSize = 0;
+                        button.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+                        button.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(50,30,144,255);
+                        button.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+                        button.ForeColor = System.Drawing.Color.FromArgb(16, 110, 190);
+                        button.BackColor = System.Drawing.Color.Transparent;
                     }
 
                     // Panels
@@ -1317,10 +1323,6 @@ namespace WDAC_Wizard
                         checkBox.BackColor = Color.White;
                     }
                 }
-
-                // Button Images
-                addButton.Image = Properties.Resources.add_button;
-                deleteButton.Image = Properties.Resources.minus_button; 
             }
         }
 


### PR DESCRIPTION
This essentially keeps the button design the same as it was, but simply adds the same mouseover hover color as the other buttons.

This follows up on WIP (https://github.com/MicrosoftDocs/WDAC-Toolkit/issues/313).