### PR TITLE
Fixed duplicate Signer ID bug

### DIFF
--- a/WDAC-Policy-Wizard/app/src/PolicyHelper.cs
+++ b/WDAC-Policy-Wizard/app/src/PolicyHelper.cs
@@ -1732,16 +1732,16 @@ namespace WDAC_Wizard
         {
             // Break out if null siPolicy provided or FileRules and Signers are empty
             if (customRulesPolicy == null
-                || customRulesPolicy.FileRules == null
-                || customRulesPolicy.FileRules.Length == 0)
+                || customRulesPolicy.Signers == null
+                || customRulesPolicy.Signers.Length == 0)
             {
                 return customRulesPolicy;
             }
 
             // Break early if existingPolicy does not have FileRules
             if (existingPolicy == null
-                || existingPolicy.FileRules == null
-                || existingPolicy.FileRules.Length == 0)
+                || existingPolicy.Signers == null
+                || existingPolicy.Signers.Length == 0)
             {
                 return customRulesPolicy;
             }
@@ -1840,7 +1840,7 @@ namespace WDAC_Wizard
                         if (idMapping.ContainsKey(id))
                         {
                             signingScn.ProductSigners.AllowedSigners.AllowedSigner[i].SignerId = idMapping[id];
-                            Logger.Log.AddInfoMsg($"SignerID alread exists. Replacing SignerID: {id} with {idMapping[id]}");
+                            Logger.Log.AddInfoMsg($"AllowedSignerID already exists. Replacing SignerID: {id} with {idMapping[id]}");
                         }
                     }
                 }
@@ -1856,7 +1856,7 @@ namespace WDAC_Wizard
                         if (idMapping.ContainsKey(id))
                         {
                             signingScn.ProductSigners.DeniedSigners.DeniedSigner[i].SignerId = idMapping[id];
-                            Logger.Log.AddInfoMsg($"SignerID alread exists. Replacing SignerID: {id} with {idMapping[id]}");
+                            Logger.Log.AddInfoMsg($"DeniedSignerID already exists. Replacing SignerID: {id} with {idMapping[id]}");
                         }
                     }
                 }
@@ -1875,7 +1875,7 @@ namespace WDAC_Wizard
                     if (idMapping.ContainsKey(id))
                     {
                         tempCiSigners[i].SignerId = idMapping[id];
-                        Logger.Log.AddInfoMsg($"SignerID alread exists. Replacing SignerID: {id} with {idMapping[id]}");
+                        Logger.Log.AddInfoMsg($"CiSignerID already exists. Replacing SignerID: {id} with {idMapping[id]}");
                     }
                 }
                 siPolicy.CiSigners = tempCiSigners;
@@ -1893,7 +1893,7 @@ namespace WDAC_Wizard
                     if (idMapping.ContainsKey(id))
                     {
                         tempPolicySigners[i].SignerId = idMapping[id];
-                        Logger.Log.AddInfoMsg($"SignerID alread exists. Replacing SignerID: {id} with {idMapping[id]}");
+                        Logger.Log.AddInfoMsg($"UpdatePolicySignerID already exists. Replacing SignerID: {id} with {idMapping[id]}");
                     }
                 }
                 siPolicy.UpdatePolicySigners = tempPolicySigners;
@@ -1911,7 +1911,7 @@ namespace WDAC_Wizard
                     if (idMapping.ContainsKey(id))
                     {
                         tempSupplementalSigners[i].SignerId = idMapping[id];
-                        Logger.Log.AddInfoMsg($"SignerID alread exists. Replacing SignerID: {id} with {idMapping[id]}");
+                        Logger.Log.AddInfoMsg($"SupplementalPolicySignerID already exists. Replacing SignerID: {id} with {idMapping[id]}");
                     }
                 }
                 siPolicy.SupplementalPolicySigners = tempSupplementalSigners;


### PR DESCRIPTION
**Issue:**

During policy edit, the Wizard was creating new signer rules with duplicate IDs causing conversion to binary to fail. 

The issue was isolated to edits where Publisher rules were only being generated, i.e. not a single file attribute rule was created. The root cause was a bad perf improvement check in the method `FormatSignerRuleIDsAgainstExsiting` that was only checking for `FileRules` and not `Signers`. When `FileRules` were empty, the Wizard would break early and signer IDs were not compared. 

**Fix:**

Fixed the bad perf check to look at the `Signers` structure instead. 

A special thanks to @davideverall, @msgerbs, @jpkool, @tom-selby, @pranay-hinge who all helped root cause by providing repro steps. 

Closing #431 

