### PR TITLE
Fix Folder Scan by moving to PS5

### DIFF
--- a/WDAC-Policy-Wizard/app/src/CreateScannedPolicy.ps1
+++ b/WDAC-Policy-Wizard/app/src/CreateScannedPolicy.ps1
@@ -16,7 +16,7 @@ param (
 )
 
 # Run New-CIPolicy -Scan to generate a policy from a directory
-# The command needs to be run twice to generate the full policy. Otherwise, the "An item with the same key has already been added." WARNING prevents the full policy
+# The command needs to be run twice to generate the full policy. Otherwise, the "An item with the same key has already been added." WARNING prevents the full policy from being generated.
 if($Deny -eq "False")
 {
     if($UserPEs -eq "True")

--- a/WDAC-Policy-Wizard/app/src/CreateScannedPolicy.ps1
+++ b/WDAC-Policy-Wizard/app/src/CreateScannedPolicy.ps1
@@ -1,0 +1,45 @@
+﻿# ScanPath: path to scan
+# PolicyPath: path where to create the new policy XML
+# Level: Rule level (e.g. Publisher, PcaCertificate,Hash)
+# Fallback: comma separated list of fallback options
+# PathsToOmit: comma separated list of paths to skip during scanning
+# Deny: True/False
+# UserPEs: whether to scan for User Mode PEs (True/False)
+param (
+    [string]$ScanPath,
+    [string]$PolicyPath,
+    [string]$Level,
+    [string]$Fallback,
+    [string]$PathsToOmit,
+    [string]$Deny,
+    [string]$UserPEs
+)
+
+# Run New-CIPolicy -Scan to generate a policy from a directory
+# The command needs to be run twice to generate the full policy. Otherwise, the "An item with the same key has already been added." WARNING prevents the full policy
+if($Deny -eq "False")
+{
+    if($UserPEs -eq "True")
+    {
+        New-CIPolicy -ScanPath $ScanPath -Level $Level -FilePath $PolicyPath -Fallback $Fallback -OmitPaths $PathsToOmit -UserPEs
+        New-CIPolicy -ScanPath $ScanPath -Level $Level -FilePath $PolicyPath -Fallback $Fallback -OmitPaths $PathsToOmit -UserPEs
+    }
+    else
+    {
+        New-CIPolicy -ScanPath $ScanPath -Level $Level -FilePath $PolicyPath -Fallback $Fallback -OmitPaths $PathsToOmit
+        New-CIPolicy -ScanPath $ScanPath -Level $Level -FilePath $PolicyPath -Fallback $Fallback -OmitPaths $PathsToOmit
+    }
+}
+else
+{
+    if($UserPEs -eq "True")
+    {
+        New-CIPolicy -ScanPath $ScanPath -Level $Level -FilePath $PolicyPath -Fallback $Fallback -OmitPaths $PathsToOmit -UserPEs -Deny
+        New-CIPolicy -ScanPath $ScanPath -Level $Level -FilePath $PolicyPath -Fallback $Fallback -OmitPaths $PathsToOmit -UserPEs -Deny
+    }
+    else
+    {
+        New-CIPolicy -ScanPath $ScanPath -Level $Level -FilePath $PolicyPath -Fallback $Fallback -OmitPaths $PathsToOmit -Deny
+        New-CIPolicy -ScanPath $ScanPath -Level $Level -FilePath $PolicyPath -Fallback $Fallback -OmitPaths $PathsToOmit -Deny
+    }
+}

--- a/WDAC-Policy-Wizard/app/src/MainForm.cs
+++ b/WDAC-Policy-Wizard/app/src/MainForm.cs
@@ -1081,7 +1081,7 @@ namespace WDAC_Wizard
                     && this.Policy._Format == WDAC_Policy.Format.MultiPolicy)
                 {
                     // Run Set-CIPolicyIdInfo -ResetPolicyID to force the policy into multiple policy format
-                    PSCmdlets.ResetGuidPs(this.Policy.SchemaPath);
+                    PSCmdlets.ResetGuidPS(this.Policy.SchemaPath);
 
                     // Deserialize again since Wizard reset the policy on disk to multi-policy
                     siPolicy = Helper.DeserializeXMLtoPolicy(this.Policy.SchemaPath);

--- a/WDAC-Policy-Wizard/app/src/PSCmdlets.cs
+++ b/WDAC-Policy-Wizard/app/src/PSCmdlets.cs
@@ -85,7 +85,7 @@ namespace WDAC_Wizard
                 deny = "True";
             }
 
-            string newPolicyScriptCmd = $"-NoProfile -ExecutionPolicy ByPass -File \"{ps1File}\"" +
+            string newPolicyScriptCmd = $"-NoProfile -ExecutionPolicy ByPass -File \"{ps1File}\" -WdacBinPath \"{wizardPath}\" " +
                 $"-DriverFilePath \"{customRule.ReferenceFile}\" -PolicyPath \"{policyPath}\" -Level {level} -Deny {deny}";
 
             Logger.Log.AddInfoMsg($"Running the following PS cmd in CreateSignerPolicyFromPS(): {newPolicyScriptCmd}");
