### PR TITLE
Remove empty or unknown signers from log files during policy editing

### DIFF
--- a/WDAC-Policy-Wizard/app/src/EventLog.cs
+++ b/WDAC-Policy-Wizard/app/src/EventLog.cs
@@ -427,7 +427,7 @@ namespace WDAC_Wizard
                 signerEvent.IssuerName = GetValueString(eventData, "IssuerName");
                 signerEvent.IssuerTBSHash = Helper.ConvertHashStringToByte(GetValueString(eventData, "IssuerTBSHash"));
 
-                // Skip events with Unknown publisher/empty TBS hash values
+                // Skip events with "Unknown" publisher and empty TBS hash values
                 // Github Issue #434 - policies with empty TBS hash rules will compile but fail to deploy 
                 if(signerEvent.IssuerTBSHash.Length == 0)
                 {

--- a/WDAC-Policy-Wizard/app/src/EventLog.cs
+++ b/WDAC-Policy-Wizard/app/src/EventLog.cs
@@ -426,6 +426,13 @@ namespace WDAC_Wizard
                 signerEvent.PublisherName = GetValueString(eventData, "PublisherName");
                 signerEvent.IssuerName = GetValueString(eventData, "IssuerName");
                 signerEvent.IssuerTBSHash = Helper.ConvertHashStringToByte(GetValueString(eventData, "IssuerTBSHash"));
+
+                // Skip events with Unknown publisher/empty TBS hash values
+                // Github Issue #434 - policies with empty TBS hash rules will compile but fail to deploy 
+                if(signerEvent.IssuerTBSHash.Length == 0)
+                {
+                    return null; 
+                }
             }
             catch (Exception e)
             {


### PR DESCRIPTION
**Issue:"**

3089 events with empty TBS hash values were successfully being created in the Wizard allowing for a user to generate a publisher or file publisher rule with an empty TBS hash and non-empty publisher name.

The policy successfully compiles but will fail to deploy with a generic CI failure. Bug filed in the OS to catch these failures in the compiler.

**Fix:**

Fail to create signer events if the TBS hash value is null/empty. 


Closes #434 
