### PR TITLE
Fix build from fresh clone

### DIFF
--- a/WDAC-Policy-Wizard/app/WDAC Wizard.csproj
+++ b/WDAC-Policy-Wizard/app/WDAC Wizard.csproj
@@ -231,6 +231,6 @@
     <WCFMetadata Include="Connected Services\" />
   </ItemGroup>
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="echo Copying neccessary files...&#xD;&#xA;copy &quot;$(ProjectDir)\Resources\RulesDict.xml&quot; &quot;$(ProjectDir)$(OutDir)\&quot; /Y&#xD;&#xA;xcopy &quot;$(ProjectDir)\Resources\policyTemplates&quot; &quot;$(ProjectDir)$(OutDir)\Templates&quot; /Y /S /I /C&#xD;&#xA;echo Done!" />
+    <Exec Command="echo Copying necessary files...&#xD;&#xA;copy &quot;$(ProjectDir)\Resources\RulesDict.xml&quot; &quot;$(ProjectDir)$(OutDir)\&quot; /Y&#xD;&#xA;xcopy &quot;$(ProjectDir)\Resources\policyTemplates&quot; &quot;$(ProjectDir)$(OutDir)\Templates&quot; /Y /S /I /C&#xD;&#xA;echo Done!" />
   </Target>  
 </Project>


### PR DESCRIPTION
Hi,
This Pull Request fixes the building process from a fresh clone by:
- Removing unnecessary EmbeddedResource defined in the project file
- Using post-build commands to copy necessary templates files to the output directory

I don't know whether this will cause other problems in the final build program,but it seems to perform well.