### PR TITLE
Added new AH fields!!

### DIFF
--- a/WDAC-Policy-Wizard/app/src/AdvancedHunting.cs
+++ b/WDAC-Policy-Wizard/app/src/AdvancedHunting.cs
@@ -94,7 +94,7 @@ namespace WDAC_Wizard
         /// <param name="e"></param>
         private static void FileHelperEngine_BeforeReadRecord(EngineBase engine, FileHelpers.Events.BeforeReadEventArgs<Record> e)
         {
-            // Replace double (and tripe quotes) with single quotes
+            // Replace double (and triple quotes) with single quotes
             e.RecordLine = ReplaceMultiQuotes(e.RecordLine);
             
             // Replace the line with the fixed version
@@ -109,8 +109,8 @@ namespace WDAC_Wizard
         /// <summary>
         /// Replaces instances of multiple quotes with single quotes
         /// </summary>
-        /// <param name="bad"></param>
-        /// <returns></returns>
+        /// <param name="record">One CSV line, or record, to clean</param>
+        /// <returns>Cleaned CSV record with double and triple quotes replaced by single quotes</returns>
         private static string ReplaceMultiQuotes(string record)
         {
             // MDE will occasionally wrap the new fields (e.g. OriginalFileName: """WpConDesktopDev.PROGRAM""")
@@ -130,8 +130,8 @@ namespace WDAC_Wizard
         /// <summary>
         /// Replaces instances of commas within data arrays to #C#
         /// </summary>
-        /// <param name="bad"></param>
-        /// <returns></returns>
+        /// <param name="record">One CSV line, or record, to clean</param>
+        /// <returns>Cleaned CSV record with mid-field commas replaced with #C#</returns>
         private static string ReplaceCommasInRecord(string record)
         {
             var fields = record.Split('"');
@@ -169,8 +169,8 @@ namespace WDAC_Wizard
         /// <summary>
         /// Converts local timestamps to UTC like "13/03/2024#C# 3:40:13.988 pm" --> 2024-03-13T06:40:13.9880000Z
         /// </summary>
-        /// <param name="bad"></param>
-        /// <returns></returns>
+        /// <param name="record">One CSV line, or record, to clean</param>
+        /// <returns>Cleaned CSV record with timestamps in ISO 8601 UTC format</returns>
         private static string ConvertTimestampsToUTC(string record)
         {
             // 2 possible timestamp formats MDE AH data can have as of 5/1/2024

--- a/WDAC-Policy-Wizard/docs/using/advanced-hunting.md
+++ b/WDAC-Policy-Wizard/docs/using/advanced-hunting.md
@@ -10,19 +10,27 @@ This document outlines the steps to create a WDAC (CI) policy from the Microsoft
 The WDAC Wizard requires the CSV file in a very specific format. The MDE AH query must follow exactly this format:
 
 ```kql
-DeviceEvents 
-| where ActionType startswith 'AppControlCodeIntegrity' 
-// SigningInfo Fields
-| extend IssuerName = parsejson(AdditionalFields).IssuerName
-| extend IssuerTBSHash = parsejson(AdditionalFields).IssuerTBSHash
-| extend PublisherName = parsejson(AdditionalFields).PublisherName
-| extend PublisherTBSHash = parsejson(AdditionalFields).PublisherTBSHash
-// Audit/Block Fields
-| extend AuthenticodeHash = parsejson(AdditionalFields).AuthenticodeHash
-| extend PolicyId = parsejson(AdditionalFields).PolicyID
-| extend PolicyName = parsejson(AdditionalFields).PolicyName
-// Keep only actionable info for the Wizard
-| project-keep Timestamp,DeviceId,DeviceName,ActionType,FileName,FolderPath,SHA1,SHA256,IssuerName,IssuerTBSHash,PublisherName,PublisherTBSHash,AuthenticodeHash,PolicyId,PolicyName
+ DeviceEvents 
+ | where ActionType startswith 'AppControlCodeIntegrity' 
+ // SigningInfo Fields
+ | extend IssuerName = parsejson(AdditionalFields).IssuerName
+ | extend IssuerTBSHash = parsejson(AdditionalFields).IssuerTBSHash
+ | extend PublisherName = parsejson(AdditionalFields).PublisherName
+ | extend PublisherTBSHash = parsejson(AdditionalFields).PublisherTBSHash
+ // Audit/Block Fields
+ | extend AuthenticodeHash = parsejson(AdditionalFields).AuthenticodeHash
+ | extend PolicyId = parsejson(AdditionalFields).PolicyID
+ | extend PolicyName = parsejson(AdditionalFields).PolicyName
+ // PE Header Fields
+ | extend OriginalFileName = parsejson(AdditionalFields).OriginalFileName
+ | extend ProductName = parsejson(AdditionalFields).ProductName
+ | extend InternalName = parsejson(AdditionalFields).InternalName
+ | extend FileDescription = parsejson(AdditionalFields).FileDescription
+ | extend FileVersion = parsejson(AdditionalFields).FileVersion
+ // Correlation Fields
+ | extend CorrelationId = parsejson(AdditionalFields).EtwActivityId
+ // Keep only actionable info for the Wizard
+ | project Timestamp,DeviceId,DeviceName,ActionType,FileName,FolderPath,SHA1,SHA256,IssuerName,IssuerTBSHash,PublisherName,PublisherTBSHash,AuthenticodeHash,PolicyId,PolicyName, OriginalFileName, ProductName, InternalName, FileDescription, FileVersion, CorrelationId
 ```
 
 The Wizard is expecting **exactly the following data fields**:
@@ -38,9 +46,15 @@ The Wizard is expecting **exactly the following data fields**:
 - IssuerTBSHash
 - PublisherName
 - PublisherTBSHash
-- AuthenticodeHash
-- PolicyId
-- PolicyName
+- AuthenticodeHash (Optional)
+- PolicyId         (Optional)
+- PolicyName       (Optional)
+- OriginalFileName (Optional)
+- ProductName      (Optional)
+- InternalName     (Optional)
+- FileDescription  (Optional)
+- FileVersion      (Optional)
+- CorrelationId    (Optional)
 
 CSV files without the required fields, or with additional fields, may fail to properly parse. 
 


### PR DESCRIPTION
Our MDE Advanced Hunting changes have been implemented and the Wizard can now parse the new fields!

**New fields include:**

OriginalFileName
InternalName
ProductName
FileVersion
FileDescription
EtwCorrelationId

The Wizard remains backwards compatible so correlation will fallback to the previously required timestamps, and none of the new fields are mandatory. This means that users can continue running their existing AH queries or use the new ones:

 ```
DeviceEvents 
 | where ActionType startswith 'AppControlCodeIntegrity' 
 // SigningInfo Fields
 | extend IssuerName = parsejson(AdditionalFields).IssuerName
 | extend IssuerTBSHash = parsejson(AdditionalFields).IssuerTBSHash
 | extend PublisherName = parsejson(AdditionalFields).PublisherName
 | extend PublisherTBSHash = parsejson(AdditionalFields).PublisherTBSHash
 // Audit/Block Fields
 | extend AuthenticodeHash = parsejson(AdditionalFields).AuthenticodeHash
 | extend PolicyId = parsejson(AdditionalFields).PolicyID
 | extend PolicyName = parsejson(AdditionalFields).PolicyName
 // PE Header Fields
 | extend OriginalFileName = parsejson(AdditionalFields).OriginalFileName
 | extend ProductName = parsejson(AdditionalFields).ProductName
 | extend InternalName = parsejson(AdditionalFields).InternalName
 | extend FileDescription = parsejson(AdditionalFields).FileDescription
 | extend FileVersion = parsejson(AdditionalFields).FileVersion
 // Correlation Fields
 | extend CorrelationId = parsejson(AdditionalFields).EtwActivityId
 // Keep only actionable info for the Wizard
 | project Timestamp,DeviceId,DeviceName,ActionType,FileName,FolderPath,SHA1,SHA256,IssuerName,IssuerTBSHash,PublisherName,PublisherTBSHash,AuthenticodeHash,PolicyId,PolicyName, OriginalFileName, ProductName, InternalName, FileDescription, FileVersion, CorrelationId
```
        