### PR TITLE
Update Advanced Hunting Query

### DIFF
--- a/WDAC-Policy-Wizard/app/src/AdvancedHunting.cs
+++ b/WDAC-Policy-Wizard/app/src/AdvancedHunting.cs
@@ -602,8 +602,13 @@ namespace WDAC_Wizard
 
         // AH KQL Query must follow:
         /*
-        DeviceEvents 
-        | where ActionType startswith 'AppControlCodeIntegrity' 
+        DeviceEvents
+        | where ActionType == 'AppControlCodeIntegrityDriverRevoked'
+            or ActionType == 'AppControlCodeIntegrityPolicyAudited'
+            or ActionType == 'AppControlCodeIntegrityPolicyBlocked'
+            or ActionType == 'AppControlCodeIntegritySigningInformation'
+            or ActionType == 'AppControlCIScriptAudited'
+            or ActionType == 'AppControlCIScriptBlcocked'
         // SigningInfo Fields
         | extend IssuerName = parsejson(AdditionalFields).IssuerName
         | extend IssuerTBSHash = parsejson(AdditionalFields).IssuerTBSHash
@@ -622,7 +627,28 @@ namespace WDAC_Wizard
         // Correlation Fields
         | extend CorrelationId = parsejson(AdditionalFields).EtwActivityId
         // Keep only actionable info for the Wizard
-        | project Timestamp,DeviceId,DeviceName,ActionType,FileName,FolderPath,SHA1,SHA256,IssuerName,IssuerTBSHash,PublisherName,PublisherTBSHash,AuthenticodeHash,PolicyId,PolicyName, OriginalFileName, ProductName, InternalName, FileDescription, FileVersion, CorrelationId
+        | project
+            Timestamp,
+            DeviceId,
+            DeviceName,
+            ActionType,
+            FileName,
+            FolderPath,
+            SHA1,
+            SHA256,
+            IssuerName,
+            IssuerTBSHash,
+            PublisherName,
+            PublisherTBSHash,
+            AuthenticodeHash,
+            PolicyId,
+            PolicyName,
+            OriginalFileName,
+            ProductName,
+            InternalName,
+            FileDescription,
+            FileVersion,
+            CorrelationId
         */
     }
 }

--- a/WDAC-Policy-Wizard/docs/using/advanced-hunting.md
+++ b/WDAC-Policy-Wizard/docs/using/advanced-hunting.md
@@ -57,7 +57,6 @@ DeviceEvents
     FileDescription,
     FileVersion,
     CorrelationId
-    * /
 ```
 
 The Wizard is expecting **exactly the following data fields**:

--- a/WDAC-Policy-Wizard/docs/using/advanced-hunting.md
+++ b/WDAC-Policy-Wizard/docs/using/advanced-hunting.md
@@ -10,27 +10,54 @@ This document outlines the steps to create a WDAC (CI) policy from the Microsoft
 The WDAC Wizard requires the CSV file in a very specific format. The MDE AH query must follow exactly this format:
 
 ```kql
