### PR TITLE
Update the policy ID at compilation time for event log policies

### DIFF
--- a/WDAC-Policy-Wizard/app/src/MainForm.cs
+++ b/WDAC-Policy-Wizard/app/src/MainForm.cs
@@ -5,22 +5,9 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Data;
 using System.Drawing;
-using System.Linq;
-using System.Net;
-using System.Text;
 using System.Windows.Forms;
 using System.IO;
-using System.Xml.Serialization;
-using System.Management.Automation;
-using System.Collections.ObjectModel;
-using System.Management.Automation.Runspaces;
-using System.Diagnostics;
-using System.Security; 
-using System.Security.Permissions; 
-
-using Microsoft.Win32;
 using WDAC_Wizard.src;
 using WDAC_Wizard.Properties;
 
@@ -774,6 +761,9 @@ namespace WDAC_Wizard
                 // Save the path under the Downloads folder 
                 string fileName = String.Format("EventLogPolicy_{0}.xml", Helper.GetFormattedDateTime());
                 string pathToWrite = Path.Combine(Helper.GetDocumentsFolder(), fileName);
+
+                // Issue # 392 - Reset the policy GUID
+                PolicyHelper.ResetPolicyGuid(this.EventLogPolicy);
 
                 try
                 {

--- a/WDAC-Policy-Wizard/app/src/PolicyHelper.cs
+++ b/WDAC-Policy-Wizard/app/src/PolicyHelper.cs
@@ -1633,7 +1633,7 @@ namespace WDAC_Wizard
                     }
 
                     // Check DeniedSigner.ExceptAllowRules that must be remapped
-                    if(signingScn.ProductSigners.DeniedSigners != null)
+                    if (signingScn.ProductSigners.DeniedSigners != null)
                     {
                         for (int i = 0; i < signingScn.ProductSigners.DeniedSigners.DeniedSigner.Length; i++)
                         {
@@ -1940,5 +1940,31 @@ namespace WDAC_Wizard
                 return String.Empty;
             }
         }
-    } 
+
+        /// <summary>
+        /// Resets the Policy ID for base and supplemental policies and BasePolicy ID, for base policies
+        /// </summary>
+        /// <param name="policy"></param>
+        public static void ResetPolicyGuid(SiPolicy policy)
+        {
+            // Catch null and Legacy policies
+            if (policy == null || policy.BasePolicyID == null)
+            {
+                return;
+            }
+
+            // Base
+            if (policy.BasePolicyID == policy.PolicyID)
+            {
+                policy.BasePolicyID = "{" + Guid.NewGuid().ToString().ToUpper() + "}";
+                policy.PolicyID = policy.BasePolicyID;
+            }
+
+            // Supplemental
+            else
+            {
+                policy.PolicyID = "{" + Guid.NewGuid().ToString().ToUpper() + "}";
+            }
+        }
+    }
 }


### PR DESCRIPTION
Received feedback the policies generated by scanning event logs should have unique policy ID, despite users having to update the BasePolicyID field anyway. 

Closing #392 

