### PR TITLE
Add log analytics parsing in the Wizard

### DIFF
--- a/WDAC-Policy-Wizard/app/Properties/Resources.Designer.cs
+++ b/WDAC-Policy-Wizard/app/Properties/Resources.Designer.cs
@@ -1086,7 +1086,7 @@ namespace WDAC_Wizard.Properties {
         /// <summary>
         ///   Looks up a localized string similar to &lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;
         ///&lt;SiPolicy xmlns=&quot;urn:schemas-microsoft-com:sipolicy&quot; PolicyType=&quot;Base Policy&quot;&gt;
-        ///  &lt;VersionEx&gt;10.2.2.0&lt;/VersionEx&gt;
+        ///  &lt;VersionEx&gt;10.3.0.0&lt;/VersionEx&gt;
         ///  &lt;PlatformID&gt;{2E07F7E4-194C-4D20-B7C9-6F44A6C5A234}&lt;/PlatformID&gt;
         ///  &lt;Rules&gt;
         ///    &lt;Rule&gt;
@@ -1220,7 +1220,7 @@ namespace WDAC_Wizard.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The Wizard could not parse any Advanced Hunting events from the CSV file(s)..
+        ///   Looks up a localized string similar to The Wizard could not parse any events from the CSV file(s)..
         /// </summary>
         internal static string UnsuccessfulAdvancedHuntingLogConversion {
             get {
@@ -1238,7 +1238,7 @@ namespace WDAC_Wizard.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The Wizard did not parse any WDAC events from the selected .evtx files..
+        ///   Looks up a localized string similar to The Wizard did not parse any WDAC events from the selected log files..
         /// </summary>
         internal static string UnsuccessfulEventLogConversionZeroEvents {
             get {

--- a/WDAC-Policy-Wizard/app/Properties/Resources.resx
+++ b/WDAC-Policy-Wizard/app/Properties/Resources.resx
@@ -485,7 +485,7 @@ Please select the  'Create Rule' button.</value>
     <value>Microsoft-Windows-CodeIntegrity/Operational</value>
   </data>
   <data name="UnsuccessfulEventLogConversionZeroEvents" xml:space="preserve">
-    <value>The Wizard did not parse any WDAC events from the selected .evtx files.</value>
+    <value>The Wizard did not parse any WDAC events from the selected log files.</value>
   </data>
   <data name="MSDocLink_RuleLevels" xml:space="preserve">
     <value>https://learn.microsoft.com/windows/security/threat-protection/windows-defender-application-control/select-types-of-rules-to-create#windows-defender-application-control-file-rule-levels</value>
@@ -494,7 +494,7 @@ Please select the  'Create Rule' button.</value>
     <value>The list of selected rule levels is empty. Please select at least 1 rule level to use while scanning the folder.</value>
   </data>
   <data name="UnsuccessfulAdvancedHuntingLogConversion" xml:space="preserve">
-    <value>The Wizard could not parse any Advanced Hunting events from the CSV file(s).</value>
+    <value>The Wizard could not parse any events from the CSV file(s).</value>
   </data>
   <data name="RuleExceptionInProgressText" xml:space="preserve">
     <value>There is an exception rule in progress.

--- a/WDAC-Policy-Wizard/app/WDAC Wizard.csproj
+++ b/WDAC-Policy-Wizard/app/WDAC Wizard.csproj
@@ -111,6 +111,7 @@
     <Compile Include="src\Exceptions_Control.Designer.cs">
       <DependentUpon>Exceptions_Control.cs</DependentUpon>
     </Compile>
+    <Compile Include="src\LogAnalytics.cs" />
     <Compile Include="src\Policy.cs" />
     <Compile Include="src\ConfigTemplate_Control.cs">
       <SubType>UserControl</SubType>

--- a/WDAC-Policy-Wizard/app/src/AdvancedHunting.cs
+++ b/WDAC-Policy-Wizard/app/src/AdvancedHunting.cs
@@ -78,7 +78,7 @@ namespace WDAC_Wizard
                 catch (Exception e)
                 {
                     LastError = e.Message;
-                    // return null; // continue in the case of mixing AH and LogAnalytic csvs
+                    // continue in the case of mixing AH and LogAnalytic csvs
                 }
             }
 

--- a/WDAC-Policy-Wizard/app/src/AdvancedHunting.cs
+++ b/WDAC-Policy-Wizard/app/src/AdvancedHunting.cs
@@ -78,7 +78,7 @@ namespace WDAC_Wizard
                 catch (Exception e)
                 {
                     LastError = e.Message;
-                    return null;
+                    // return null; // continue in the case of mixing AH and LogAnalytic csvs
                 }
             }
 

--- a/WDAC-Policy-Wizard/app/src/AdvancedHunting.cs
+++ b/WDAC-Policy-Wizard/app/src/AdvancedHunting.cs
@@ -152,13 +152,20 @@ namespace WDAC_Wizard
                     localTimeStamp = localTimeStamp.Replace(DEL_VALUE, ",");
 
                     // Parse the timestamp
-                    DateTime localDateTime = DateTime.ParseExact(localTimeStamp, timestampFormat, null);
+                    try
+                    {
+                        DateTime localDateTime = DateTime.ParseExact(localTimeStamp, timestampFormat, null);
 
-                    // Convert to UTC
-                    string utcDateTime = localDateTime.ToUniversalTime().ToString("o");
+                        // Convert to UTC
+                        string utcDateTime = localDateTime.ToUniversalTime().ToString("o");
 
-                    fields[0] = utcDateTime; 
-                    return string.Join(",", fields);
+                        fields[0] = utcDateTime;
+                        return string.Join(",", fields);
+                    }
+                    catch(Exception exp)
+                    {
+                        return localTimeStamp; 
+                    }
                 }
 
             }

--- a/WDAC-Policy-Wizard/app/src/EditWorkflow.Designer.cs
+++ b/WDAC-Policy-Wizard/app/src/EditWorkflow.Designer.cs
@@ -403,7 +403,7 @@ namespace WDAC_Wizard
             this.textBox_AdvancedHuntingPaths.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
             this.textBox_AdvancedHuntingPaths.Size = new System.Drawing.Size(453, 37);
             this.textBox_AdvancedHuntingPaths.TabIndex = 126;
-            this.textBox_AdvancedHuntingPaths.Text = "Select MDE Advanced Hunting and/or LogAnalytic CSV Files";
+            this.textBox_AdvancedHuntingPaths.Text = "Select MDE Advanced Hunting and/or Log Analytics CSV Files";
             // 
             // label8
             // 
@@ -412,9 +412,9 @@ namespace WDAC_Wizard
             this.label8.ForeColor = System.Drawing.Color.Black;
             this.label8.Location = new System.Drawing.Point(23, 210);
             this.label8.Name = "label8";
-            this.label8.Size = new System.Drawing.Size(435, 18);
+            this.label8.Size = new System.Drawing.Size(447, 18);
             this.label8.TabIndex = 125;
-            this.label8.Text = "Parse Advanced Hunting and LogAnalytic Events to Policy";
+            this.label8.Text = "Parse Advanced Hunting and Log Analytics Events to Policy";
             // 
             // textBox_EventLog
             // 
@@ -453,10 +453,10 @@ namespace WDAC_Wizard
             this.ahParsingLearnMore_Label.Location = new System.Drawing.Point(4, 41);
             this.ahParsingLearnMore_Label.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.ahParsingLearnMore_Label.Name = "ahParsingLearnMore_Label";
-            this.ahParsingLearnMore_Label.Size = new System.Drawing.Size(455, 18);
+            this.ahParsingLearnMore_Label.Size = new System.Drawing.Size(467, 18);
             this.ahParsingLearnMore_Label.TabIndex = 127;
             this.ahParsingLearnMore_Label.Tag = "IgnoreDarkMode";
-            this.ahParsingLearnMore_Label.Text = "Learn more about parsing Advanced Hunting and LogAnalytic logs    ";
+            this.ahParsingLearnMore_Label.Text = "Learn more about parsing Advanced Hunting and Log Analytics logs    ";
             this.ahParsingLearnMore_Label.Visible = false;
             this.ahParsingLearnMore_Label.Click += new System.EventHandler(this.AHLearnMoreLabel_Click);
             // 

--- a/WDAC-Policy-Wizard/app/src/EditWorkflow.Designer.cs
+++ b/WDAC-Policy-Wizard/app/src/EditWorkflow.Designer.cs
@@ -117,11 +117,11 @@ namespace WDAC_Wizard
             // 
             // textBoxPolicyPath
             // 
+            this.textBoxPolicyPath.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.textBoxPolicyPath.Font = new System.Drawing.Font("Tahoma", 9F);
             this.textBoxPolicyPath.Location = new System.Drawing.Point(17, 22);
             this.textBoxPolicyPath.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.textBoxPolicyPath.Name = "textBoxPolicyPath";
-            this.textBoxPolicyPath.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.textBoxPolicyPath.ReadOnly = true;
             this.textBoxPolicyPath.Size = new System.Drawing.Size(462, 26);
             this.textBoxPolicyPath.TabIndex = 1;
@@ -179,22 +179,22 @@ namespace WDAC_Wizard
             // 
             // textBox_PolicyName
             // 
+            this.textBox_PolicyName.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.textBox_PolicyName.Font = new System.Drawing.Font("Tahoma", 9F);
             this.textBox_PolicyName.Location = new System.Drawing.Point(126, 42);
             this.textBox_PolicyName.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.textBox_PolicyName.Name = "textBox_PolicyName";
-            this.textBox_PolicyName.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.textBox_PolicyName.Size = new System.Drawing.Size(351, 26);
             this.textBox_PolicyName.TabIndex = 2;
             this.textBox_PolicyName.TextChanged += new System.EventHandler(this.TextBox_PolicyName_TextChanged);
             // 
             // textBoxSaveLocation
             // 
+            this.textBoxSaveLocation.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.textBoxSaveLocation.Font = new System.Drawing.Font("Tahoma", 9F);
             this.textBoxSaveLocation.Location = new System.Drawing.Point(20, 154);
             this.textBoxSaveLocation.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.textBoxSaveLocation.Name = "textBoxSaveLocation";
-            this.textBoxSaveLocation.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.textBoxSaveLocation.ReadOnly = true;
             this.textBoxSaveLocation.Size = new System.Drawing.Size(462, 26);
             this.textBoxSaveLocation.TabIndex = 112;
@@ -213,11 +213,11 @@ namespace WDAC_Wizard
             // 
             // textBox_PolicyID
             // 
+            this.textBox_PolicyID.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.textBox_PolicyID.Font = new System.Drawing.Font("Tahoma", 9F);
             this.textBox_PolicyID.Location = new System.Drawing.Point(126, 77);
             this.textBox_PolicyID.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.textBox_PolicyID.Name = "textBox_PolicyID";
-            this.textBox_PolicyID.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.textBox_PolicyID.Size = new System.Drawing.Size(351, 26);
             this.textBox_PolicyID.TabIndex = 3;
             this.textBox_PolicyID.TextChanged += new System.EventHandler(this.TextBox_PolicyID_TextChanged);
@@ -393,17 +393,17 @@ namespace WDAC_Wizard
             // 
             // textBox_AdvancedHuntingPaths
             // 
+            this.textBox_AdvancedHuntingPaths.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.textBox_AdvancedHuntingPaths.Font = new System.Drawing.Font("Tahoma", 9F);
             this.textBox_AdvancedHuntingPaths.Location = new System.Drawing.Point(22, 232);
             this.textBox_AdvancedHuntingPaths.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.textBox_AdvancedHuntingPaths.Multiline = true;
             this.textBox_AdvancedHuntingPaths.Name = "textBox_AdvancedHuntingPaths";
-            this.textBox_AdvancedHuntingPaths.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.textBox_AdvancedHuntingPaths.ReadOnly = true;
             this.textBox_AdvancedHuntingPaths.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
             this.textBox_AdvancedHuntingPaths.Size = new System.Drawing.Size(453, 37);
             this.textBox_AdvancedHuntingPaths.TabIndex = 126;
-            this.textBox_AdvancedHuntingPaths.Text = "Select MDE Advanced Hunting CSV Files";
+            this.textBox_AdvancedHuntingPaths.Text = "Select MDE Advanced Hunting and/or LogAnalytic CSV Files";
             // 
             // label8
             // 
@@ -412,18 +412,18 @@ namespace WDAC_Wizard
             this.label8.ForeColor = System.Drawing.Color.Black;
             this.label8.Location = new System.Drawing.Point(23, 210);
             this.label8.Name = "label8";
-            this.label8.Size = new System.Drawing.Size(349, 18);
+            this.label8.Size = new System.Drawing.Size(435, 18);
             this.label8.TabIndex = 125;
-            this.label8.Text = "Parse MDE Advanced Hunting Events to Policy";
+            this.label8.Text = "Parse Advanced Hunting and LogAnalytic Events to Policy";
             // 
             // textBox_EventLog
             // 
+            this.textBox_EventLog.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.textBox_EventLog.Font = new System.Drawing.Font("Tahoma", 9F);
             this.textBox_EventLog.Location = new System.Drawing.Point(23, 27);
             this.textBox_EventLog.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.textBox_EventLog.Multiline = true;
             this.textBox_EventLog.Name = "textBox_EventLog";
-            this.textBox_EventLog.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.textBox_EventLog.ReadOnly = true;
             this.textBox_EventLog.Size = new System.Drawing.Size(453, 43);
             this.textBox_EventLog.TabIndex = 123;
@@ -453,10 +453,10 @@ namespace WDAC_Wizard
             this.ahParsingLearnMore_Label.Location = new System.Drawing.Point(4, 41);
             this.ahParsingLearnMore_Label.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.ahParsingLearnMore_Label.Name = "ahParsingLearnMore_Label";
-            this.ahParsingLearnMore_Label.Size = new System.Drawing.Size(349, 18);
+            this.ahParsingLearnMore_Label.Size = new System.Drawing.Size(455, 18);
             this.ahParsingLearnMore_Label.TabIndex = 127;
             this.ahParsingLearnMore_Label.Tag = "IgnoreDarkMode";
-            this.ahParsingLearnMore_Label.Text = "Learn more about parsing Advanced Hunting logs    ";
+            this.ahParsingLearnMore_Label.Text = "Learn more about parsing Advanced Hunting and LogAnalytic logs    ";
             this.ahParsingLearnMore_Label.Visible = false;
             this.ahParsingLearnMore_Label.Click += new System.EventHandler(this.AHLearnMoreLabel_Click);
             // 
@@ -485,12 +485,12 @@ namespace WDAC_Wizard
             // 
             // textBox_EventLogFilePath
             // 
+            this.textBox_EventLogFilePath.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.textBox_EventLogFilePath.Font = new System.Drawing.Font("Tahoma", 9F);
             this.textBox_EventLogFilePath.Location = new System.Drawing.Point(23, 133);
             this.textBox_EventLogFilePath.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.textBox_EventLogFilePath.Multiline = true;
             this.textBox_EventLogFilePath.Name = "textBox_EventLogFilePath";
-            this.textBox_EventLogFilePath.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.textBox_EventLogFilePath.ReadOnly = true;
             this.textBox_EventLogFilePath.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
             this.textBox_EventLogFilePath.Size = new System.Drawing.Size(453, 37);

--- a/WDAC-Policy-Wizard/app/src/EditWorkflow.cs
+++ b/WDAC-Policy-Wizard/app/src/EditWorkflow.cs
@@ -308,7 +308,28 @@ namespace WDAC_Wizard
             }
             else if(this.Workflow == WorkflowType.AdvancedHunting)
             {
-                this._MainWindow.CiEvents = AdvancedHunting.ReadAdvancedHuntingCsvFiles(this.EventLogPaths);
+                // Process CSV file(s) as if they are Advanced Hunting and LogAnalytics
+
+                List<CiEvent> aHuntingEvents = AdvancedHunting.ReadAdvancedHuntingCsvFiles(this.EventLogPaths);
+                List<CiEvent> lAnalyticEvents = LogAnalytics.ReadLogAnalyticCsvFiles(this.EventLogPaths); 
+
+                if(aHuntingEvents != null)
+                {
+                    this._MainWindow.CiEvents = aHuntingEvents; 
+                }
+
+                if(lAnalyticEvents != null)
+                {
+                    if (this._MainWindow.CiEvents == null)
+                    {
+                        this._MainWindow.CiEvents = lAnalyticEvents; 
+                    }
+                    else
+                    {
+                        this._MainWindow.CiEvents.AddRange(lAnalyticEvents);
+                    }
+                }
+
             }
             else
             {

--- a/WDAC-Policy-Wizard/app/src/EventLog.cs
+++ b/WDAC-Policy-Wizard/app/src/EventLog.cs
@@ -617,6 +617,7 @@ namespace WDAC_Wizard
         public string IssuerName { get; set; }
         public byte[] IssuerTBSHash { get; set; }
         public string PublisherName { get; set; }
+        public byte[] PublisherTBSHash { get; set; }
 
         // AH Device Specific
         public string Timestamp { get; set; }

--- a/WDAC-Policy-Wizard/app/src/Helper.cs
+++ b/WDAC-Policy-Wizard/app/src/Helper.cs
@@ -71,8 +71,8 @@ namespace WDAC_Wizard
         /// <summary>
         /// Converts a path like \Device\HarddiskVolume3\Windows\System32\wbem\WMIC.exe to "C\Windows\System32\wbem\WMIC.exe
         /// </summary>
-        /// <param name="NTPath"></param>
-        /// <returns></returns>
+        /// <param name="NTPath">Path containing \Device\HarddiskVolume3</param>
+        /// <returns>A converted path like C:\Windows</returns>
         public static string GetDOSPath(string NTPath)
         {
             string windowsDir = Environment.GetFolderPath(Environment.SpecialFolder.Windows);
@@ -99,8 +99,8 @@ namespace WDAC_Wizard
         /// <summary>
         /// Helper function to call OpenFileDialog and multi-select files
         /// </summary>
-        /// <param name="displayTitle"></param>
-        /// <param name="browseFileType"></param>
+        /// <param name="displayTitle">Title to display on the Open File Dialog UI</param>
+        /// <param name="browseFileType">Enum of types of files supported by the Wizard for opening</param>
         /// <returns>String list of file paths if paths found and user clicks OK. Null otherwise</returns>
         public static List<string> BrowseForMultiFiles(string displayTitle, BrowseFileType browseFileType)
         {
@@ -146,17 +146,17 @@ namespace WDAC_Wizard
         /// <summary>
         /// Browse for single file path using OpenFileDialog
         /// </summary>
-        /// <param name="displayTitle"></param>
-        /// <param name="browseFile"></param>
+        /// <param name="displayTitle">Title to display on the Open File Dialog UI</param>
+        /// <param name="browseFileType">Enum of types of files supported by the Wizard for opening</param>
         /// <returns>Path to file if user selects Ok and file exists. String.Empty otherwise</returns>
-        public static string BrowseForSingleFile(string displayTitle, BrowseFileType browseFile)
+        public static string BrowseForSingleFile(string displayTitle, BrowseFileType browseFileType)
         {
             // Open file dialog to get file or folder path
             OpenFileDialog openFileDialog = new OpenFileDialog();
             openFileDialog.Title = displayTitle;
             openFileDialog.CheckPathExists = true;
 
-            if (browseFile.Equals(BrowseFileType.PEFile))
+            if (browseFileType.Equals(BrowseFileType.PEFile))
             {
                 openFileDialog.Filter = "Portable Executable Files (*.exe; *.dll; *.rll; *.bin)|*.EXE;*.DLL;*.RLL;*.BIN|" +
                 "Script Files (*.ps1, *.bat, *.vbs, *.js)|*.PS1;*.BAT;*.VBS;*.JS|" +
@@ -166,11 +166,11 @@ namespace WDAC_Wizard
 
                 openFileDialog.FilterIndex = 4; // Display All Binary Files by default (everything)
             }
-            else if (browseFile.Equals(BrowseFileType.Policy))
+            else if (browseFileType.Equals(BrowseFileType.Policy))
             {
                 openFileDialog.Filter = "WDAC Policy Files (*.xml)|*.xml";
             }
-            else if (browseFile.Equals(BrowseFileType.CsvFile))
+            else if (browseFileType.Equals(BrowseFileType.CsvFile))
             {
                 openFileDialog.Filter = "MDE AH CSV Files (*.csv)|*.csv";
             }
@@ -191,7 +191,7 @@ namespace WDAC_Wizard
         /// <summary>
         /// Browse for foler path using the FolderBrowserDialog
         /// </summary>
-        /// <param name="displayTitle"></param>
+        /// <param name="displayTitle">Title to display on the Open File Dialog UI</param>
         /// <returns></returns>
         public static string GetFolderPath(string displayTitle)
         {
@@ -212,8 +212,10 @@ namespace WDAC_Wizard
         /// <summary>
         /// Open SaveFileDialog for a single file
         /// </summary>
-        /// <returns>>Path to file if user selects Ok and file exists. String.Empty otherwise</returns>
-        public static string SaveSingleFile(string displayTitle, BrowseFileType browseFile)
+        /// <param name="displayTitle">Title to display on the Open File Dialog UI</param>
+        /// <param name="browseFileType">Enum of types of files supported by the Wizard for saving</param>
+        /// <returns>Path to file if user selects Ok and file exists. String.Empty otherwise</returns>
+        public static string SaveSingleFile(string displayTitle, BrowseFileType browseFileType)
         {
             string saveLocationPath = String.Empty;
 
@@ -222,7 +224,7 @@ namespace WDAC_Wizard
             saveFileDialog.Title = displayTitle;
             saveFileDialog.CheckPathExists = true;
 
-            if (browseFile == BrowseFileType.Policy)
+            if (browseFileType == BrowseFileType.Policy)
             {
                 saveFileDialog.Filter = "Policy Files (*.xml)|*.xml";
             }
@@ -239,12 +241,11 @@ namespace WDAC_Wizard
             return saveLocationPath;
         }
 
-        //
-        // Summary:
-        //     Scans the input string folderPth and finds the filepath with the greatest _ID. 
-        //      
-        // Returns:
-        //     String with the newest _ID filename. example) policy_44.xml 
+        /// <summary>
+        /// Scans the input string folderPth and finds the filepath with the greatest _ID
+        /// </summary>
+        /// <param name="folderPth">Path to the folder where to scan for a unique file</param>
+        /// <returns>String with the newest _ID filename. example) policy_44.xml</returns>
         public static string GetUniquePolicyPath(string folderPth)
         {
             string newUniquePath = "";
@@ -287,7 +288,7 @@ namespace WDAC_Wizard
         /// <summary>
         /// Deserialize the xml policy on disk to SiPolicy
         /// </summary>
-        /// <param name="xmlPath"></param>
+        /// <param name="xmlPath">Path to the xml file on disk</param>
         /// <returns>SiPolicy object</returns>
         public static SiPolicy DeserializeXMLtoPolicy(string xmlPath)
         {
@@ -314,7 +315,7 @@ namespace WDAC_Wizard
         /// <summary>
         /// Deserialize the xml policy string to SiPolicy
         /// </summary>
-        /// <param name="xmlPath"></param>
+        /// <param name="xmlPath">Path to the xml file on disk</param>
         /// <returns>SiPolicy object</returns>
         public static SiPolicy DeserializeXMLStringtoPolicy(string xmlContents)
         {
@@ -345,7 +346,7 @@ namespace WDAC_Wizard
         /// Serialize the SiPolicy object to XML file
         /// </summary>
         /// <param name="siPolicy">SiPolicy object</param>
-        /// <param name="xmlPath">Path to serialize the SiPolicy to</param>
+        /// <param name="xmlPath">Path on disk to serialize the SiPolicy to</param>
         public static void SerializePolicytoXML(SiPolicy siPolicy, string xmlPath)
         {
             if (siPolicy == null || xmlPath == null)
@@ -379,6 +380,11 @@ namespace WDAC_Wizard
             return true;
         }
 
+        /// <summary>
+        /// Formats the CN of the certificate subject
+        /// </summary>
+        /// <param name="publisher">Subject of the publisher containing all the CN=, L=, etc.</param>
+        /// <returns></returns>
         public static string FormatPublisherCN(string publisher)
         {
             string formattedPub;
@@ -401,6 +407,11 @@ namespace WDAC_Wizard
             return formattedPub;
         }
 
+        /// <summary>
+        /// Checks for empty/null or "N/A" in the provided text
+        /// </summary>
+        /// <param name="text">Text string to verify</param>
+        /// <returns></returns>
         public static bool IsValidText(string text)
         {
             if (String.IsNullOrWhiteSpace(text))
@@ -455,8 +466,11 @@ namespace WDAC_Wizard
             return false; 
         }
 
-        // Check that version has 4 parts (follows ww.xx.yy.zz format)
-        // And each part < 2^16
+        /// <summary>
+        /// Check that version has 4 parts (follows ww.xx.yy.zz format), and each part < 2^16
+        /// </summary>
+        /// <param name="version">Version string (e.g. 22.33.456.7890) </param>
+        /// <returns>Bool stating whether the input string is a valid version</returns>
         public static bool IsValidVersion(string version)
         {
             var versionParts = version.Split('.');
@@ -503,6 +517,12 @@ namespace WDAC_Wizard
                                    fileVersionInfo.FileBuildPart, fileVersionInfo.FilePrivatePart);
         }
 
+        /// <summary>
+        /// Compares the min and max versions
+        /// </summary>
+        /// <param name="minVersion"></param>
+        /// <param name="maxVersion"></param>
+        /// <returns></returns>
         public static int CompareVersions(string minVersion, string maxVersion)
         {
             var minversionParts = minVersion.Split('.');
@@ -624,7 +644,9 @@ namespace WDAC_Wizard
 
         /// <summary>
         /// Check that the given directory is write-accessable by the user.  
-        /// /// </summary>
+        /// </summary>
+        /// <param name="path">Directory path to verify user writeability</param>
+        /// <returns>Bool representing user writeability. True if writeable, otherwise, false</returns>
         public static bool IsUserWriteable(string path)
         {
             // Try to create a subdir in the folderPath. If successful, write access is true. 
@@ -680,7 +702,13 @@ namespace WDAC_Wizard
             return results;
         }
 
-        // Dump all of the package family names for the custom rules table
+
+
+        /// <summary>
+        /// Dump all of the package family names for the custom rules table
+        /// </summary>
+        /// <param name="policyCustomRule">PolicyCustomRule object</param>
+        /// <returns>Comma-delimitted tring of packaged family names</returns>
         public static string GetListofPackages(PolicyCustomRules policyCustomRule)
         {
             string output = String.Empty;
@@ -734,110 +762,11 @@ namespace WDAC_Wizard
             return new string(ekuArray);
         }
 
-        public static List<string> GetEKUOctet(int node)
-        {
-            List<string> octet = new List<string>();
-            const int MAX_EKU_VAL = 127;
-            const int MSB = 0;
-            const int IGNORE_POS = 9;
-
-            if (node > MAX_EKU_VAL)
-            {
-                // Node values greater than or equal to 128 are encoded on multiple bytes.
-                // Bit 7 of the leftmost byte is set to one.
-                // Bits 0 through 6 of each byte contains the encoded value.
-                string s = Convert.ToString(node, 2); //Convert to binary in a string
-
-                int[] bits = s.PadLeft(16, '0') // Add 0's from left
-                             .Select(c => int.Parse(c.ToString())) // convert each char to int
-                             .ToArray();
-
-                // MSB (bit 7 of the leftmost byte) set to 1
-                // Ignoring bit 7 of the rightmost byte (ie set to 0)
-                // Shifting the right nibble of the leftmost byte by 1 bit
-                bits[MSB] = 1;
-                bits[IGNORE_POS] = 0;
-
-                bits[4] = bits[5];
-                bits[5] = bits[6];
-                bits[6] = bits[7];
-                bits[7] = 0;
-
-                // Convert left and right byte to hex to add to octet list
-                List<string> decArr = DecodeBitArray(bits);
-                octet.Add(decArr[0] + decArr[1]);
-                octet.Add(decArr[2] + decArr[3]);
-            }
-            else
-            {
-                // Node values less than or equal to 127 are encoded on one byte.
-                octet.Add(FormatHexString(node.ToString("X")));
-            }
-
-            return octet;
-        }
-
-        /// <summary>
-        ///  Simple method to ensure hex values are size=2
-        /// </summary>
-        /// <param name="hex_in"></param>
-        /// <returns></returns>
-        public static string FormatHexString(string hex_in)
-        {
-            if (String.IsNullOrEmpty(hex_in))
-            {
-                return String.Empty;
-            }
-            if (hex_in.Length == 1)
-            {
-                return "0" + hex_in;
-            }
-            else
-            {
-                return hex_in;
-            }
-        }
-
-        /// <summary>
-        /// Convert bit array to hexidecimal values
-        /// </summary>
-        /// <param name="bits"></param>
-        /// <returns></returns>
-        public static List<string> DecodeBitArray(int[] bits)
-        {
-            List<string> octet = new List<string>();
-            int val = 0;
-
-            for (int i = 0; i < bits.Length; i++)
-            {
-                if (i % 4 == 0)
-                {
-                    val = 0;
-                    val += 8 * bits[i];
-                }
-                else if (i % 4 == 1)
-                {
-                    val += 4 * bits[i];
-                }
-                else if (i % 4 == 2)
-                {
-                    val += 2 * bits[i];
-                }
-                else if (i % 4 == 3)
-                {
-                    val += 1 * bits[i];
-                    octet.Add(val.ToString("X"));
-                }
-            }
-
-            return octet;
-        }
-
         /// <summary>
         /// Converts a hash byte[] to hash hex string
         /// </summary>
-        /// <param name="hashByte"></param>
-        /// <returns></returns>
+        /// <param name="hashByte">Byte array of representing a hash</param>
+        /// <returns>Hexidecimal, readable hash string</returns>
         public static string ConvertHash(byte[] hashByte)
         {
             if (hashByte == null)

--- a/WDAC-Policy-Wizard/app/src/Helper.cs
+++ b/WDAC-Policy-Wizard/app/src/Helper.cs
@@ -66,8 +66,13 @@ namespace WDAC_Wizard
         static int cDenyRules = 0;
         static int cAllowRules = 0;
         static int cFileAttribs = 0;
-        static int cSigners = 0; 
+        static int cSigners = 0;
 
+        /// <summary>
+        /// Converts a path like \Device\HarddiskVolume3\Windows\System32\wbem\WMIC.exe to "C\Windows\System32\wbem\WMIC.exe
+        /// </summary>
+        /// <param name="NTPath"></param>
+        /// <returns></returns>
         public static string GetDOSPath(string NTPath)
         {
             string windowsDir = Environment.GetFolderPath(Environment.SpecialFolder.Windows);

--- a/WDAC-Policy-Wizard/app/src/LogAnalytics.cs
+++ b/WDAC-Policy-Wizard/app/src/LogAnalytics.cs
@@ -205,6 +205,9 @@ namespace WDAC_Wizard
         /// <returns></returns>
         private static string ReplaceCommasInRecord(string record)
         {
+            //string delimiter = "\",";
+            //var fields = record.Split(new String[] { delimiter }, StringSplitOptions.None);
+
             var fields = record.Split('"');
             if (fields.Length > 1)
             {
@@ -229,7 +232,7 @@ namespace WDAC_Wizard
             {
                 return record;
             }
-        }
+        }     
 
         /// <summary>
         /// CSV row Record class. Each of the row names map to the variable names below in this order. 
@@ -264,5 +267,41 @@ namespace WDAC_Wizard
             public string PublisherTBSHash;
             public string IssuerTBSHash;
         }
+        
+
+        // 30d CSV
+
+        /*
+        [DelimitedRecord(",")]
+        public class LogAnalyticsRecord
+        {
+            public string TimeGenerated;
+            public string Computer;
+            public string UserName;
+            public string Action;
+            public string publishervalue;
+            public string PublisherName;
+            public string Details;
+            public string AffectedFile;
+            public string ProcessName;
+            public string Status;
+            public string PolicyID;
+            public string PolicyGUID;
+            public string PolicyHash;
+            public string SHA1_Hash;
+            public string OriginalFileName;
+            public string InternalName;
+            public string FileDescription;
+            public string ProductName;
+            public string FileVersion;
+            public string PolicyName;
+            public string SHA256_Hash;
+            public string IssuerName;
+            public string NotValidAfter;
+            public string NotValidBefore;
+            public string PublisherTBSHash;
+            public string IssuerTBSHash;
+        }
+        */
     }
 }

--- a/WDAC-Policy-Wizard/app/src/LogAnalytics.cs
+++ b/WDAC-Policy-Wizard/app/src/LogAnalytics.cs
@@ -194,14 +194,44 @@ namespace WDAC_Wizard
         private static void FileHelperEngine_LogAnalyticsBeforeReadRecord(EngineBase engine, 
             FileHelpers.Events.BeforeReadEventArgs<LogAnalyticsRecord> e)
         {
+            // Replace common phrases with commas first
+            e.RecordLine = ReplaceCommonIssuePhrases(e.RecordLine); 
+
             // Replace the line with the fixed version
             e.RecordLine = ReplaceCommasInRecord(e.RecordLine);
+        }
+
+
+        /// <summary>
+        /// Replaces common phrases to help with comma removal success
+        /// </summary>
+        /// <param name="record"></param>
+        /// <returns></returns>
+        private static string ReplaceCommonIssuePhrases(string record)
+        {
+            /* Common failures include:
+             * However,
+             * auditing policy,
+             * , Inc.
+             */
+            string[] commonFailures = { "However,", "auditing policy,", ", Inc" };
+            string[] replacementValues = { "However", "auditing policy", " Inc" }; 
+
+            for(int i = 0; i < commonFailures.Length; i++)
+            {
+                if(record.Contains(commonFailures[i]))
+                {
+                    record = record.Replace(commonFailures[i], replacementValues[i]); 
+                }
+            }
+
+            return record; 
         }
 
         /// <summary>
         /// Replaces instances of commas within data arrays to #C#
         /// </summary>
-        /// <param name="bad"></param>
+        /// <param></param>
         /// <returns></returns>
         private static string ReplaceCommasInRecord(string record)
         {

--- a/WDAC-Policy-Wizard/app/src/LogAnalytics.cs
+++ b/WDAC-Policy-Wizard/app/src/LogAnalytics.cs
@@ -25,7 +25,8 @@ namespace WDAC_Wizard
         /// <summary>
         /// Parses the CSV file to CiEvent fields
         /// </summary>
-        /// <param name="filepath"></param>
+        /// <param name="filepaths">List of filepaths to try to parse for csv events</param>
+        /// <returns>List of CiEvent objects containing policy event info</returns>
         public static List<CiEvent> ReadLogAnalyticCsvFiles(List<string> filepaths)
         {
             List<CiEvent> ciEvents = new List<CiEvent>();
@@ -64,7 +65,7 @@ namespace WDAC_Wizard
                 catch (Exception e)
                 {
                     LastError = e.Message;
-                    // return null; // continue in the case of mixing AH and LogAnalytic csvs
+                    // continue in the case of mixing AH and LogAnalytic csvs
                 }
             }
 
@@ -73,10 +74,10 @@ namespace WDAC_Wizard
 
 
         /// <summary>
-        /// Iterates through all of the AH records and creates corresponding CiEvent objects
+        /// Iterates through all of the LogAnalytic records and creates corresponding CiEvent objects
         /// </summary>
-        /// <param name="records"></param>
-        /// <returns></returns>
+        /// <param name="records">Array of LogAnalyticRecord objects to use in generating CiEvents</param>
+        /// <returns>List of CiEvent objects containing policy event info</returns>
         public static List<CiEvent> ParseRecordsIntoCiEvents(LogAnalyticsRecord[] records)
         {
             List<CiEvent> ciEvents = new List<CiEvent>();
@@ -112,8 +113,9 @@ namespace WDAC_Wizard
         /// <summary>
         /// Creates a 3076/3077 CiEvent from the fields in the AH Record
         /// </summary>
-        /// <param name="record"></param>
-        /// <returns></returns>
+        /// <param name="record">Single LogAnalytic CSV record to parse into a policy log event</param>
+        /// <param name="eventId">String containing the event ID</param>
+        /// <returns>Single CiEvent object containing policy event info</returns>
         private static CiEvent Create3076_3077Event(LogAnalyticsRecord record, string eventId)
         {
             CiEvent ciEvent = new CiEvent();
@@ -144,9 +146,9 @@ namespace WDAC_Wizard
         /// <summary>
         /// Determines whether the provided ciEvent unique or a duplicate within the event logs
         /// </summary>
-        /// <param name="newEvent"></param>
-        /// <param name="existingEvents"></param>
-        /// <returns></returns>
+        /// <param name="newEvent">Newly created CI policy event</param>
+        /// <param name="existingEvents">List of CI policy events to verify against</param>
+        /// <returns>True if event exists in existingEvents. False if unique event.</returns>
         private static bool IsDuplicateEvent(CiEvent newEvent, List<CiEvent> existingEvents)
         {
             if (existingEvents.Count == 0)
@@ -189,8 +191,8 @@ namespace WDAC_Wizard
         /// <summary>
         /// Event handler for bad data like commas and malformed timestamps
         /// </summary>
-        /// <param name="engine"></param>
-        /// <param name="e"></param>
+        /// <param name="engine">FileHelpers parsing engine</param>
+        /// <param name="e">BeforeReadEventArg</param>
         private static void FileHelperEngine_LogAnalyticsBeforeReadRecord(EngineBase engine, 
             FileHelpers.Events.BeforeReadEventArgs<LogAnalyticsRecord> e)
         {
@@ -205,8 +207,8 @@ namespace WDAC_Wizard
         /// <summary>
         /// Replaces common phrases to help with comma removal success
         /// </summary>
-        /// <param name="record"></param>
-        /// <returns></returns>
+        /// <param name="record">Single LogAnalytic CSV record to verify for common issues</param>
+        /// <returns>String containing the fixed record</returns>
         private static string ReplaceCommonIssuePhrases(string record)
         {
             /* Common failures include:
@@ -231,8 +233,8 @@ namespace WDAC_Wizard
         /// <summary>
         /// Replaces instances of commas within data arrays to #C#
         /// </summary>
-        /// <param></param>
-        /// <returns></returns>
+        /// <param name="record">Single LogAnalytic CSV record to verify for common issues</param>
+        /// <returns>String containing the fixed record</returns>
         private static string ReplaceCommasInRecord(string record)
         {
             //string delimiter = "\",";
@@ -297,41 +299,5 @@ namespace WDAC_Wizard
             public string PublisherTBSHash;
             public string IssuerTBSHash;
         }
-        
-
-        // 30d CSV
-
-        /*
-        [DelimitedRecord(",")]
-        public class LogAnalyticsRecord
-        {
-            public string TimeGenerated;
-            public string Computer;
-            public string UserName;
-            public string Action;
-            public string publishervalue;
-            public string PublisherName;
-            public string Details;
-            public string AffectedFile;
-            public string ProcessName;
-            public string Status;
-            public string PolicyID;
-            public string PolicyGUID;
-            public string PolicyHash;
-            public string SHA1_Hash;
-            public string OriginalFileName;
-            public string InternalName;
-            public string FileDescription;
-            public string ProductName;
-            public string FileVersion;
-            public string PolicyName;
-            public string SHA256_Hash;
-            public string IssuerName;
-            public string NotValidAfter;
-            public string NotValidBefore;
-            public string PublisherTBSHash;
-            public string IssuerTBSHash;
-        }
-        */
     }
 }

--- a/WDAC-Policy-Wizard/app/src/LogAnalytics.cs
+++ b/WDAC-Policy-Wizard/app/src/LogAnalytics.cs
@@ -1,0 +1,268 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using FileHelpers;
+using System.IO; 
+
+namespace WDAC_Wizard
+{
+    internal static class LogAnalytics
+    {
+        // Event ID constants
+        const string AUDIT_EVENT_ID = "3076";
+        const string BLOCK_EVENT_ID = "3077";
+
+        // Delimitted value ',' will be replaced with #C#
+        const string DEL_VALUE = "#C#";
+
+        // Errors
+        const string NORECORDS_EXC = "No LogAnalytics Records parsed";
+        const string HEADERRECORDS_EXC = @"LogAnalytics Records are not properly formatted. 
+                                         The Wizard could not find critical data columns.";
+
+        private static string LastError = string.Empty;
+
+        /// <summary>
+        /// Parses the CSV file to CiEvent fields
+        /// </summary>
+        /// <param name="filepath"></param>
+        public static List<CiEvent> ReadLogAnalyticCsvFiles(List<string> filepaths)
+        {
+            List<CiEvent> ciEvents = new List<CiEvent>();
+
+            var fileHelperEngine = new FileHelperEngine<LogAnalytics.LogAnalyticsRecord>();
+            fileHelperEngine.ErrorManager.ErrorMode = ErrorMode.IgnoreAndContinue; //Read the file and drop bad records
+
+            // Replace any commas like in Zoom Communications, Inc per bug #273
+            fileHelperEngine.BeforeReadRecord += FileHelperEngine_LogAnalyticsBeforeReadRecord;
+
+            // Parse each CSV File provided by the user
+            foreach (var filepath in filepaths)
+            {
+                try
+                {
+                    var records = fileHelperEngine.ReadFile(filepath);
+
+                    // Assert csv must have a header and 1 row of data
+                    if (records.Length < 2)
+                    {
+                        throw new Exception(NORECORDS_EXC);
+                    }
+
+                    // Assert the following columns must be present
+                    if (records[0].Action == null
+                       || records[0].AffectedFile== null
+                       || records[0].SHA1_Hash == null
+                       || records[0].IssuerTBSHash == null)
+                    {
+                        throw new Exception(HEADERRECORDS_EXC);
+                    }
+
+                    ciEvents.AddRange(ParseRecordsIntoCiEvents(records));
+
+                }
+                catch (Exception e)
+                {
+                    LastError = e.Message;
+                    // return null; // continue in the case of mixing AH and LogAnalytic csvs
+                }
+            }
+
+            return ciEvents;
+        }
+
+
+        /// <summary>
+        /// Iterates through all of the AH records and creates corresponding CiEvent objects
+        /// </summary>
+        /// <param name="records"></param>
+        /// <returns></returns>
+        public static List<CiEvent> ParseRecordsIntoCiEvents(LogAnalyticsRecord[] records)
+        {
+            List<CiEvent> ciEvents = new List<CiEvent>();
+            CiEvent ciEvent = new CiEvent();
+
+            foreach (var record in records)
+            {
+                switch (record.Action)
+                {
+                    case AUDIT_EVENT_ID:
+                         ciEvent = Create3076_3077Event(record, AUDIT_EVENT_ID);
+                         break;
+                    
+                     case BLOCK_EVENT_ID:
+                         ciEvent = Create3076_3077Event(record, BLOCK_EVENT_ID);
+                         break;
+
+                    default:
+                        continue;
+                }
+
+                // De-duplicate audit and block events
+                if (!IsDuplicateEvent(ciEvent, ciEvents))
+                {
+                    ciEvents.Add(ciEvent);
+                    ciEvent = new CiEvent();
+                }
+            }
+
+            return ciEvents;
+        }
+
+        /// <summary>
+        /// Creates a 3076/3077 CiEvent from the fields in the AH Record
+        /// </summary>
+        /// <param name="record"></param>
+        /// <returns></returns>
+        private static CiEvent Create3076_3077Event(LogAnalyticsRecord record, string eventId)
+        {
+            CiEvent ciEvent = new CiEvent();
+            ciEvent.EventId = Convert.ToInt32(eventId);
+            ciEvent.FileName = Path.GetFileName(record.AffectedFile);
+            ciEvent.FilePath = Helper.GetDOSPath(record.AffectedFile); // + "\\" + ciEvent.FileName;
+            ciEvent.SHA1 = Helper.ConvertHashStringToByte(record.SHA1_Hash);
+            ciEvent.SHA2 = Helper.ConvertHashStringToByte(record.SHA256_Hash);
+            ciEvent.OriginalFilename = record.OriginalFileName;
+            ciEvent.InternalFilename = record.InternalName;
+            ciEvent.FileDescription = record.FileDescription;
+            ciEvent.ProductName = record.ProductName;
+            ciEvent.FileVersion = record.FileVersion; 
+
+            // Signing Attributes
+            ciEvent.SignerInfo.PublisherName = record.PublisherName;
+            ciEvent.SignerInfo.PublisherTBSHash = Helper.ConvertHashStringToByte(record.PublisherTBSHash); 
+            ciEvent.SignerInfo.IssuerName = record.IssuerName;
+            ciEvent.SignerInfo.IssuerTBSHash = Helper.ConvertHashStringToByte(record.IssuerTBSHash); 
+
+            // Policy
+            ciEvent.PolicyId = record.PolicyGUID; 
+            ciEvent.PolicyName = record.PolicyName;
+
+            return ciEvent;
+        }
+
+        /// <summary>
+        /// Determines whether the provided ciEvent unique or a duplicate within the event logs
+        /// </summary>
+        /// <param name="newEvent"></param>
+        /// <param name="existingEvents"></param>
+        /// <returns></returns>
+        private static bool IsDuplicateEvent(CiEvent newEvent, List<CiEvent> existingEvents)
+        {
+            if (existingEvents.Count == 0)
+            {
+                return false;
+            }
+
+            // Check to see if all of the following match: 
+            // 1. FilePath
+            // 2. EventId (Audit vs Block)
+            // 3. PolicyId (Blocked in different policies --> show each)
+            // 4. FileHash (gives version)
+            // 5. Publisher TBS (PEhash would be the same across different signatures)
+            
+            string filePath = newEvent.FilePath;
+            int eventId = newEvent.EventId;
+            string policyId = newEvent.PolicyId;
+            byte[] eventSHA2 = newEvent.SHA2;
+            byte[] publisherTBS = newEvent.SignerInfo.PublisherTBSHash != null ? newEvent.SignerInfo.PublisherTBSHash : 
+                                    new byte[] { 0 };  // Init to 0 in case file is unsigned
+
+            foreach (CiEvent existingEvent in existingEvents)
+            {               
+                byte[] existingEventPublisherTBS = existingEvent.SignerInfo.PublisherTBSHash != null ?
+                                                    existingEvent.SignerInfo.PublisherTBSHash : new byte[] { 0 };
+
+                if (eventId == existingEvent.EventId
+                    && filePath == existingEvent.FilePath
+                    && policyId == existingEvent.PolicyId
+                    && eventSHA2.SequenceEqual(existingEvent.SHA2)
+                    && publisherTBS.SequenceEqual(existingEventPublisherTBS))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Event handler for bad data like commas and malformed timestamps
+        /// </summary>
+        /// <param name="engine"></param>
+        /// <param name="e"></param>
+        private static void FileHelperEngine_LogAnalyticsBeforeReadRecord(EngineBase engine, 
+            FileHelpers.Events.BeforeReadEventArgs<LogAnalyticsRecord> e)
+        {
+            // Replace the line with the fixed version
+            e.RecordLine = ReplaceCommasInRecord(e.RecordLine);
+        }
+
+        /// <summary>
+        /// Replaces instances of commas within data arrays to #C#
+        /// </summary>
+        /// <param name="bad"></param>
+        /// <returns></returns>
+        private static string ReplaceCommasInRecord(string record)
+        {
+            var fields = record.Split('"');
+            if (fields.Length > 1)
+            {
+                // String replace on the substrings with quotes; skip first and last
+                for (int i = 1; i < fields.Length - 1; i++)
+                {
+                    string sString = fields[i];
+
+                    // Filter out this case - ["DigiCert Trusted G4 Code Signing RSA4096 SHA256, 2021 CA1"
+                    // | ",1bd538b5ca353f4949201b01e8d3d34794020a6f3a79628c2cb36e0656dc5aaf," "Zoom Video Communications, Inc."]
+                    if (sString.Split(',').Length > 2)
+                        continue;
+
+                    sString = sString.Replace(",", DEL_VALUE);
+                    sString = sString.Replace("\"", "");
+                    fields[i] = sString;
+                }
+
+                return string.Join("", fields);
+            }
+            else
+            {
+                return record;
+            }
+        }
+
+        /// <summary>
+        /// CSV row Record class. Each of the row names map to the variable names below in this order. 
+        /// </summary>
+        [DelimitedRecord(",")]
+        public class LogAnalyticsRecord
+        {
+            public string TimeGenerated;
+            public string Computer;
+            public string UserName;
+            public string Action;
+            public string publishervalue;
+            public string PublisherName;
+            public string Details;
+            public string AffectedFile;
+            public string ProcessName;
+            public string Status;
+            public string PolicyID;
+            public string PolicyGUID;
+            public string PolicyHash;
+            public string SHA1_Hash;
+            public string OriginalFileName;
+            public string InternalName;
+            public string FileDescription;
+            public string ProductName;
+            public string FileVersion;
+            public string PolicyName;
+            public string SHA256_Hash;
+            public string IssuerName;
+            public string NotValidAfter;
+            public string NotValidBefore;
+            public string PublisherTBSHash;
+            public string IssuerTBSHash;
+        }
+    }
+}


### PR DESCRIPTION
**What Changed**

Added support for parsing Log Analytics CSV files which the Windows Server team built. The Wizard supports a mix of MDE Advanced Hunting logs and Log Analytics csv files, or one of the other. 

![image](https://github.com/MicrosoftDocs/WDAC-Toolkit/assets/23045608/0aa264f0-eea4-46ed-9eed-324fbb71d7fc)