@@ -175,8 +175,8 @@ namespace WDAC_Wizard
                 deny = "True";
             }
 
-            string newPolicyScriptCmd = $"-NoProfile -ExecutionPolicy ByPass -File \"{ps1File}\" -WdacBinPath \"{wizardPath}\" " +
-                $"-ScanPath \"{scanPath}\" -PolicyPath \"{policyPath}\" -Level {level} -Fallback {fallbacks} -PathsToOmit \"{pathsToOmit}\"" +
+            string newPolicyScriptCmd = $"-NoProfile -ExecutionPolicy ByPass -File \"{ps1File}\" -ScanPath \"{scanPath}\" " +
+                $"-PolicyPath \"{policyPath}\" -Level {level} -Fallback {fallbacks} -PathsToOmit \"{pathsToOmit}\"" +
                 $" -Deny {deny} -UserPEs {userPEs}";
 
             Logger.Log.AddInfoMsg($"Running the following PS cmd in CreateScannedPolicyFromPS(): {newPolicyScriptCmd}");

--- a/WDAC-Policy-Wizard/app/src/PSCmdlets.cs
+++ b/WDAC-Policy-Wizard/app/src/PSCmdlets.cs
@@ -85,7 +85,7 @@ namespace WDAC_Wizard
                 deny = "True";
             }
 
-            string newPolicyScriptCmd = $"-NoProfile -ExecutionPolicy ByPass -File \"{ps1File}\" -WdacBinPath \"{wizardPath}\" " +
+            string newPolicyScriptCmd = $"-NoProfile -ExecutionPolicy ByPass -File \"{ps1File}\"" +
                 $"-DriverFilePath \"{customRule.ReferenceFile}\" -PolicyPath \"{policyPath}\" -Level {level} -Deny {deny}";
 
             Logger.Log.AddInfoMsg($"Running the following PS cmd in CreateSignerPolicyFromPS(): {newPolicyScriptCmd}");

--- a/WDAC-Policy-Wizard/app/src/PolicyHelper.cs
+++ b/WDAC-Policy-Wizard/app/src/PolicyHelper.cs
@@ -1011,7 +1011,7 @@ namespace WDAC_Wizard
 
                     case PolicyCustomRules.RuleType.Hash:
                         {
-                            object[] hashRules = PSCmdlets.CreateHashRulesFromPS(exceptAllowRule);
+                            object[] hashRules = PSCmdlets.CreatePolicyRuleFromPS(exceptAllowRule).FileRules;
                             Array.Resize(ref exceptAllowRules, exceptAllowRules.Length + hashRules.Length - 1); // re-size the exceptDenyRules id to accomodate (likely) 3 more hash rules
                             foreach (object hashRule in hashRules)
                             {
@@ -1065,7 +1065,7 @@ namespace WDAC_Wizard
 
                     case PolicyCustomRules.RuleType.Hash:
                         {
-                            object[] hashRules = PSCmdlets.CreateHashRulesFromPS(exceptDenyRule);
+                            object[] hashRules = PSCmdlets.CreatePolicyRuleFromPS(exceptDenyRule).FileRules;
                             Array.Resize(ref exceptDenyRules, exceptDenyRules.Length + hashRules.Length - 1); // re-size the exceptDenyRules id to accomodate (likely) 3 more hash rules
                             foreach (object hashRule in hashRules)
                             {

--- a/WDAC-Policy-Wizard/app/src/PolicyHelper.cs
+++ b/WDAC-Policy-Wizard/app/src/PolicyHelper.cs
@@ -233,7 +233,7 @@ namespace WDAC_Wizard
         internal static SiPolicy CreateFilePublisherRule(PolicyCustomRules customRule, SiPolicy siPolicy)
         {
             // Still need to run the PS cmd to generate the TBS hash for the signer(s)
-            SiPolicy tempSiPolicy = PSCmdlets.CreateSignerFromPS(customRule);
+            SiPolicy tempSiPolicy = PSCmdlets.CreatePolicyRuleFromPS(customRule);
 
             if (tempSiPolicy == null)
             {


### PR DESCRIPTION
**Issue:**

- The folder scan operation (New-CiPolicy -ScanPath <>) was broken upon upgrade to dotnet core. In addition to New-CIPolicyRule parsing, it appears this scenario is incompatible on pwsh (.NET Core)
- Closing #297 

**Fix:**

- Addressed the bug by moving the folder scan operation into a ps1 file and executing it with the inbox PowerShell (5.x) version
- New-CIPolicy -ScanPath must be called twice as first call generates a "An item with the same key has already been added" WARNING. This causes only a subset of the file rules to be written to policy
- Also moved other PS commands like hash generation to the PS5 invocation method