### PR TITLE
Fixed typo and specified how to generate these hashes

### DIFF
--- a/WDAC-Policy-Wizard/app/src/CustomRuleConditionsPanel.Designer.cs
+++ b/WDAC-Policy-Wizard/app/src/CustomRuleConditionsPanel.Designer.cs
@@ -660,7 +660,7 @@
             richTextBox_CustomHashes.Name = "richTextBox_CustomHashes";
             richTextBox_CustomHashes.Size = new System.Drawing.Size(559, 96);
             richTextBox_CustomHashes.TabIndex = 114;
-            richTextBox_CustomHashes.Text = "Insert a comma separated list of SHA1 and SHA256 Authenticode/PE Hashes.\r\n" +
+            richTextBox_CustomHashes.Text = "Insert a comma-separated list of SHA1 and SHA256 Authenticode/PE Hashes.\r\n" +
                 "Sigcheck from Sysinternals (aka.ms/sigcheck) supports creation of the hashes.";
             richTextBox_CustomHashes.Visible = false;
             richTextBox_CustomHashes.Click += RichTextBox_CustomHashes_Click;


### PR DESCRIPTION
**Issue:**

Typo in the 'Use Custom Hash Values' support text: SHA2 instead of SHA256. Technically, all SHA2 algorithms are supported, but clarified 'SHA256' to reduce confusion. 

**Fix:**

<img width="758" height="855" alt="image" src="https://github.com/user-attachments/assets/8df1a30e-288e-4893-9ecb-96329077649b" />

Fixing #492 