### PR TITLE
Fixed event log policy output

### DIFF
--- a/WDAC-Policy-Wizard/app/MSIX/EmptyWDAC.xml
+++ b/WDAC-Policy-Wizard/app/MSIX/EmptyWDAC.xml
@@ -37,6 +37,6 @@
   <UpdatePolicySigners />
   <CiSigners />
   <HvciOptions>0</HvciOptions>
-  <BasePolicyID>{784C4414-79F4-4C32-A6A5-F0FB42A51D0D}</BasePolicyID>
-  <PolicyID>{784C4414-79F4-4C32-A6A5-F0FB42A51D0D}</PolicyID>
+  <BasePolicyID>{32002E5A-B0DA-4401-9AC3-C24F25849804}</BasePolicyID>
+  <PolicyID>{32002E5A-B0DA-4401-9AC3-C24F25849804}</PolicyID>
 </SiPolicy>

--- a/WDAC-Policy-Wizard/app/Properties/Resources.Designer.cs
+++ b/WDAC-Policy-Wizard/app/Properties/Resources.Designer.cs
@@ -349,7 +349,33 @@ namespace WDAC_Wizard.Properties {
                 return ResourceManager.GetString("EmptyWDAC", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to &lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;
+        ///&lt;SiPolicy xmlns=&quot;urn:schemas-microsoft-com:sipolicy&quot; PolicyType=&quot;Supplemental Policy&quot;&gt;
+        ///  &lt;VersionEx&gt;10.0.0.0&lt;/VersionEx&gt;
+        ///  &lt;PlatformID&gt;{2E07F7E4-194C-4D20-B7C9-6F44A6C5A234}&lt;/PlatformID&gt;
+        ///  &lt;Rules&gt;
+        ///    &lt;Rule&gt;
+        ///      &lt;Option&gt;Enabled:Unsigned System Integrity Policy&lt;/Option&gt;
+        ///    &lt;/Rule&gt;
+        ///    &lt;Rule&gt;
+        ///      &lt;Option&gt;Enabled:Audit Mode&lt;/Option&gt;
+        ///    &lt;/Rule&gt;
+        ///    &lt;Rule&gt;
+        ///      &lt;Option&gt;Enabled:Advanced Boot Options Menu&lt;/Option&gt;
+        ///    &lt;/Rule&gt;
+        ///    &lt;Rule&gt;
+        ///      &lt;Option&gt;Required:En [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string Empty_Supplemental
+        {
+            get
+            {
+                return ResourceManager.GetString("Empty_Supplemental", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Empty_Supplemental.xml.
         /// </summary>

--- a/WDAC-Policy-Wizard/app/Properties/Resources.resx
+++ b/WDAC-Policy-Wizard/app/Properties/Resources.resx
@@ -587,4 +587,7 @@ Do you want the Wizard to warn you about these types of path rules in the future
   <data name="MaxVersion" xml:space="preserve">
     <value>65535.65535.65535.65535</value>
   </data>
+  <data name="Empty_Supplemental" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\policyTemplates\Empty_Supplemental.xml;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
 </root>

--- a/WDAC-Policy-Wizard/app/Properties/Settings.Designer.cs
+++ b/WDAC-Policy-Wizard/app/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace WDAC_Wizard.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.10.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.9.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));

--- a/WDAC-Policy-Wizard/app/Resources/policyTemplates/EmptyWDAC.xml
+++ b/WDAC-Policy-Wizard/app/Resources/policyTemplates/EmptyWDAC.xml
@@ -37,6 +37,6 @@
   <UpdatePolicySigners />
   <CiSigners />
   <HvciOptions>0</HvciOptions>
-  <BasePolicyID>{784C4414-79F4-4C32-A6A5-F0FB42A51D0D}</BasePolicyID>
-  <PolicyID>{784C4414-79F4-4C32-A6A5-F0FB42A51D0D}</PolicyID>
+  <BasePolicyID>{32002E5A-B0DA-4401-9AC3-C24F25849804}</BasePolicyID>
+  <PolicyID>{32002E5A-B0DA-4401-9AC3-C24F25849804}</PolicyID>
 </SiPolicy>

--- a/WDAC-Policy-Wizard/app/Resources/policyTemplates/Empty_Supplemental.xml
+++ b/WDAC-Policy-Wizard/app/Resources/policyTemplates/Empty_Supplemental.xml
@@ -1,0 +1,46 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<SiPolicy xmlns="urn:schemas-microsoft-com:sipolicy" PolicyType="Supplemental Policy">
+  <VersionEx>10.0.0.0</VersionEx>
+  <PlatformID>{2E07F7E4-194C-4D20-B7C9-6F44A6C5A234}</PlatformID>
+  <!-- The majority of supplemental policy rules are inherited from the base. See https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-application-control/select-types-of-rules-to-create for more info -->
+  <Rules>
+    <Rule>
+      <Option>Enabled:Unsigned System Integrity Policy</Option>
+    </Rule>
+    <Rule>
+      <Option>Enabled:Inherit Default Policy</Option>
+    </Rule>
+  </Rules>
+  <!--EKUS-->
+  <EKUs />
+  <!--File Rules-->
+  <FileRules />
+  <!--Signers-->
+  <Signers />
+  <!--Driver Signing Scenarios-->
+  <SigningScenarios>
+    <SigningScenario Value="131" ID="ID_SIGNINGSCENARIO_DRIVERS_1" FriendlyName="Auto generated policy on 09-24-2021">
+      <ProductSigners />
+    </SigningScenario>
+    <SigningScenario Value="12" ID="ID_SIGNINGSCENARIO_WINDOWS" FriendlyName="Auto generated policy on 09-24-2021">
+      <ProductSigners />
+    </SigningScenario>
+  </SigningScenarios>
+  <UpdatePolicySigners />
+  <CiSigners />
+  <HvciOptions>0</HvciOptions>
+  <BasePolicyID>{E0ABDA1F-CCF0-468E-8855-3E0F08B02D6A}</BasePolicyID>
+  <PolicyID>{B5C8D1E7-A920-4E0C-BD86-783BB59C145E}</PolicyID>
+  <Settings>
+    <Setting Provider="PolicyInfo" Key="Information" ValueName="Name">
+      <Value>
+        <String>SupplementalTemplate</String>
+      </Value>
+    </Setting>
+    <Setting Provider="PolicyInfo" Key="Information" ValueName="Id">
+      <Value>
+        <String>041922</String>
+      </Value>
+    </Setting>
+  </Settings>
+</SiPolicy>

--- a/WDAC-Policy-Wizard/app/WDAC Wizard.csproj
+++ b/WDAC-Policy-Wizard/app/WDAC Wizard.csproj
@@ -33,6 +33,11 @@
     <StartupObject></StartupObject>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Update="Properties\Settings.Designer.cs">
+      <DesignTimeSharedInput>True</DesignTimeSharedInput>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Settings.settings</DependentUpon>
+    </Compile>
     <Compile Update="src\BuildPage.cs">
       <SubType>UserControl</SubType>
     </Compile>
@@ -194,6 +199,10 @@
     <Content Include="Resources\imgs\windows-logo.png" />
     <Content Include="Resources\imgs\wizard-ico.ico" />
     <Content Include="Resources\policyTemplates\AllowMicrosoft.xml" />
+    <None Update="Properties\Settings.settings">
+      <Generator>SettingsSingleFileGenerator</Generator>
+      <LastGenOutput>Settings.Designer.cs</LastGenOutput>
+    </None>
     <None Update="Resources\policyTemplates\cipolicy.xsd">
       <SubType>Designer</SubType>
     </None>

--- a/WDAC-Policy-Wizard/app/src/EventLogRuleConfiguration.cs
+++ b/WDAC-Policy-Wizard/app/src/EventLogRuleConfiguration.cs
@@ -40,7 +40,7 @@ namespace WDAC_Wizard
 
             this.CiEvents = pMainWindow.CiEvents; 
             this._MainWindow = pMainWindow; 
-            this.siPolicy = Helper.DeserializeXMLStringtoPolicy(Properties.Resources.EmptyWDAC);
+            this.siPolicy = Helper.DeserializeXMLStringtoPolicy(Properties.Resources.Empty_Supplemental);
 
             this.DisplayObjects = new List<EventDisplayObject>();
 

--- a/WDAC-Policy-Wizard/app/src/Helper.cs
+++ b/WDAC-Policy-Wizard/app/src/Helper.cs
@@ -889,6 +889,25 @@ namespace WDAC_Wizard
         }
 
         /// <summary>
+        /// Gets the path of the documents folder. If documents folder path doesn't exist, fallsback to Desktop folder
+        /// </summary>
+        /// <returns>MyDocuments folder path. Else, Desktop path</returns>
+        internal static string GetDocumentsFolder()
+        {
+            string docPath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments); 
+            string deskPath = Environment.GetFolderPath(Environment.SpecialFolder.Desktop);
+
+            if(Path.Exists(docPath))
+            {
+                return docPath;
+            }
+            else
+            {
+                return deskPath;
+            }
+        }
+
+        /// <summary>
         /// Calls DateTime.UTCNow and formats to ISO 8601 (YYYY-MM-DD)
         /// </summary>
         /// <returns>DateTime string in format YYYY-MM-DD</returns>

--- a/WDAC-Policy-Wizard/app/src/MainForm.cs
+++ b/WDAC-Policy-Wizard/app/src/MainForm.cs
@@ -771,9 +771,9 @@ namespace WDAC_Wizard
             // Short circuit policy building if using Event Log workflow
             if(this.Policy.PolicyWorkflow == WDAC_Policy.Workflow.Edit && this.EditWorkflow == EditWorkflowType.EventLog)
             {
-                // Save the path under the AppDataLocal\Temp\WDACWizard folder 
+                // Save the path under the Downloads folder 
                 string fileName = String.Format("EventLogPolicy_{0}.xml", Helper.GetFormattedDateTime());
-                string pathToWrite = Path.Combine(this.TempFolderPath, fileName);
+                string pathToWrite = Path.Combine(Helper.GetDocumentsFolder(), fileName);
 
                 try
                 {


### PR DESCRIPTION
**Issues**

1. Policies created were generated with a GUID which collides with a Microsoft policy which causes issues deploying the policy
2. Policies are generated as Base Policies, which some folks didn't like
3. Policies were written to AppDataLocal, which some folks didn't like

**Fixes:**

1. Updated the EmptyWdac.xml GUIDs
2. Policies updated to Supplemental Policy type
3. Policies now written to Documents folder; fallback to Desktop path

Closing #370 