### PR TITLE
Updating event log parsing to use json

### DIFF
--- a/WDAC-Policy-Wizard/app/src/Helper.cs
+++ b/WDAC-Policy-Wizard/app/src/Helper.cs
@@ -769,6 +769,18 @@ namespace WDAC_Wizard
         /// <returns></returns>
         public static byte[] ConvertHashStringToByte(string sHash)
         {
+            // Null/empty catch
+            if(String.IsNullOrEmpty(sHash))
+            {
+                return new byte[0];
+            }
+
+            // Odd length
+            if(sHash.Length % 2 == 1)
+            {
+                return new byte[0];
+            }
+
             byte[] bHash = new byte[sHash.Length / 2];
             int _base = 16;
             string sValue;  //chunk into 2's


### PR DESCRIPTION
**Issue:**

- In relation to Issue #382, it was discovered that Windows event log forwarding converts every field to strings. This caused parsing to fail where all hash fields (SHA1, SHA256 and file hashes) are encoded as byte arrays
- Additionally, I recognized that the existing parsing logic drops fields with empty strings (e.g. OriginalFilename, InteralName, etc.). This caused many out of bounds parsing errors

**Fix:**

- Updated event log parsing to use JSON string parsing which addresses both issues above. JSON string parsing allows for indexing all fields, regardless if they are null or empty

**Testing:**

- Tested against all EVTX files in test bank and the ForwardedEvent.evtx file added in the issue