### PR TITLE
Do not show the 'Enable UMCI question' for Supplemental policies

### DIFF
--- a/WDAC-Policy-Wizard/app/src/CustomRuleConditionsPanel.cs
+++ b/WDAC-Policy-Wizard/app/src/CustomRuleConditionsPanel.cs
@@ -2528,7 +2528,11 @@ namespace WDAC_Wizard
             // If the policy doesn't support UMCI, prompt the user and set it
             if (this.checkBox_userMode.Checked)
             {
-                if (!PolicyHelper.PolicyHasRule(this.Policy.PolicyRuleOptions, OptionType.EnabledUMCI))
+                // Skip this check on supplemental policies (and AppIdTagging policies) as UMCI will always be off
+                // since UMCI state is inherited from the base policy. Issue #501
+
+                if (this.Policy._PolicyType == WDAC_Policy.PolicyType.BasePolicy
+                    && !PolicyHelper.PolicyHasRule(this.Policy.PolicyRuleOptions, OptionType.EnabledUMCI))
                 {
                     DialogResult res = MessageBox.Show("Your policy does not have User mode code integrity (UMCI) enabled so this UMCI rule will not be enforced. Would you like the Wizard to enable UMCI?",
                                                         "Proceed with UMCI Rule Creation?",


### PR DESCRIPTION
**Issue:**

1. Supplemental policies will always have UMCI disabled as it's an inherited rule-option from the base policy
2. The Wizard will (confusingly) prompt the user whether they want to enable UMCI and proceed with rule creation when creating rules for supplemental policies

**Fix: **

1. Ignore UMCI state on non base policies (supplementals and AppId Tagging)