### PR TITLE
Added a check for empty Issuing TBS hash rules to block rule creation

### DIFF
--- a/WDAC-Policy-Wizard/app/src/EventLogRuleConfiguration.cs
+++ b/WDAC-Policy-Wizard/app/src/EventLogRuleConfiguration.cs
@@ -354,10 +354,9 @@ namespace WDAC_Wizard
             this.PublisherUIState[3] = this.versionCheckBox.Checked == true ? 1 : 0;
             this.PublisherUIState[4] = this.productCheckBox.Checked == true ? 1 : 0;
 
-            // Check the issuing CA is not empty AND Issuer TBS hash not empty
+            // Check the issuing CA is not empty 
             if (String.IsNullOrEmpty(this.issuerTextBox.Text) 
                 || this.issuerTextBox.Text == Properties.Resources.BadEventPubValue)
-                
             {
                 // Log exception error and throw error to user
                 MessageBox.Show(this,String.Format("The Issuer is invalid for rule creation. The issuer cannot be empty or '{0}'", Properties.Resources.BadEventPubValue), 
@@ -371,9 +370,10 @@ namespace WDAC_Wizard
                 return false; 
             }
 
-            if ( this.CiEvents[this.SelectedRow].SignerInfo.IssuerTBSHash.Length == 0)
-            // Check the issuing CA is not empty AND Issuer TBS hash not empty
+            // Check the Issuer TBS hash is not empty as well
             // Instances where the issuing CA is in the data but not the TBS hash. GitHub Issue #478
+            if (this.CiEvents[this.SelectedRow].SignerInfo.IssuerTBSHash == null 
+                || this.CiEvents[this.SelectedRow].SignerInfo.IssuerTBSHash.Length == 0)
             {
                 // Log exception error and throw error to user
                 MessageBox.Show(this, "The Issuer is invalid for rule creation. The Issuer TBS hash value is empty. This is likely an issue in the Advanced Hunting data.",
@@ -386,7 +386,6 @@ namespace WDAC_Wizard
                 Logger.Log.AddWarningMsg("Event Log Config - Invalid publisher rule with a null Issuer TBS Hash");
                 return false;
             }
-
 
             if (PublisherUIState[1] == 1 && (String.IsNullOrEmpty(this.publisherTextBox.Text) 
                 || this.publisherTextBox.Text == Properties.Resources.BadEventPubValue))


### PR DESCRIPTION
**Issue:**

- Seeing instances in MDE Advanced Hunting data where the issuing CA name is valid but the data does not have the issuing CA's TBS hash value
- This passes the IsValidPublisher check resulting in a rule created with an empty TBS hash value
- Fixes #478 

**Fix:**

- Added a check in the Wizard to block rule creation if issuer TBS hash value is empty/null
- New failure message:

<img width="1237" height="737" alt="image" src="https://github.com/user-attachments/assets/48fa7902-51d3-473d-b913-dafe0d5fdb43" />
