### PR TITLE
Fixed incorrect logic in PowerShell script causing rule actions to be flipped

### DIFF
--- a/WDAC-Policy-Wizard/app/MSIX/CreateSignerPolicy.ps1
+++ b/WDAC-Policy-Wizard/app/MSIX/CreateSignerPolicy.ps1
@@ -11,6 +11,7 @@ param (
 )
 
 # Expected to fail due to CmdletInvocationException error. Hresult = -2146233087
+# This fixes the KeyNotFound error and frees the error for the subsequent New-CiPolicyRule cmd
 try
 {
     $DummySignerRule = New-CIPolicyRule -Level Publisher -DriverFilePath $WdacBinPath -Fallback Hash
@@ -22,11 +23,11 @@ catch
 # Run New-CIPolicyRule to generate a rule object from the provided driver file path and specified level (Publisher vs PcaCertificate)
 if($Deny -eq "False")
 {
-    $SignerRule = New-CIPolicyRule -Level $Level -DriverFilePath $DriverFilePath -Fallback Hash -Deny
+    $SignerRule = New-CIPolicyRule -Level $Level -DriverFilePath $DriverFilePath -Fallback Hash
 }
 else
 {
-    $SignerRule = New-CIPolicyRule -Level $Level -DriverFilePath $DriverFilePath -Fallback Hash
+    $SignerRule = New-CIPolicyRule -Level $Level -DriverFilePath $DriverFilePath -Fallback Hash -Deny
 }
 
 # Create policy from the SignerRule object

--- a/WDAC-Policy-Wizard/app/src/CreateSignerPolicy.ps1
+++ b/WDAC-Policy-Wizard/app/src/CreateSignerPolicy.ps1
@@ -23,11 +23,11 @@ catch
 # Run New-CIPolicyRule to generate a rule object from the provided driver file path and specified level (Publisher vs PcaCertificate)
 if($Deny -eq "False")
 {
-    $SignerRule = New-CIPolicyRule -Level $Level -DriverFilePath $DriverFilePath -Fallback Hash -Deny
+    $SignerRule = New-CIPolicyRule -Level $Level -DriverFilePath $DriverFilePath -Fallback Hash
 }
 else
 {
-    $SignerRule = New-CIPolicyRule -Level $Level -DriverFilePath $DriverFilePath -Fallback Hash
+    $SignerRule = New-CIPolicyRule -Level $Level -DriverFilePath $DriverFilePath -Fallback Hash -Deny
 }
 
 # Create policy from the SignerRule object


### PR DESCRIPTION
**Issue:**

Rules set to Allow in the UI were created as Deny
Rules set to Deny in the UI were created as Allow

**Fix:**

Issue in the new PowerShell script which appended the -Deny flag if the Deny parameter == False. Fixed the logic


Closing #386 