### PR TITLE
Update advanced-hunting.md

### DIFF
--- a/WDAC-Policy-Wizard/docs/using/advanced-hunting.md
+++ b/WDAC-Policy-Wizard/docs/using/advanced-hunting.md
@@ -22,7 +22,7 @@ DeviceEvents
 | extend PolicyId = parsejson(AdditionalFields).PolicyID
 | extend PolicyName = parsejson(AdditionalFields).PolicyName
 // Keep only actionable info for the Wizard
-| project Timestamp,DeviceId,DeviceName,ActionType,FileName,FolderPath,SHA1,SHA256,IssuerName,IssuerTBSHash,PublisherName,PublisherTBSHash,AuthenticodeHash,PolicyId,PolicyName
+| project-keep Timestamp,DeviceId,DeviceName,ActionType,FileName,FolderPath,SHA1,SHA256,IssuerName,IssuerTBSHash,PublisherName,PublisherTBSHash,AuthenticodeHash,PolicyId,PolicyName
 ```
 
 The Wizard is expecting **exactly the following data fields**:


### PR DESCRIPTION
Update the KQL query from "project" to "project-keep", otherwise the results window drops the "AuthenticodeHash" column if the whole column has null values.

[project-keep operator documentation](https://learn.microsoft.com/en-us/azure/data-explorer/kusto/query/project-keep-operator)