### PR TITLE
Fixed XML Parsing Error with ExceptAllowRules

### DIFF
--- a/WDAC-Policy-Wizard/app/src/MainForm.cs
+++ b/WDAC-Policy-Wizard/app/src/MainForm.cs
@@ -109,8 +109,7 @@ namespace WDAC_Wizard
                 this.Policy._PolicyType = WDAC_Policy.PolicyType.BasePolicy;
 
                 PageController(sender, e); 
-                button_Next.Visible = true; 
-
+                button_Next.Visible = true;
             }
 
             else

--- a/WDAC-Policy-Wizard/app/src/SigningRules_Control.cs
+++ b/WDAC-Policy-Wizard/app/src/SigningRules_Control.cs
@@ -233,14 +233,15 @@ namespace WDAC_Wizard
                         if (scenario.ProductSigners.DeniedSigners.DeniedSigner[i].ExceptAllowRule != null)
                         {
                             // Iterate through all of the exceptions, get the ID and map to filename
-                            for (int j = 0; j < scenario.ProductSigners.AllowedSigners.AllowedSigner[i].ExceptDenyRule.Length; j++)
+                            for (int j = 0; j < scenario.ProductSigners.DeniedSigners.DeniedSigner[i].ExceptAllowRule.Length; j++)
                             {
                                 exceptionID = scenario.ProductSigners.DeniedSigners.DeniedSigner[i].ExceptAllowRule[j].AllowRuleID;
                                 exceptionList += String.Format("{0}, ", exceptionID);
 
                                 if (!fileExceptionsDict.ContainsKey(exceptionID))
+                                {
                                     fileExceptionsDict.Add(scenario.ProductSigners.DeniedSigners.DeniedSigner[i].ExceptAllowRule[j].AllowRuleID, String.Empty);
-
+                                }
                             }
                         }
 


### PR DESCRIPTION
**Issue**
Properly constructed WDAC policy with DeniedSigner with ExceptAllowRule would fail Wizard parsing resulting in dropping the entry from the Rules table. 

**Root Cause**
The parsing method was referencing the AllowedSigner.ExceptDenyRule instead of DeniedSigner.ExceptAllowRule, presumably due to a bad copy and paste. 

**Fix**
Replaced the bad reference and validated that the XML is correctly parsed

Closing #344 