### PR TITLE
Fix bug in Wizard with EKUs

### DIFF
--- a/WDAC-Policy-Wizard/app/src/Helper.cs
+++ b/WDAC-Policy-Wizard/app/src/Helper.cs
@@ -10,11 +10,12 @@ using System.Linq;
 using System.Diagnostics;
 using System.Xml.Serialization;
 using Microsoft.Win32;
-using System.Security.Cryptography; 
 using System.Security.Cryptography.X509Certificates;
 using System.Windows.Forms;
 using Windows.Management.Deployment;
-using Windows.ApplicationModel; 
+using Windows.ApplicationModel;
+using System.Formats.Asn1;
+
 
 namespace WDAC_Wizard
 {
@@ -740,13 +741,12 @@ namespace WDAC_Wizard
                 return null;
             }
 
-            var ekuOid = CryptoConfig.EncodeOID(stringEku);
-            var ekuBit = BitConverter.ToString(ekuOid).Replace("-", "");
+            AsnWriter asn = new AsnWriter(AsnEncodingRules.DER);
+            asn.WriteObjectIdentifier(stringEku);
 
-            var ekuArray = ekuBit.ToCharArray();
-            ekuArray[1] = '1';
-
-            return new string(ekuArray);
+            var ekuByteArray = asn.Encode();
+            ekuByteArray[0] = 1;
+            return BitConverter.ToString(ekuByteArray).Replace("-", "");
         }
 
         /// <summary>

--- a/WDAC-Policy-Wizard/app/src/PolicyHelper.cs
+++ b/WDAC-Policy-Wizard/app/src/PolicyHelper.cs
@@ -1172,7 +1172,7 @@ namespace WDAC_Wizard
                 eku.Value = Helper.ConvertHashStringToByte(customRule.EKUEncoded);
 
                 signers = SetSignersEKUs(signers, eku);
-                siPolicy = AddSiPolicyEKUs(eku, signerSiPolicy);
+                siPolicy = AddSiPolicyEKUs(eku, siPolicy);
             }
 
             // If none of the extra attributes are to be added and null exceptions, skip creating a FileAttrib rule
@@ -1999,6 +1999,12 @@ namespace WDAC_Wizard
                 resultantPolicy.CiSigners = MergeCiSigners(tempPolicy.CiSigners, resultantPolicy.CiSigners);
             }
 
+            // Handle EKUs
+            if(tempPolicy.EKUs != null && tempPolicy.EKUs.Length > 0)
+            {
+                resultantPolicy.EKUs = MergeEKUs(tempPolicy.EKUs, resultantPolicy.EKUs);
+            }
+            
             return resultantPolicy;
         }
 
@@ -2273,6 +2279,46 @@ namespace WDAC_Wizard
             }
 
             return ciSignerCopy;
+        }
+
+
+        /// <summary>
+        /// Handles the merge operation between a new EKU[] and an existing EKU[] struct
+        /// </summary>
+        /// <param name="newEKU"></param>
+        /// <param name="resultEKU"></param>
+        /// <returns></returns>
+        static EKU[] MergeEKUs(EKU[] newEKU, EKU[] resultEKU)
+        {
+            // Short circuit if nothing from the new sipolicy
+            if (newEKU == null || newEKU.Length == 0)
+            {
+                return resultEKU;
+            }
+
+            // Return newFileRules if resultFileRules is empty/null
+            if (resultEKU == null || resultEKU.Length == 0)
+            {
+                return newEKU;
+            }
+
+            int copySize = newEKU.Length + resultEKU.Length;
+            EKU[] ekuCopy = new EKU[copySize];
+
+            // New EKUs
+            for (int i = 0; i < newEKU.Length; i++)
+            {
+                ekuCopy[i] = newEKU[i];
+            }
+
+            // Existing EKUs
+            for (int i = 0; i < resultEKU.Length; i++)
+            {
+                // Offset the index to length of new EKUs to not overwrite entries
+                ekuCopy[i + newEKU.Length] = resultEKU[i];
+            }
+
+            return ekuCopy;
         }
 
         /// <summary>


### PR DESCRIPTION
**Issue:**

EKU rules were not being added to new policies

**Fix:**

The new merge step did not merge the EKU rules so while the Signer had an EKU reference, the EKU section of the policy was missing the EKUs. Added in a merge EKU method

Also migrated off the obsolete method to calculate the ASN1 encoded value for EKUs. Now using the ASN1 API