### PR TITLE
Fixed several scenarios where CiSigners are not being added or cleared

### DIFF
--- a/WDAC-Policy-Wizard/app/src/PolicyHelper.cs
+++ b/WDAC-Policy-Wizard/app/src/PolicyHelper.cs
@@ -967,6 +967,15 @@ namespace WDAC_Wizard
                 }
             }
 
+            // Add CiSigner - Github Issue #161, #450
+            // Usermode rule you are creating a rule for, you need to add signer to cisigners.
+            // Kernel mode rule, don't add signer to cisigners
+            // If you don't know always add to cisigners.
+            if (scenarioStates.umciEnabled)
+            {
+                siPolicy = AddSiPolicyCiSigner(signers, siPolicy);
+            }
+
             return siPolicy;
         }
 
@@ -1188,15 +1197,6 @@ namespace WDAC_Wizard
 
                 // Add signer references
                 siPolicy = AddSiPolicySigner(signers, siPolicy, customRule.Permission, customRule.SigningScenarioCheckStates);
-
-                // Add CiSigner - Github Issue #161
-                // Usermode rule you are creating a rule for, you need to add signer to cisigners.
-                // Kernel mode rule, don't add signer to cisigners
-                // If you don't know always add to cisigners.
-                if (customRule.SigningScenarioCheckStates.umciEnabled)
-                {
-                    siPolicy = AddSiPolicyCiSigner(signers, siPolicy);
-                }
             }
             else
             {


### PR DESCRIPTION
**Issue:**

Customers reported that the Wizard is creating rules that are not effective as of version 2.5.0.1. 

**Root Cause:**

The Wizard is dropping the CiSigners sections from custom policies in 2 scenarios:

1. Custom FileAttribute Signer rules
2. Certificate rules

To catch these, and future proof, I have moved the AddCiSigners call to the method invoked when any Signer is added to policy thereby asserting CiSigners are always added