### PR TITLE
Add Microsoft Publisher Certificate to Trusted Publisher Cert Store

### DIFF
--- a/WDAC-Policy-Wizard/app/App.config
+++ b/WDAC-Policy-Wizard/app/App.config
@@ -34,6 +34,9 @@
             <setting name="useDarkMode" serializeAs="String">
                 <value>False</value>
             </setting>
+            <setting name="showIntegrityIssue" serializeAs="String">
+                <value>True</value>
+            </setting>
         </WDAC_Wizard.Properties.Settings>
     </userSettings>
   <runtime>

--- a/WDAC-Policy-Wizard/app/Properties/Settings.Designer.cs
+++ b/WDAC-Policy-Wizard/app/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace WDAC_Wizard.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.9.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.12.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -116,6 +116,18 @@ namespace WDAC_Wizard.Properties {
             }
             set {
                 this["useDarkMode"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        public bool showIntegrityIssue {
+            get {
+                return ((bool)(this["showIntegrityIssue"]));
+            }
+            set {
+                this["showIntegrityIssue"] = value;
             }
         }
     }

--- a/WDAC-Policy-Wizard/app/Properties/Settings.settings
+++ b/WDAC-Policy-Wizard/app/Properties/Settings.settings
@@ -26,5 +26,8 @@
     <Setting Name="useDarkMode" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="showIntegrityIssue" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/WDAC-Policy-Wizard/app/src/MainForm.cs
+++ b/WDAC-Policy-Wizard/app/src/MainForm.cs
@@ -1928,7 +1928,7 @@ namespace WDAC_Wizard
 
         /// <summary>
         /// Shows message to user that script signer was not added to Trusted Store
-        /// They will have to manully do that
+        /// They will have to manually do that
         /// </summary>
         private void ShowPSTrustFailureUI()
         {

--- a/WDAC-Policy-Wizard/app/src/MainForm.cs
+++ b/WDAC-Policy-Wizard/app/src/MainForm.cs
@@ -795,6 +795,12 @@ namespace WDAC_Wizard
 
             if (this.Policy.PolicyWorkflow != WDAC_Policy.Workflow.Merge)
             {
+                // Add trust for Signed Scripts
+                bool success = PSCmdlets.AddPSSigner();
+                if (!success) {
+                    ShowPSTrustFailureUI();
+                }
+                
                 // Handle custom value rules: 
                 siPolicyNewRules = ProcessCustomValueRules(worker, siPolicyNewRules);
 
@@ -1917,6 +1923,32 @@ namespace WDAC_Wizard
                 button_Next.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
                 button_Next.ForeColor = System.Drawing.Color.Black;
                 button_Next.BackColor = System.Drawing.Color.WhiteSmoke;
+            }
+        }
+
+        /// <summary>
+        /// Shows message to user that script signer was not added to Trusted Store
+        /// They will have to manully do that
+        /// </summary>
+        private void ShowPSTrustFailureUI()
+        {
+            // Break early if setting is disabled. The user has already seen this message and elected not to show this
+            if (!Properties.Settings.Default.showIntegrityIssue)
+            {
+                return; 
+            }
+
+            DialogResult res = MessageBox.Show("The Wizard was unable to add trust for required PowerShell scripts. This may lead to policy build hanging during Folder Scanning. " +
+                                                "To fix this issue, you must add the signing certificate to the Current User's Trusted Publisher Store. \r\n\r\n" +
+                                                "Do you want to continue receiving this message on future failures?",
+                                                "Wizard Integrity Issue",
+                                                MessageBoxButtons.YesNo,
+                                                MessageBoxIcon.Question);
+
+            if (res == DialogResult.No)
+            {
+                Properties.Settings.Default.showIntegrityIssue = false; 
+                Properties.Settings.Default.Save();
             }
         }
 

--- a/WDAC-Policy-Wizard/app/src/PSCmdlets.cs
+++ b/WDAC-Policy-Wizard/app/src/PSCmdlets.cs
@@ -96,7 +96,7 @@ namespace WDAC_Wizard
                 FileName = "powershell.exe",
                 Arguments = newPolicyScriptCmd,
                 UseShellExecute = false,
-                CreateNoWindow = false,
+                CreateNoWindow = true,
                 RedirectStandardOutput = true,
                 RedirectStandardError = true
             };
@@ -188,7 +188,7 @@ namespace WDAC_Wizard
                 FileName = "powershell.exe",
                 Arguments = newPolicyScriptCmd,
                 UseShellExecute = false,
-                CreateNoWindow = false,
+                CreateNoWindow = true,
                 RedirectStandardOutput = true,
                 RedirectStandardError = true
             };
