### PR TITLE
Removed dynamic code security from templates

### DIFF
--- a/WDAC-Policy-Wizard/app/MSIX/AllowMicrosoft - SingleFormat.xml
+++ b/WDAC-Policy-Wizard/app/MSIX/AllowMicrosoft - SingleFormat.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <SiPolicy xmlns="urn:schemas-microsoft-com:sipolicy">
-  <VersionEx>10.1.1.0</VersionEx>
+  <VersionEx>10.0.5.0</VersionEx>
   <PolicyTypeID>{A244370E-44C9-4C06-B551-F6016E563076}</PolicyTypeID>
   <PlatformID>{2E07F7E4-194C-4D20-B7C9-6F44A6C5A234}</PlatformID>
   <Rules>
@@ -146,7 +146,7 @@
     </Setting>
     <Setting Provider="PolicyInfo" Key="Information" ValueName="Id">
       <Value>
-        <String>12022022</String>
+        <String>09172024</String>
       </Value>
     </Setting>
   </Settings>

--- a/WDAC-Policy-Wizard/app/MSIX/AllowMicrosoft.xml
+++ b/WDAC-Policy-Wizard/app/MSIX/AllowMicrosoft.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <SiPolicy xmlns="urn:schemas-microsoft-com:sipolicy" PolicyType="Base Policy">
-  <VersionEx>10.0.4.0</VersionEx>
+  <VersionEx>10.0.5.0</VersionEx>
   <PolicyID>{959A0F15-8985-4551-A208-5FFE9EDB3A70}</PolicyID>
   <BasePolicyID>{959A0F15-8985-4551-A208-5FFE9EDB3A70}</BasePolicyID>
   <PlatformID>{2E07F7E4-194C-4D20-B7C9-6F44A6C5A234}</PlatformID>
@@ -16,9 +16,6 @@
     </Rule>
     <Rule>
       <Option>Enabled:Inherit Default Policy</Option>
-    </Rule>
-    <Rule>
-      <Option>Enabled:Dynamic Code Security</Option>
     </Rule>
     <Rule>
       <Option>Enabled:Update Policy No Reboot</Option>
@@ -168,7 +165,7 @@
     </Setting>
     <Setting Provider="PolicyInfo" Key="Information" ValueName="Id">
       <Value>
-        <String>12022022</String>
+        <String>09172024</String>
       </Value>
     </Setting>
   </Settings>

--- a/WDAC-Policy-Wizard/app/MSIX/DefaultWindows_Audit - SingleFormat.xml
+++ b/WDAC-Policy-Wizard/app/MSIX/DefaultWindows_Audit - SingleFormat.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <SiPolicy xmlns="urn:schemas-microsoft-com:sipolicy">
-  <VersionEx>10.2.0.0</VersionEx>
+  <VersionEx>10.3.0.0</VersionEx>
   <PolicyTypeID>{A244370E-44C9-4C06-B551-F6016E563076}</PolicyTypeID>
   <PlatformID>{2E07F7E4-194C-4D20-B7C9-6F44A6C5A234}</PlatformID>
   <Rules>
@@ -21,9 +21,6 @@
     </Rule>
     <Rule>
       <Option>Enabled:Update Policy No Reboot</Option>
-    </Rule>
-    <Rule>
-      <Option>Enabled:Dynamic Code Security</Option>
     </Rule>
     <Rule>
       <Option>Enabled:Revoked Expired As Unsigned</Option>
@@ -253,7 +250,7 @@
     </Setting>
     <Setting Provider="PolicyInfo" Key="Information" ValueName="Id">
       <Value>
-        <String>04122024</String>
+        <String>09172024</String>
       </Value>
     </Setting>
   </Settings>

--- a/WDAC-Policy-Wizard/app/MSIX/DefaultWindows_Audit.xml
+++ b/WDAC-Policy-Wizard/app/MSIX/DefaultWindows_Audit.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <SiPolicy xmlns="urn:schemas-microsoft-com:sipolicy" PolicyType="Base Policy">
-  <VersionEx>10.2.0.0</VersionEx>
+  <VersionEx>10.3.0.0</VersionEx>
   <PolicyID>{E0ABDA1F-CCF0-468E-8855-3E0F08B02D6A}</PolicyID>
   <BasePolicyID>{E0ABDA1F-CCF0-468E-8855-3E0F08B02D6A}</BasePolicyID>
   <PlatformID>{2E07F7E4-194C-4D20-B7C9-6F44A6C5A234}</PlatformID>
@@ -22,9 +22,6 @@
     </Rule>
     <Rule>
       <Option>Enabled:Update Policy No Reboot</Option>
-    </Rule>
-    <Rule>
-      <Option>Enabled:Dynamic Code Security</Option>
     </Rule>
     <Rule>
       <Option>Enabled:Revoked Expired As Unsigned</Option>
@@ -257,7 +254,7 @@
     </Setting>
     <Setting Provider="PolicyInfo" Key="Information" ValueName="Id">
       <Value>
-        <String>04122024</String>
+        <String>09172024</String>
       </Value>
     </Setting>
   </Settings>

