### PR TITLE
Add script events advanced hunting

### DIFF
--- a/WDAC-Policy-Wizard/app/src/AdvancedHunting.cs
+++ b/WDAC-Policy-Wizard/app/src/AdvancedHunting.cs
@@ -15,7 +15,6 @@ namespace WDAC_Wizard
         const string SCRIPT_AUDIT_EVENT_NAME = "AppControlCIScriptAudited"; // 8028
         const string SCRIPT_BLOCK_EVENT_NAME = "AppControlCIScriptBlocked"; // 8029
 
-
         const int DRIVER_REV_EVENT_ID = 3023;
         const int AUDIT_EVENT_ID = 3076;
         const int BLOCK_EVENT_ID = 3077;

--- a/WDAC-Policy-Wizard/app/src/AdvancedHunting.cs
+++ b/WDAC-Policy-Wizard/app/src/AdvancedHunting.cs
@@ -45,7 +45,7 @@ namespace WDAC_Wizard
             List<CiEvent> ciEvents = new List<CiEvent>(); 
 
             var fileHelperEngine = new FileHelperEngine<AdvancedHunting.Record>();
-            //fileHelperEngine.ErrorManager.ErrorMode = ErrorMode.IgnoreAndContinue; //Read the file and drop bad records
+            fileHelperEngine.ErrorManager.ErrorMode = ErrorMode.IgnoreAndContinue; //Read the file and drop bad records
 
             // Replace any commas like in Zoom Communications, Inc per bug #273
             fileHelperEngine.BeforeReadRecord += FileHelperEngine_BeforeReadRecord;
@@ -317,10 +317,6 @@ namespace WDAC_Wizard
             {
                 signerEvent.PublisherName = signerEvent.PublisherName.Replace(DEL_VALUE, ",");
             }
-
-            // Bug reported where MDE AH is in local time instead of Zulu time
-            // Replace Timestamp	"13/03/2024#C# 3:40:13.988 pm"	with string
-
 
             return signerEvent;
         }


### PR DESCRIPTION
Fixed 2 bugs reported by a WDAC Wizard user pertaining to MDE Advanced Hunting parsing - 

1. 8028/8029 events were not properly consumed by the Wizard
2. Customers who opt for local time, as opposed to ISO 8601 UTC times will not have their signing information events correlated 

The Wizard now supports local time by converting the timestamps to ISO 8601 e.g.  
**13/03/2024, 3:40:13.988 pm** is converted to **2024-03-13T06:40:13.9880000Z**

Fixes #349 