@@ -465,6 +465,42 @@ namespace WDAC_Wizard
             }
             _Runspace.Dispose();
 
+        }
+
+        /// <summary>
+        /// Tries to add the ps1 script signer to the Trusted Publisher store
+        /// so folder scanning and signer rule creation via the script will not hang
+        /// </summary>
+        /// <returns></returns>
+        internal static bool AddPSSigner()
+        {
+            string ps1File = Path.Combine(Helper.GetExecutablePath(false), PS_SCAN_FILENAME);
+            string tempPath = Path.GetTempFileName();
+
+            // Create runspace, pipeline and runscript
+            Pipeline pipeline = CreatePipeline();
+
+            pipeline.Commands.AddScript($"$certificate = Get-AuthenticodeSignature -FilePath {ps1File} | Select-Object -ExpandProperty SignerCertificate");
+            pipeline.Commands.AddScript($"Export-Certificate -Cert $certificate -FilePath {tempPath}");
+            pipeline.Commands.AddScript($"Import-Certificate -FilePath {tempPath} -CertStoreLocation Cert:\\CurrentUser\\TrustedPublisher");
+
+            foreach (var cmd in pipeline.Commands)
+            {
+                Logger.Log.AddInfoMsg($"Running PS Cmd: {cmd}");
+            }
+
+            try
+            {
+                Collection<PSObject> results = pipeline.Invoke();
+            }
+            catch (Exception e)
+            {
+                Logger.Log.AddErrorMsg(String.Format("Exception encountered in MergeCustomRulesPolicy(): {0}", e));
+                return false;
+            }
+        
+            _Runspace.Dispose();
+            return true; 
         }
     }
 }

--- a/WDAC-Policy-Wizard/app/src/PSCmdlets.cs
+++ b/WDAC-Policy-Wizard/app/src/PSCmdlets.cs
@@ -85,7 +85,7 @@ namespace WDAC_Wizard
                 deny = "True";
             }
 
-            string newPolicyScriptCmd = $"-NoProfile -ExecutionPolicy ByPass -File \"{ps1File}\" -WdacBinPath \"{wizardPath}\" " +
+            string newPolicyScriptCmd = $"-NoProfile -ExecutionPolicy Bypass -File \"{ps1File}\" -WdacBinPath \"{wizardPath}\" " +
                 $"-DriverFilePath \"{customRule.ReferenceFile}\" -PolicyPath \"{policyPath}\" -Level {level} -Deny {deny}";
 
             Logger.Log.AddInfoMsg($"Running the following PS cmd in CreateSignerPolicyFromPS(): {newPolicyScriptCmd}");
@@ -96,7 +96,7 @@ namespace WDAC_Wizard
                 FileName = "powershell.exe",
                 Arguments = newPolicyScriptCmd,
                 UseShellExecute = false,
-                CreateNoWindow = true,
+                CreateNoWindow = false,
                 RedirectStandardOutput = true,
                 RedirectStandardError = true
             };
@@ -176,7 +176,7 @@ namespace WDAC_Wizard
                 deny = "True";
             }
 
-            string newPolicyScriptCmd = $"-NoProfile -ExecutionPolicy ByPass -File \"{ps1File}\" -ScanPath \"{scanPath}\" " +
+            string newPolicyScriptCmd = $"-NoProfile -ExecutionPolicy Bypass -File \"{ps1File}\" -ScanPath \"{scanPath}\" " +
                 $"-PolicyPath \"{policyPath}\" -Level {level} -Fallback {fallbacks} -PathsToOmit \"{pathsToOmit}\"" +
                 $" -Deny {deny} -UserPEs {userPEs}";
 
@@ -188,7 +188,7 @@ namespace WDAC_Wizard
                 FileName = "powershell.exe",
                 Arguments = newPolicyScriptCmd,
                 UseShellExecute = false,
-                CreateNoWindow = true,
+                CreateNoWindow = false,
                 RedirectStandardOutput = true,
                 RedirectStandardError = true
             };


### PR DESCRIPTION
**Issue and Root Cause**

In some locked down environments, the Wizard fails to perform folder scanning (in PS 5) as the script execution policy does not permit 'untrusted scripts'. While the script is signed, the Microsoft Publisher is not trusted. 


**Fix:**

The Wizard will now try to add the Wizard signing certificate to the Current User's Trusted Publisher certificate store when running 1) Folder Scan - CreateScannedPolicy.ps1 and 2) Publisher and Hash rules - CreateSignerPolicy.ps1 

If the addition to the store fails, the user will be prompted to add it manually. The user can also suppress the prompts by selecting 'No' on the following dialog -

![image](https://github.com/user-attachments/assets/d0754315-f6ed-4f8a-b3ee-bd0c21df7c4a)


