### PR TITLE
Convert supplemental xmls to binary policies to deploy

### DIFF
--- a/WDAC-Policy-Wizard/app/src/EventLogRuleConfiguration.cs
+++ b/WDAC-Policy-Wizard/app/src/EventLogRuleConfiguration.cs
@@ -1703,8 +1703,14 @@ namespace WDAC_Wizard
                 }
             }
 
+            // Check for curly braces
+            if(mostCommonGuid.Contains('{'))
+            {
+                return mostCommonGuid.ToUpperInvariant(); 
+            }
+
             // Return the most common GUID
-            return mostCommonGuid; 
+            return "{" + mostCommonGuid.ToUpperInvariant() + "}";
         }
     }
 

--- a/WDAC-Policy-Wizard/app/src/PSCmdlets.cs
+++ b/WDAC-Policy-Wizard/app/src/PSCmdlets.cs
@@ -318,7 +318,7 @@ namespace WDAC_Wizard
         /// <summary>
         /// Method to convert the xml policy file into a binary CI policy file
         /// </summary>
-        internal static string ConvertPolicyToBinary(string schemaPath)
+        internal static string CompilePolicyBinary(string xmlPath)
         {
             // Operations: Converts the xml schema into a binary policy
             Logger.Log.AddInfoMsg("-- Converting to Binary --");
@@ -329,23 +329,24 @@ namespace WDAC_Wizard
             // If multi-policy format, use the {PolicyGUID}.cip format as defined in https://docs.microsoft.com/windows/security/threat-protection/windows-defender-application-control/deploy-multiple-windows-defender-application-control-policies#deploying-multiple-policies-locally
             string binaryFileName = string.Empty;
             string binPath = string.Empty; 
-            SiPolicy finalSiPolicy = Helper.DeserializeXMLtoPolicy(schemaPath);
+            SiPolicy finalSiPolicy = Helper.DeserializeXMLtoPolicy(xmlPath);
 
             if (finalSiPolicy != null)
             {
+                // Multi-policy format policies always have a base policy ID. 
                 if (finalSiPolicy.BasePolicyID != null)
-
                 {
-                    binaryFileName = String.Format("{0}.cip", finalSiPolicy.PolicyID);
+                    binaryFileName = $"{finalSiPolicy.PolicyID}.cip";
                 }
                 else
                 {
+                    // Legacy policies do not. Set bin name to SiPolicy.p7b
                     binaryFileName = "SiPolicy.p7b";
                 }
 
-                binPath = Path.Combine(Path.GetDirectoryName(schemaPath), binaryFileName);
+                binPath = Path.Combine(Path.GetDirectoryName(xmlPath), binaryFileName);
                 string binConvertCmd = String.Format("ConvertFrom-CIPolicy -XmlFilePath \"{0}\" -BinaryFilePath \"{1}\"",
-                                                     schemaPath, binPath);
+                                                     xmlPath, binPath);
 
                 pipeline.Commands.AddScript(binConvertCmd);
                 Logger.Log.AddInfoMsg("Running the following commands: " + binConvertCmd);


### PR DESCRIPTION
The event log parsing workflow now converts event logs to supplemental policies with: 

1. Base Policy Id set to the most common policy ID in the audit/block events
2. A unique Policy Id
3. Parameters to convert a supplemental xml to cip

The Wizard now offers the ability to convert the xml to cip if the setting is enabled in the Settings Menu