### PR TITLE
Fixed AllKeys COM bug

### DIFF
--- a/WDAC-Policy-Wizard/app/Properties/Resources.Designer.cs
+++ b/WDAC-Policy-Wizard/app/Properties/Resources.Designer.cs
@@ -272,7 +272,7 @@ namespace WDAC_Wizard.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to All Keys.
+        ///   Looks up a localized string similar to AllKeys.
         /// </summary>
         internal static string ComObjectAllKeys {
             get {

--- a/WDAC-Policy-Wizard/app/Properties/Resources.resx
+++ b/WDAC-Policy-Wizard/app/Properties/Resources.resx
@@ -473,7 +473,7 @@ Please select the  'Create Rule' button.</value>
     <value>The COM Object Guid is invalid. Please see the docs for more information.</value>
   </data>
   <data name="ComObjectAllKeys" xml:space="preserve">
-    <value>All Keys</value>
+    <value>AllKeys</value>
   </data>
   <data name="MSDocLink_ComObjects" xml:space="preserve">
     <value>https://learn.microsoft.com/windows/security/threat-protection/windows-defender-application-control/allow-com-object-registration-in-windows-defender-application-control-policy</value>

--- a/WDAC-Policy-Wizard/app/src/CustomRuleConditionsPanel.Designer.cs
+++ b/WDAC-Policy-Wizard/app/src/CustomRuleConditionsPanel.Designer.cs
@@ -476,7 +476,7 @@
             this.comboBoxComKeyType.Font = new System.Drawing.Font("Tahoma", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.comboBoxComKeyType.FormattingEnabled = true;
             this.comboBoxComKeyType.Items.AddRange(new object[] {
-            "All Keys",
+            "AllKeys",
             "Custom Key"});
             this.comboBoxComKeyType.Location = new System.Drawing.Point(176, 150);
             this.comboBoxComKeyType.Margin = new System.Windows.Forms.Padding(2);


### PR DESCRIPTION
**Issue:**
COM object rules with Keys set to All Keys were broken resulting in all coms being blocked. 

**Root Cause/Fix:**
The string for AllKeys was "All Keys" instead of "AllKeys". Corrected the string in the resources file. 

Fixes #348 