- DeviceEvents 
- | where ActionType startswith 'AppControlCodeIntegrity' 
- // SigningInfo Fields
- | extend IssuerName = parsejson(AdditionalFields).IssuerName
- | extend IssuerTBSHash = parsejson(AdditionalFields).IssuerTBSHash
- | extend PublisherName = parsejson(AdditionalFields).PublisherName
- | extend PublisherTBSHash = parsejson(AdditionalFields).PublisherTBSHash
- // Audit/Block Fields
- | extend AuthenticodeHash = parsejson(AdditionalFields).AuthenticodeHash
- | extend PolicyId = parsejson(AdditionalFields).PolicyID
- | extend PolicyName = parsejson(AdditionalFields).PolicyName
- // PE Header Fields
- | extend OriginalFileName = parsejson(AdditionalFields).OriginalFileName
- | extend ProductName = parsejson(AdditionalFields).ProductName
- | extend InternalName = parsejson(AdditionalFields).InternalName
- | extend FileDescription = parsejson(AdditionalFields).FileDescription
- | extend FileVersion = parsejson(AdditionalFields).FileVersion
- // Correlation Fields
- | extend CorrelationId = parsejson(AdditionalFields).EtwActivityId
- // Keep only actionable info for the Wizard
- | project Timestamp,DeviceId,DeviceName,ActionType,FileName,FolderPath,SHA1,SHA256,IssuerName,IssuerTBSHash,PublisherName,PublisherTBSHash,AuthenticodeHash,PolicyId,PolicyName, OriginalFileName, ProductName, InternalName, FileDescription, FileVersion, CorrelationId
+DeviceEvents
+| where ActionType == 'AppControlCodeIntegrityDriverRevoked'
+    or ActionType == 'AppControlCodeIntegrityPolicyAudited'
+    or ActionType == 'AppControlCodeIntegrityPolicyBlocked'
+    or ActionType == 'AppControlCodeIntegritySigningInformation'
+    or ActionType == 'AppControlCIScriptAudited'
+    or ActionType == 'AppControlCIScriptBlcocked'
+// SigningInfo Fields
+| extend IssuerName = parsejson(AdditionalFields).IssuerName
+| extend IssuerTBSHash = parsejson(AdditionalFields).IssuerTBSHash
+| extend PublisherName = parsejson(AdditionalFields).PublisherName
+| extend PublisherTBSHash = parsejson(AdditionalFields).PublisherTBSHash
+// Audit/Block Fields
+| extend AuthenticodeHash = parsejson(AdditionalFields).AuthenticodeHash
+| extend PolicyId = parsejson(AdditionalFields).PolicyID
+| extend PolicyName = parsejson(AdditionalFields).PolicyName
+// PE Header Fields
+| extend OriginalFileName = parsejson(AdditionalFields).OriginalFileName
+| extend ProductName = parsejson(AdditionalFields).ProductName
+| extend InternalName = parsejson(AdditionalFields).InternalName
+| extend FileDescription = parsejson(AdditionalFields).FileDescription
+| extend FileVersion = parsejson(AdditionalFields).FileVersion
+// Correlation Fields
+| extend CorrelationId = parsejson(AdditionalFields).EtwActivityId
+// Keep only actionable info for the Wizard
+| project
+    Timestamp,
+    DeviceId,
+    DeviceName,
+    ActionType,
+    FileName,
+    FolderPath,
+    SHA1,
+    SHA256,
+    IssuerName,
+    IssuerTBSHash,
+    PublisherName,
+    PublisherTBSHash,
+    AuthenticodeHash,
+    PolicyId,
+    PolicyName,
+    OriginalFileName,
+    ProductName,
+    InternalName,
+    FileDescription,
+    FileVersion,
+    CorrelationId
+    * /
 ```
 
 The Wizard is expecting **exactly the following data fields**:


### PR DESCRIPTION
I have updated the Advanced Hunting query to be more specific and also detect events that aren't being collected by the current query. 

**Missed Events**

As per https://github.com/MicrosoftDocs/WDAC-Toolkit/blob/fd87c779d1cc06d7207e5c0502a810f2c08d89cc/WDAC-Policy-Wizard/app/src/AdvancedHunting.cs#L16-17 there are events starting with "AppControlCIScript" which wouldn't be picked up as the current query specifies "startswith 'AppControlCodeIntegrity' "

**Extra Events**

As per the the below link, there are extra events being picked up which the WDAC wizard doesn't need
* AppControlCodeIntegrityImageRevoked
* AppControlCodeIntegrityOriginAllowed
* AppControlCodeIntegrityPolicyLoaded

https://learn.microsoft.com/en-us/windows/security/application-security/application-control/app-control-for-business/operations/querying-application-control-events-centrally-using-advanced-hunting#action-types


**Misc Notes**
If this PR is accepted, the docs at MS should also be updated - https://learn.microsoft.com/en-us/windows/security/application-security/application-control/app-control-for-business/design/appcontrol-wizard-parsing-event-logs#mde-advanced-hunting-app-control-event-parsing