### PR TITLE
Prompt user if the Add Allow Rule button was re-clicked

### DIFF
--- a/WDAC-Policy-Wizard/app/src/EventLogRuleConfiguration.cs
+++ b/WDAC-Policy-Wizard/app/src/EventLogRuleConfiguration.cs
@@ -102,6 +102,20 @@ namespace WDAC_Wizard
             EventDisplayObject dp = this.DisplayObjects[this.SelectedRow];
             CiEvent ciEvent = this.CiEvents[this.SelectedRow];
 
+            // Check if rule was already added
+            if(dp.Action != null &&
+                dp.Action.Contains("Added to policy"))
+            {
+                DialogResult res = MessageBox.Show("This allow rule was already created and will be added to the resulting policy. Do you want to create the rule again?",
+                                                   "WDAC Wizard - New Rule Creation",
+                                                   MessageBoxButtons.YesNo,
+                                                   MessageBoxIcon.Warning);
+                if (res == DialogResult.No)
+                {
+                    return;
+                }
+            }
+
             switch(this.ruleTypeComboBox.SelectedIndex)
             {
                 case 0: // Publisher


### PR DESCRIPTION
**Issue:**

It was discovered that the Wizard will create 1 rule per 1 "+ Allow Rule" button select. 
Closing #395

**Fix:**

Prompt the user if a rule was already created. This allows the user to create a publisher rule, go back, and create a path rule, for example. 

![image](https://github.com/MicrosoftDocs/WDAC-Toolkit/assets/23045608/877773b3-a3aa-47c9-9a73-611a11a4a0d7)