--- a/WDAC-Policy-Wizard/app/Resources/policyTemplates/AllowMicrosoft - SingleFormat.xml
+++ b/WDAC-Policy-Wizard/app/Resources/policyTemplates/AllowMicrosoft - SingleFormat.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <SiPolicy xmlns="urn:schemas-microsoft-com:sipolicy">
-  <VersionEx>10.1.1.0</VersionEx>
+  <VersionEx>10.0.5.0</VersionEx>
   <PolicyTypeID>{A244370E-44C9-4C06-B551-F6016E563076}</PolicyTypeID>
   <PlatformID>{2E07F7E4-194C-4D20-B7C9-6F44A6C5A234}</PlatformID>
   <Rules>
@@ -146,7 +146,7 @@
     </Setting>
     <Setting Provider="PolicyInfo" Key="Information" ValueName="Id">
       <Value>
-        <String>12022022</String>
+        <String>09172024</String>
       </Value>
     </Setting>
   </Settings>

--- a/WDAC-Policy-Wizard/app/Resources/policyTemplates/AllowMicrosoft.xml
+++ b/WDAC-Policy-Wizard/app/Resources/policyTemplates/AllowMicrosoft.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <SiPolicy xmlns="urn:schemas-microsoft-com:sipolicy" PolicyType="Base Policy">
-  <VersionEx>10.0.4.0</VersionEx>
+  <VersionEx>10.0.5.0</VersionEx>
   <PolicyID>{959A0F15-8985-4551-A208-5FFE9EDB3A70}</PolicyID>
   <BasePolicyID>{959A0F15-8985-4551-A208-5FFE9EDB3A70}</BasePolicyID>
   <PlatformID>{2E07F7E4-194C-4D20-B7C9-6F44A6C5A234}</PlatformID>
@@ -16,9 +16,6 @@
     </Rule>
     <Rule>
       <Option>Enabled:Inherit Default Policy</Option>
-    </Rule>
-    <Rule>
-      <Option>Enabled:Dynamic Code Security</Option>
     </Rule>
     <Rule>
       <Option>Enabled:Update Policy No Reboot</Option>
@@ -168,7 +165,7 @@
     </Setting>
     <Setting Provider="PolicyInfo" Key="Information" ValueName="Id">
       <Value>
-        <String>12022022</String>
+        <String>09172024</String>
       </Value>
     </Setting>
   </Settings>

--- a/WDAC-Policy-Wizard/app/Resources/policyTemplates/DefaultWindows_Audit - SingleFormat.xml
+++ b/WDAC-Policy-Wizard/app/Resources/policyTemplates/DefaultWindows_Audit - SingleFormat.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <SiPolicy xmlns="urn:schemas-microsoft-com:sipolicy">
-  <VersionEx>10.2.0.0</VersionEx>
+  <VersionEx>10.3.0.0</VersionEx>
   <PolicyTypeID>{A244370E-44C9-4C06-B551-F6016E563076}</PolicyTypeID>
   <PlatformID>{2E07F7E4-194C-4D20-B7C9-6F44A6C5A234}</PlatformID>
   <Rules>
@@ -21,9 +21,6 @@
     </Rule>
     <Rule>
       <Option>Enabled:Update Policy No Reboot</Option>
-    </Rule>
-    <Rule>
-      <Option>Enabled:Dynamic Code Security</Option>
     </Rule>
     <Rule>
       <Option>Enabled:Revoked Expired As Unsigned</Option>
@@ -253,7 +250,7 @@
     </Setting>
     <Setting Provider="PolicyInfo" Key="Information" ValueName="Id">
       <Value>
-        <String>04122024</String>
+        <String>09172024</String>
       </Value>
     </Setting>
   </Settings>

--- a/WDAC-Policy-Wizard/app/Resources/policyTemplates/DefaultWindows_Audit.xml
+++ b/WDAC-Policy-Wizard/app/Resources/policyTemplates/DefaultWindows_Audit.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <SiPolicy xmlns="urn:schemas-microsoft-com:sipolicy" PolicyType="Base Policy">
-  <VersionEx>10.2.0.0</VersionEx>
+  <VersionEx>10.3.0.0</VersionEx>
   <PolicyID>{E0ABDA1F-CCF0-468E-8855-3E0F08B02D6A}</PolicyID>
   <BasePolicyID>{E0ABDA1F-CCF0-468E-8855-3E0F08B02D6A}</BasePolicyID>
   <PlatformID>{2E07F7E4-194C-4D20-B7C9-6F44A6C5A234}</PlatformID>
@@ -22,9 +22,6 @@
     </Rule>
     <Rule>
       <Option>Enabled:Update Policy No Reboot</Option>
-    </Rule>
-    <Rule>
-      <Option>Enabled:Dynamic Code Security</Option>
     </Rule>
     <Rule>
       <Option>Enabled:Revoked Expired As Unsigned</Option>
@@ -257,7 +254,7 @@
     </Setting>
     <Setting Provider="PolicyInfo" Key="Information" ValueName="Id">
       <Value>
-        <String>04122024</String>
+        <String>09172024</String>
       </Value>
     </Setting>
   </Settings>


### PR DESCRIPTION
## Why? 

- Dynamic code security still continues to log false positive error events. Removing from templates until this behavior is fixed. 

## How Tested?

- Compiled policies to binary
- Verified the UI parses the policy and show Dynamic Code Security disabled


![image](https://github.com/user-attachments/assets/edee7467-fb8a-4efd-be89-2471e575f194)

